### PR TITLE
feat: add lookback-based backfill to iShares index provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ yarn-error.log*
 
 # local .env files
 .env.local*
+
+# Worktrees
+.worktrees/

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -101,6 +101,7 @@ Examples:
 		fi.ImportFiles(fetchCtx, sub, files, outChan, exitChan)
 
 		summary := <-exitChan
+
 		close(outChan)
 		wg.Wait()
 
@@ -137,6 +138,7 @@ func resolveSubscription(ctx context.Context, lib *library.Library, nameOrID str
 	}
 
 	var matches []*library.Subscription
+
 	for _, s := range allSubs {
 		if s.Name == nameOrID {
 			matches = append(matches, s)
@@ -155,6 +157,7 @@ func resolveSubscription(ctx context.Context, lib *library.Library, nameOrID str
 
 func init() {
 	importCmd.Flags().StringP("subscription", "s", "", "Subscription name or ID (required)")
+
 	if err := importCmd.MarkFlagRequired("subscription"); err != nil {
 		log.Fatal().Err(err).Msg("could not mark subscription flag as required")
 	}

--- a/docs/superpowers/plans/2026-03-30-ishares-backfill.md
+++ b/docs/superpowers/plans/2026-03-30-ishares-backfill.md
@@ -1,0 +1,1029 @@
+# iShares Index Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add lookback-based backfill to the iShares index provider, with weight-change tracking and correct state reconstruction from snapshots + changelog.
+
+**Architecture:** Extract an `indexMember` type that carries both FIGI and weight. Add `currentIndexMembers` to reconstruct true index state from the last snapshot plus subsequent changelog entries. Add `tradingDays` to query the DB for valid trading dates. Modify `diffSnapshots` to detect adds, removes, and significant weight changes. Modify `shouldTakeSnapshot` to accept a reference date. Wire backfill loop into `downloadSingleISharesETF` using `LookbackFromContext`.
+
+**Tech Stack:** Go, Ginkgo v2 + Gomega, pgx/v5, resty/v2, zerolog
+
+**Spec:** `docs/superpowers/specs/2026-03-30-ishares-backfill-design.md`
+
+---
+
+## File Map
+
+- **Modify:** `provider/index_helpers.go` -- add `indexMember` type, `currentIndexMembers`, `tradingDays`; change `shouldTakeSnapshot` signature; change `diffSnapshots` to use `indexMember` and detect weight changes
+- **Modify:** `provider/index_helpers_test.go` -- update all existing tests and add new tests for the above
+- **Modify:** `provider/ishares.go` -- backfill loop in `downloadSingleISharesETF`, `asOfDate` URL parameter
+- **Modify:** `provider/nasdaq.go:200-214` -- update calls to `diffSnapshots`, `shouldTakeSnapshot` for new signatures
+- **Modify:** `provider/hooks_test.go` -- update `diffSnapshots` call for new signature
+
+---
+
+### Task 1: Add `indexMember` type and update `diffSnapshots` signature
+
+**Files:**
+- Modify: `provider/index_helpers.go:38-57`
+- Modify: `provider/index_helpers_test.go:56-89`
+
+- [ ] **Step 1: Write failing tests for updated `diffSnapshots`**
+
+In `provider/index_helpers_test.go`, replace the existing `diffSnapshots` Describe block with:
+
+```go
+var _ = Describe("diffSnapshots", func() {
+	It("returns all as added when previous is empty", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, map[string]indexMember{})
+		Expect(adds).To(HaveLen(2))
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("returns all as removed when current is empty", func() {
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(map[string]indexMember{}, previous)
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(HaveLen(1))
+		Expect(removes).To(HaveKey("AAPL"))
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("detects additions and removals", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"GOOG": {CompositeFigi: "BBG009S39JX6", Weight: 0.03},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(HaveLen(1))
+		Expect(adds).To(HaveKey("GOOG"))
+		Expect(removes).To(HaveLen(1))
+		Expect(removes).To(HaveKey("MSFT"))
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("returns empty when sets are identical", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("detects significant weight change above 0.01 threshold", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.065},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("AAPL"))
+		Expect(weightChanges["AAPL"].Weight).To(BeNumerically("~", 0.065, 0.0001))
+	})
+
+	It("ignores weight change below 0.01 threshold", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.055},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("detects weight change exactly at 0.01 boundary", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.06},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(weightChanges).To(HaveLen(1))
+	})
+
+	It("handles simultaneous adds, removes, and weight changes", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.08},
+			"GOOG": {CompositeFigi: "BBG009S39JX6", Weight: 0.03},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(HaveLen(1))
+		Expect(adds).To(HaveKey("GOOG"))
+		Expect(removes).To(HaveLen(1))
+		Expect(removes).To(HaveKey("MSFT"))
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("AAPL"))
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "diffSnapshots" ./provider/`
+Expected: compilation errors -- `indexMember` type and 3-return `diffSnapshots` don't exist yet.
+
+- [ ] **Step 3: Implement `indexMember` type and updated `diffSnapshots`**
+
+In `provider/index_helpers.go`, add the `indexMember` type after the imports and before `shouldTakeSnapshot`:
+
+```go
+// indexMember represents a constituent of an index with its FIGI and weight.
+type indexMember struct {
+	CompositeFigi string
+	Weight        float64
+}
+
+const weightChangeThreshold = 0.01
+```
+
+Replace the existing `diffSnapshots` function (lines 38-57) with:
+
+```go
+// diffSnapshots compares current holdings against previous holdings
+// and returns maps of added, removed, and weight-changed tickers.
+// A weight change is significant when the absolute difference exceeds weightChangeThreshold.
+func diffSnapshots(current, previous map[string]indexMember) (added, removed, weightChanged map[string]indexMember) {
+	added = make(map[string]indexMember)
+	removed = make(map[string]indexMember)
+	weightChanged = make(map[string]indexMember)
+
+	for ticker, member := range current {
+		prev, ok := previous[ticker]
+		if !ok {
+			added[ticker] = member
+			continue
+		}
+
+		delta := member.Weight - prev.Weight
+		if delta < 0 {
+			delta = -delta
+		}
+
+		if delta >= weightChangeThreshold {
+			weightChanged[ticker] = member
+		}
+	}
+
+	for ticker, member := range previous {
+		if _, ok := current[ticker]; !ok {
+			removed[ticker] = member
+		}
+	}
+
+	return
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "diffSnapshots" ./provider/`
+Expected: all 8 diffSnapshots specs PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/index_helpers.go provider/index_helpers_test.go
+git commit -m "feat: add indexMember type and weight-change detection to diffSnapshots"
+```
+
+---
+
+### Task 2: Update `shouldTakeSnapshot` to accept a reference date
+
+**Files:**
+- Modify: `provider/index_helpers.go:15-36`
+- Modify: `provider/index_helpers_test.go:10-54`
+
+- [ ] **Step 1: Update tests for new `shouldTakeSnapshot` signature**
+
+In `provider/index_helpers_test.go`, replace the existing `shouldTakeSnapshot` Describe block with:
+
+```go
+var _ = Describe("shouldTakeSnapshot", func() {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+
+	It("returns true when no previous snapshot exists", func() {
+		Expect(shouldTakeSnapshot(time.Time{}, now, "weekly")).To(BeTrue())
+	})
+
+	It("returns true when daily and last snapshot was yesterday", func() {
+		yesterday := now.AddDate(0, 0, -1)
+		Expect(shouldTakeSnapshot(yesterday, now, "daily")).To(BeTrue())
+	})
+
+	It("returns false when daily and last snapshot was today", func() {
+		Expect(shouldTakeSnapshot(now, now, "daily")).To(BeFalse())
+	})
+
+	It("returns true when weekly and last snapshot was 8 days ago", func() {
+		eightDaysAgo := now.AddDate(0, 0, -8)
+		Expect(shouldTakeSnapshot(eightDaysAgo, now, "weekly")).To(BeTrue())
+	})
+
+	It("returns false when weekly and last snapshot was 3 days ago", func() {
+		threeDaysAgo := now.AddDate(0, 0, -3)
+		Expect(shouldTakeSnapshot(threeDaysAgo, now, "weekly")).To(BeFalse())
+	})
+
+	It("returns true when monthly and last snapshot was 32 days ago", func() {
+		thirtyTwoDaysAgo := now.AddDate(0, 0, -32)
+		Expect(shouldTakeSnapshot(thirtyTwoDaysAgo, now, "monthly")).To(BeTrue())
+	})
+
+	It("returns false when monthly and last snapshot was 15 days ago", func() {
+		fifteenDaysAgo := now.AddDate(0, 0, -15)
+		Expect(shouldTakeSnapshot(fifteenDaysAgo, now, "monthly")).To(BeFalse())
+	})
+
+	It("returns true when quarterly and last snapshot was 95 days ago", func() {
+		ninetyFiveDaysAgo := now.AddDate(0, 0, -95)
+		Expect(shouldTakeSnapshot(ninetyFiveDaysAgo, now, "quarterly")).To(BeTrue())
+	})
+
+	It("defaults to weekly for unknown frequency", func() {
+		eightDaysAgo := now.AddDate(0, 0, -8)
+		Expect(shouldTakeSnapshot(eightDaysAgo, now, "bogus")).To(BeTrue())
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "shouldTakeSnapshot" ./provider/`
+Expected: compilation error -- `shouldTakeSnapshot` takes 2 args, not 3.
+
+- [ ] **Step 3: Update `shouldTakeSnapshot` implementation**
+
+In `provider/index_helpers.go`, replace the existing `shouldTakeSnapshot` function (lines 13-36) with:
+
+```go
+// shouldTakeSnapshot returns true if a new snapshot should be taken based on the
+// configured frequency, the date of the last snapshot, and the current processing date.
+func shouldTakeSnapshot(lastSnapshotDate, currentDate time.Time, frequency string) bool {
+	if lastSnapshotDate.IsZero() {
+		return true
+	}
+
+	var interval time.Duration
+
+	switch frequency {
+	case "daily":
+		interval = 24 * time.Hour
+	case "weekly":
+		interval = 7 * 24 * time.Hour
+	case "monthly":
+		interval = 30 * 24 * time.Hour
+	case "quarterly":
+		interval = 90 * 24 * time.Hour
+	default:
+		interval = 7 * 24 * time.Hour
+	}
+
+	return currentDate.Sub(lastSnapshotDate) >= interval
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "shouldTakeSnapshot" ./provider/`
+Expected: all 9 shouldTakeSnapshot specs PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/index_helpers.go provider/index_helpers_test.go
+git commit -m "refactor: add currentDate parameter to shouldTakeSnapshot"
+```
+
+---
+
+### Task 3: Update callers of `diffSnapshots` and `shouldTakeSnapshot`
+
+This task fixes compilation for all callers that use the old signatures: `ishares.go`, `nasdaq.go`, and `hooks_test.go`.
+
+**Files:**
+- Modify: `provider/ishares.go:240-269`
+- Modify: `provider/nasdaq.go:190-214`
+- Modify: `provider/hooks_test.go`
+
+- [ ] **Step 1: Update `ishares.go` callers**
+
+In `provider/ishares.go`, replace lines 240-269 (from "Build current holdings map" through the `shouldTakeSnapshot` call) with:
+
+```go
+	// Build current holdings map (ticker -> indexMember) and weight map
+	currentHoldings := make(map[string]indexMember, len(parseResult.Holdings))
+	weightMap := make(map[string]float64, len(parseResult.Holdings))
+	for _, holding := range parseResult.Holdings {
+		figi := figiMap[holding.Ticker]
+		if figi != "" {
+			currentHoldings[holding.Ticker] = indexMember{
+				CompositeFigi: figi,
+				Weight:        holding.Weight,
+			}
+		}
+		weightMap[holding.Ticker] = holding.Weight
+	}
+
+	// Get previous snapshot and emit changelog
+	table := subscription.DataTablesMap[data.IndexKey]
+	previous := previousSnapshotTickers(ctx, subscription.Library.Pool, table, etf.IndexName)
+	previousMembers := make(map[string]indexMember, len(previous))
+	for t, figi := range previous {
+		previousMembers[t] = indexMember{CompositeFigi: figi}
+	}
+	added, removed, _ := diffSnapshots(currentHoldings, previousMembers)
+
+	eventDate := parseResult.SnapshotDate
+	if eventDate.IsZero() {
+		eventDate = time.Now().UTC().Truncate(24 * time.Hour)
+	}
+
+	addedFigi := make(map[string]string, len(added))
+	for t, m := range added {
+		addedFigi[t] = m.CompositeFigi
+	}
+	removedFigi := make(map[string]string, len(removed))
+	for t, m := range removed {
+		removedFigi[t] = m.CompositeFigi
+	}
+
+	emitChangelog(addedFigi, removedFigi, etf.IndexName, eventDate, weightMap, &data.Observation{
+		ObservationDate:  time.Now(),
+		SubscriptionID:   subscription.ID,
+		SubscriptionName: subscription.Name,
+	}, out)
+	numObs += len(added) + len(removed)
+
+	// Check if a snapshot should be taken
+	lastDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, etf.IndexName)
+	if shouldTakeSnapshot(lastDate, eventDate, snapshotFrequency) {
+```
+
+Also update the snapshot emission block (lines 271-297) to use `currentHoldings` map:
+
+```go
+		for t, member := range currentHoldings {
+			out <- &data.Observation{
+				IndexSnapshot: &data.IndexSnapshot{
+					Ticker:        t,
+					CompositeFigi: member.CompositeFigi,
+					IndexName:     etf.IndexName,
+					SnapshotDate:  eventDate,
+					Weight:        member.Weight,
+				},
+				ObservationDate:  time.Now(),
+				SubscriptionID:   subscription.ID,
+				SubscriptionName: subscription.Name,
+			}
+
+			numObs++
+		}
+
+		logger.Info().
+			Int("NumSnapshots", len(currentHoldings)).
+			Str("IndexName", etf.IndexName).
+			Time("SnapshotDate", eventDate).
+			Msg("emitted index snapshots")
+	}
+
+	return numObs, nil
+}
+```
+
+- [ ] **Step 2: Update `nasdaq.go` callers**
+
+In `provider/nasdaq.go`, replace lines 190-214 (from "Build current holdings map" through the `shouldTakeSnapshot` call) with:
+
+```go
+	// Build current holdings map (ticker -> indexMember)
+	currentHoldings := make(map[string]indexMember, len(holdings))
+	for _, holding := range holdings {
+		if figi, ok := figiMap[holding.Ticker]; ok {
+			currentHoldings[holding.Ticker] = indexMember{CompositeFigi: figi}
+		}
+	}
+
+	// Get previous snapshot and emit changelog
+	table := subscription.DataTablesMap[data.IndexKey]
+	previous := previousSnapshotTickers(ctx, subscription.Library.Pool, table, "ndx100")
+	previousMembers := make(map[string]indexMember, len(previous))
+	for t, figi := range previous {
+		previousMembers[t] = indexMember{CompositeFigi: figi}
+	}
+	added, removed, _ := diffSnapshots(currentHoldings, previousMembers)
+
+	eventDate := time.Now().UTC().Truncate(24 * time.Hour)
+
+	addedFigi := make(map[string]string, len(added))
+	for t, m := range added {
+		addedFigi[t] = m.CompositeFigi
+	}
+	removedFigi := make(map[string]string, len(removed))
+	for t, m := range removed {
+		removedFigi[t] = m.CompositeFigi
+	}
+
+	emitChangelog(addedFigi, removedFigi, "ndx100", eventDate, nil, &data.Observation{
+		ObservationDate:  time.Now(),
+		SubscriptionID:   subscription.ID,
+		SubscriptionName: subscription.Name,
+	}, out)
+	numObs += len(added) + len(removed)
+
+	// Check if a snapshot should be taken
+	lastDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, "ndx100")
+	if shouldTakeSnapshot(lastDate, eventDate, snapshotFrequency) {
+```
+
+Also update the snapshot loop (lines 222-238) to use `currentHoldings`:
+
+```go
+		// Build a weight map for quick lookup
+		weightMap := make(map[string]float64, len(holdings))
+		for _, holding := range holdings {
+			weightMap[holding.Ticker] = holding.Weight
+		}
+
+		snapshotDate := eventDate
+
+		for ticker, member := range currentHoldings {
+			out <- &data.Observation{
+				IndexSnapshot: &data.IndexSnapshot{
+					Ticker:        ticker,
+					CompositeFigi: member.CompositeFigi,
+					IndexName:     "ndx100",
+					SnapshotDate:  snapshotDate,
+					Weight:        weightMap[ticker],
+				},
+				ObservationDate:  time.Now(),
+				SubscriptionID:   subscription.ID,
+				SubscriptionName: subscription.Name,
+			}
+
+			numObs++
+		}
+```
+
+- [ ] **Step 3: Update `hooks_test.go`**
+
+In `provider/hooks_test.go`, the `ComputeAdjustedClose` tests do not call `diffSnapshots` or `shouldTakeSnapshot`, so no changes are needed. Verify by reading the file.
+
+If any other test files reference the old signatures, update them.
+
+- [ ] **Step 4: Run full provider test suite**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race ./provider/`
+Expected: all specs PASS, no compilation errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/ishares.go provider/nasdaq.go
+git commit -m "refactor: update ishares and nasdaq to use indexMember and new signatures"
+```
+
+---
+
+### Task 4: Add `tradingDays` helper
+
+**Files:**
+- Modify: `provider/index_helpers.go`
+- Modify: `provider/index_helpers_test.go`
+
+- [ ] **Step 1: Write failing test for `tradingDays`**
+
+This function calls the DB's `trading_days(DATE, DATE)` SQL function. Since unit tests don't have a DB connection, write a test that validates the function exists and returns an error on nil pool. Add to `provider/index_helpers_test.go`:
+
+```go
+var _ = Describe("tradingDays", func() {
+	It("returns an error when pool is nil", func() {
+		start := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2026, 1, 9, 0, 0, 0, 0, time.UTC)
+		_, err := tradingDays(context.Background(), nil, start, end)
+		Expect(err).To(HaveOccurred())
+	})
+})
+```
+
+Add `"context"` to the imports at the top of the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "tradingDays" ./provider/`
+Expected: compilation error -- `tradingDays` not defined.
+
+- [ ] **Step 3: Implement `tradingDays`**
+
+In `provider/index_helpers.go`, add after the `previousSnapshotTickers` function:
+
+```go
+// tradingDays returns NYSE trading days between start and end (inclusive)
+// by calling the database's trading_days(DATE, DATE) function.
+func tradingDays(ctx context.Context, pool *pgxpool.Pool, start, end time.Time) ([]time.Time, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("database pool is nil")
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not acquire db connection for tradingDays: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, `SELECT dt FROM trading_days($1::date, $2::date) AS dt ORDER BY dt`, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("could not query trading days: %w", err)
+	}
+	defer rows.Close()
+
+	var days []time.Time
+
+	for rows.Next() {
+		var dt time.Time
+		if err := rows.Scan(&dt); err != nil {
+			return nil, fmt.Errorf("error scanning trading day: %w", err)
+		}
+
+		days = append(days, dt)
+	}
+
+	return days, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "tradingDays" ./provider/`
+Expected: 1 spec PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/index_helpers.go provider/index_helpers_test.go
+git commit -m "feat: add tradingDays helper to query NYSE trading days from DB"
+```
+
+---
+
+### Task 5: Add `currentIndexMembers` helper
+
+**Files:**
+- Modify: `provider/index_helpers.go`
+- Modify: `provider/index_helpers_test.go`
+
+- [ ] **Step 1: Write failing test for `currentIndexMembers`**
+
+Add to `provider/index_helpers_test.go`:
+
+```go
+var _ = Describe("currentIndexMembers", func() {
+	It("returns empty map when pool is nil", func() {
+		asOf := time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)
+		result := currentIndexMembers(context.Background(), nil, "test_table", "sp500", asOf)
+		Expect(result).To(BeEmpty())
+	})
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "currentIndexMembers" ./provider/`
+Expected: compilation error -- `currentIndexMembers` not defined.
+
+- [ ] **Step 3: Implement `currentIndexMembers`**
+
+In `provider/index_helpers.go`, add after the `tradingDays` function:
+
+```go
+// currentIndexMembers reconstructs the true index membership as of a given date
+// by taking the most recent snapshot on or before asOfDate and applying all
+// changelog entries (adds, removes, weight-changes) between that snapshot and asOfDate.
+func currentIndexMembers(ctx context.Context, pool *pgxpool.Pool, table, indexName string, asOfDate time.Time) map[string]indexMember {
+	if pool == nil {
+		return map[string]indexMember{}
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("could not acquire db connection for currentIndexMembers")
+		return map[string]indexMember{}
+	}
+	defer conn.Release()
+
+	// Get the most recent snapshot on or before asOfDate
+	var snapshotDate time.Time
+
+	err = conn.QueryRow(ctx,
+		fmt.Sprintf(`SELECT COALESCE(MAX(snapshot_date), '0001-01-01') FROM %s_snapshot WHERE index_name = $1 AND snapshot_date <= $2`, table),
+		indexName, asOfDate,
+	).Scan(&snapshotDate)
+	if err != nil {
+		log.Error().Err(err).Msg("could not query snapshot date for currentIndexMembers")
+		return map[string]indexMember{}
+	}
+
+	result := make(map[string]indexMember)
+
+	if !snapshotDate.IsZero() {
+		// Load the snapshot
+		rows, err := conn.Query(ctx,
+			fmt.Sprintf(`SELECT ticker, composite_figi, weight FROM %s_snapshot WHERE index_name = $1 AND snapshot_date = $2`, table),
+			indexName, snapshotDate,
+		)
+		if err != nil {
+			log.Error().Err(err).Msg("could not query snapshot for currentIndexMembers")
+			return map[string]indexMember{}
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var ticker, figi string
+			var weight float64
+
+			if err := rows.Scan(&ticker, &figi, &weight); err != nil {
+				log.Error().Err(err).Msg("error scanning snapshot row in currentIndexMembers")
+				continue
+			}
+
+			result[ticker] = indexMember{CompositeFigi: figi, Weight: weight}
+		}
+
+		rows.Close()
+	}
+
+	// Apply changelog entries after the snapshot date up to asOfDate
+	changeRows, err := conn.Query(ctx,
+		fmt.Sprintf(`SELECT ticker, composite_figi, action, weight FROM %s_changelog WHERE index_name = $1 AND event_date > $2 AND event_date <= $3 ORDER BY event_date`, table),
+		indexName, snapshotDate, asOfDate,
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("could not query changelog for currentIndexMembers")
+		return result
+	}
+	defer changeRows.Close()
+
+	for changeRows.Next() {
+		var ticker, figi, action string
+		var weight float64
+
+		if err := changeRows.Scan(&ticker, &figi, &action, &weight); err != nil {
+			log.Error().Err(err).Msg("error scanning changelog row in currentIndexMembers")
+			continue
+		}
+
+		switch action {
+		case "add":
+			result[ticker] = indexMember{CompositeFigi: figi, Weight: weight}
+		case "remove":
+			delete(result, ticker)
+		case "weight-change":
+			if member, ok := result[ticker]; ok {
+				member.Weight = weight
+				result[ticker] = member
+			}
+		}
+	}
+
+	return result
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race --focus "currentIndexMembers" ./provider/`
+Expected: 1 spec PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/index_helpers.go provider/index_helpers_test.go
+git commit -m "feat: add currentIndexMembers to reconstruct index state from snapshot + changelog"
+```
+
+---
+
+### Task 6: Add `emitWeightChanges` helper
+
+**Files:**
+- Modify: `provider/index_helpers.go`
+
+- [ ] **Step 1: Add `emitWeightChanges` function**
+
+In `provider/index_helpers.go`, add after the existing `emitChangelog` function:
+
+```go
+// emitWeightChanges emits IndexChange observations with "weight-change" action.
+func emitWeightChanges(changes map[string]indexMember, indexName string, eventDate time.Time, subscription *data.Observation, out chan<- *data.Observation) {
+	for ticker, member := range changes {
+		out <- &data.Observation{
+			IndexChange: &data.IndexChange{
+				Ticker:        ticker,
+				CompositeFigi: member.CompositeFigi,
+				IndexName:     indexName,
+				EventDate:     eventDate,
+				Action:        "weight-change",
+				Weight:        member.Weight,
+			},
+			ObservationDate:  subscription.ObservationDate,
+			SubscriptionID:   subscription.SubscriptionID,
+			SubscriptionName: subscription.SubscriptionName,
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run full suite to verify compilation**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race ./provider/`
+Expected: all specs PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add provider/index_helpers.go
+git commit -m "feat: add emitWeightChanges helper for weight-change changelog entries"
+```
+
+---
+
+### Task 7: Wire up backfill loop in `downloadSingleISharesETF`
+
+This is the core change. The function gains a backfill loop that fetches historical CSVs using `asOfDate`, diffs against in-memory state, and emits changelog + snapshot observations.
+
+**Files:**
+- Modify: `provider/ishares.go:90,194-301`
+
+- [ ] **Step 1: Update URL template**
+
+In `provider/ishares.go`, change the `iSharesHoldingsURLTemplate` constant (line 90) to remove the trailing parameter so we can conditionally append `asOfDate`:
+
+The existing template already works -- we just append `&asOfDate=YYYYMMDD` when needed. No change to the constant is required.
+
+- [ ] **Step 2: Rewrite `downloadSingleISharesETF` with backfill support**
+
+Replace the entire `downloadSingleISharesETF` function (lines 194-301) with:
+
+```go
+func downloadSingleISharesETF(
+	ctx context.Context,
+	client *resty.Client,
+	ticker string,
+	etf iSharesETF,
+	figiMap map[string]string,
+	snapshotFrequency string,
+	subscription *library.Subscription,
+	out chan<- *data.Observation,
+) (int, error) {
+	logger := zerolog.Ctx(ctx)
+	numObs := 0
+	table := subscription.DataTablesMap[data.IndexKey]
+
+	lookback := LookbackFromContext(ctx, 14*24*time.Hour)
+
+	// Build the list of dates to fetch.
+	// Always includes today (empty asOfDate = current data).
+	type fetchDate struct {
+		date     time.Time
+		asOfDate string // empty means "today / no asOfDate param"
+	}
+
+	var dates []fetchDate
+
+	startDate := time.Now().Add(-lookback)
+	yesterday := time.Now().AddDate(0, 0, -1).Truncate(24 * time.Hour)
+
+	if startDate.Before(yesterday) {
+		days, err := tradingDays(ctx, subscription.Library.Pool, startDate, yesterday)
+		if err != nil {
+			logger.Warn().Err(err).Msg("could not query trading days, falling back to today only")
+		} else {
+			for _, d := range days {
+				dates = append(dates, fetchDate{
+					date:     d,
+					asOfDate: d.Format("20060102"),
+				})
+			}
+		}
+	}
+
+	// Always fetch today's data last (no asOfDate)
+	dates = append(dates, fetchDate{
+		date: time.Now().UTC().Truncate(24 * time.Hour),
+	})
+
+	// Load initial state from DB: last snapshot + changelog entries up to start
+	state := currentIndexMembers(ctx, subscription.Library.Pool, table, etf.IndexName, startDate)
+	memLastSnapshotDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, etf.IndexName)
+
+	obsTemplate := &data.Observation{
+		ObservationDate:  time.Now(),
+		SubscriptionID:   subscription.ID,
+		SubscriptionName: subscription.Name,
+	}
+
+	for i, fd := range dates {
+		// Build URL
+		csvURL := fmt.Sprintf(iSharesHoldingsURLTemplate, etf.ProductID, etf.Slug, ticker)
+		if fd.asOfDate != "" {
+			csvURL += "&asOfDate=" + fd.asOfDate
+		}
+
+		logger.Info().Str("URL", csvURL).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("downloading iShares holdings CSV")
+
+		resp, err := client.R().SetContext(ctx).Get(csvURL)
+		if err != nil {
+			logger.Error().Err(err).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("HTTP request failed")
+			continue
+		}
+
+		if resp.StatusCode() != 200 {
+			logger.Error().Int("StatusCode", resp.StatusCode()).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("HTTP error")
+			continue
+		}
+
+		csvData := resp.Body()
+		logger.Info().Int("Bytes", len(csvData)).Str("IndexName", etf.IndexName).Msg("downloaded iShares holdings CSV")
+
+		parseResult, err := parseISharesCSV(csvData)
+		if err != nil {
+			logger.Error().Err(err).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("could not parse CSV")
+			continue
+		}
+
+		if len(parseResult.Holdings) == 0 {
+			logger.Warn().Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("no holdings found")
+			continue
+		}
+
+		logger.Info().
+			Int("NumHoldings", len(parseResult.Holdings)).
+			Time("SnapshotDate", parseResult.SnapshotDate).
+			Str("IndexName", etf.IndexName).
+			Msg("parsed iShares holdings")
+
+		// Build current holdings map
+		currentHoldings := make(map[string]indexMember, len(parseResult.Holdings))
+		weightMap := make(map[string]float64, len(parseResult.Holdings))
+
+		for _, holding := range parseResult.Holdings {
+			figi := figiMap[holding.Ticker]
+			if figi != "" {
+				currentHoldings[holding.Ticker] = indexMember{
+					CompositeFigi: figi,
+					Weight:        holding.Weight,
+				}
+			}
+
+			weightMap[holding.Ticker] = holding.Weight
+		}
+
+		// Diff against in-memory state
+		added, removed, weightChanged := diffSnapshots(currentHoldings, state)
+
+		eventDate := parseResult.SnapshotDate
+		if eventDate.IsZero() {
+			eventDate = fd.date
+		}
+
+		// Emit changelog: adds and removes
+		addedFigi := make(map[string]string, len(added))
+		for t, m := range added {
+			addedFigi[t] = m.CompositeFigi
+		}
+
+		removedFigi := make(map[string]string, len(removed))
+		for t, m := range removed {
+			removedFigi[t] = m.CompositeFigi
+		}
+
+		emitChangelog(addedFigi, removedFigi, etf.IndexName, eventDate, weightMap, obsTemplate, out)
+		numObs += len(added) + len(removed)
+
+		// Emit weight changes
+		emitWeightChanges(weightChanged, etf.IndexName, eventDate, obsTemplate, out)
+		numObs += len(weightChanged)
+
+		// Check if snapshot is due
+		if shouldTakeSnapshot(memLastSnapshotDate, eventDate, snapshotFrequency) {
+			for t, member := range currentHoldings {
+				out <- &data.Observation{
+					IndexSnapshot: &data.IndexSnapshot{
+						Ticker:        t,
+						CompositeFigi: member.CompositeFigi,
+						IndexName:     etf.IndexName,
+						SnapshotDate:  eventDate,
+						Weight:        member.Weight,
+					},
+					ObservationDate:  obsTemplate.ObservationDate,
+					SubscriptionID:   obsTemplate.SubscriptionID,
+					SubscriptionName: obsTemplate.SubscriptionName,
+				}
+
+				numObs++
+			}
+
+			memLastSnapshotDate = eventDate
+
+			logger.Info().
+				Int("NumSnapshots", len(currentHoldings)).
+				Str("IndexName", etf.IndexName).
+				Time("SnapshotDate", eventDate).
+				Msg("emitted index snapshots")
+		}
+
+		// Update in-memory state
+		for t, m := range added {
+			state[t] = m
+		}
+
+		for t := range removed {
+			delete(state, t)
+		}
+
+		for t, m := range weightChanged {
+			state[t] = m
+		}
+
+		// Rate-limit delay between requests (skip after last)
+		if i < len(dates)-1 {
+			delay := 5*time.Second + time.Duration(rand.IntN(41))*time.Second
+			logger.Info().Dur("Delay", delay).Msg("waiting between iShares historical requests")
+			time.Sleep(delay)
+		}
+	}
+
+	return numObs, nil
+}
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race ./provider/`
+Expected: all specs PASS.
+
+- [ ] **Step 4: Run full project test suite**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race ./...`
+Expected: all suites PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/ishares.go
+git commit -m "feat: add lookback-based backfill to iShares index provider"
+```
+
+---
+
+### Task 8: Run linter and fix issues
+
+**Files:**
+- Possibly: `provider/index_helpers.go`, `provider/ishares.go`, `provider/nasdaq.go`
+
+- [ ] **Step 1: Run linter**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && make lint`
+Expected: no errors. If there are errors, fix them.
+
+- [ ] **Step 2: Run full test suite one final time**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data/.worktrees/feature-backfill && ginkgo run -race ./...`
+Expected: all suites PASS, Test Suite Passed.
+
+- [ ] **Step 3: Commit any lint fixes**
+
+```bash
+git add -A
+git commit -m "style: fix lint issues from backfill implementation"
+```
+
+Only commit if there were lint fixes. Skip if clean.

--- a/docs/superpowers/specs/2026-03-30-ishares-backfill-design.md
+++ b/docs/superpowers/specs/2026-03-30-ishares-backfill-design.md
@@ -1,0 +1,74 @@
+# iShares Index Backfill Design
+
+## Problem
+
+The iShares index provider only fetches today's holdings. There is no way to backfill historical index composition data. The EOD provider supports a `--lookback` flag that controls how far back to fetch; the iShares provider should support the same mechanism.
+
+Additionally, `previousSnapshotTickers` only returns the last full snapshot from the database, ignoring changelog entries (adds/removes) that occurred after that snapshot. This means if a ticker was removed via changelog after the last snapshot, it would be reported as removed again on the next run.
+
+## Design
+
+### Backfill Flow
+
+1. `downloadSingleISharesETF` reads `LookbackFromContext(ctx, 14*24*time.Hour)` -- same default as EOD.
+2. When lookback > 0, query the database using the existing `trading_days(start, end)` SQL function to get the list of dates from `now - lookback` to yesterday. Today's data is always fetched last without `asOfDate` (current behavior).
+3. Load initial index state from the database using a new `currentIndexMembers` helper that reconstructs the true membership: last snapshot before the start date + all changelog adds/removes between that snapshot and the start date.
+4. Loop through trading days oldest-first:
+   - Fetch CSV with `&asOfDate=YYYYMMDD` appended to the existing URL template.
+   - Diff against in-memory state (not DB).
+   - Emit changelog entries for adds/removes.
+   - Check `shouldTakeSnapshot` using the processing date vs the in-memory last snapshot date (not wall-clock `time.Since`).
+   - If snapshot is due, emit snapshot observations and update in-memory last snapshot date.
+   - Update in-memory state with adds/removes.
+   - Rate-limit delay between requests.
+5. After the loop, fetch today's data without `asOfDate` (preserving existing behavior).
+
+### Weight Change Tracking
+
+The changelog currently only records "add" and "remove" actions. A new "weight-change" action is added to capture significant shifts in constituent weights. The existing schema already supports this -- no migration needed.
+
+A weight change is significant when the absolute difference exceeds 0.01 (1 percentage point). For example, a holding moving from 0.05 to 0.065 (delta 0.015) is recorded; a move from 0.05 to 0.055 (delta 0.005) is not.
+
+During diffing, `diffSnapshots` is extended to also compare weights for tickers present in both the current and previous state. The in-memory state tracks weights alongside FIGIs so that weight changes can be detected. `currentIndexMembers` also returns weights so the initial state is complete.
+
+### Changes
+
+#### `index_helpers.go`
+
+**New function: `currentIndexMembers(ctx, pool, table, indexName, asOfDate) map[string]indexMember`**
+
+Where `indexMember` is a struct with `CompositeFigi string` and `Weight float64`.
+
+Reconstructs the true index membership (including weights) as of a given date:
+1. Query the most recent snapshot on or before `asOfDate` (tickers, FIGIs, and weights).
+2. Query all changelog entries between that snapshot date and `asOfDate`.
+3. Apply adds/removes/weight-changes to the snapshot to produce the true state.
+
+This replaces `previousSnapshotTickers` in the iShares flow and fixes the existing bug where changelog entries after the last snapshot were ignored.
+
+**New function: `tradingDays(ctx, pool, start, end) ([]time.Time, error)`**
+
+Calls the existing `trading_days(DATE, DATE)` SQL function to get a list of NYSE trading days in the given range.
+
+**Modified: `shouldTakeSnapshot(lastSnapshotDate, currentDate, frequency) bool`**
+
+Add a `currentDate` parameter instead of using `time.Since()`, so it works correctly during backfill when processing historical dates. All existing callers updated to pass `time.Now()` or the processing date.
+
+#### `ishares.go`
+
+**Modified URL template**: Add `asOfDate` support. The URL becomes:
+```
+base_url + "&asOfDate=YYYYMMDD"  (for historical)
+base_url                          (for today, no change)
+```
+
+**Modified `downloadSingleISharesETF`**: Accept `ctx` for lookback. When lookback > 0, run the backfill loop described above. The function signature gains no new parameters -- lookback comes from context, and trading days come from the subscription's DB pool.
+
+### What Does Not Change
+
+- The `snapshotFrequency` config and its semantics.
+- The CSV parser (`parseISharesCSV`).
+- The `emitChangelog` function.
+- The `diffSnapshots` function signature changes to accept and return weight data, and to detect significant weight changes (see above).
+- Non-iShares index providers (e.g., Nasdaq).
+- The `previousSnapshotTickers` function remains available for other callers, though iShares will use `currentIndexMembers` instead.

--- a/provider/hooks_test.go
+++ b/provider/hooks_test.go
@@ -40,9 +40,9 @@ var _ = Describe("ComputeAdjustedClose", func() {
 		// After row 1: adjustFactor = 1.0 * (1 + 2/102) = 1.01961
 		// Row 2: AdjClose = 101 / 1.01961 ~= 99.07
 		rows := []EodRow{
-			{Close: 100.0, Dividend: 0, SplitFactor: 1.0},  // newest
+			{Close: 100.0, Dividend: 0, SplitFactor: 1.0},   // newest
 			{Close: 102.0, Dividend: 2.0, SplitFactor: 1.0}, // ex-dividend date
-			{Close: 101.0, Dividend: 0, SplitFactor: 1.0},  // oldest
+			{Close: 101.0, Dividend: 0, SplitFactor: 1.0},   // oldest
 		}
 		result := ComputeAdjustedClose(rows)
 		Expect(result[0].AdjClose).To(BeNumerically("~", 100.0, 0.01))

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -175,6 +175,7 @@ func currentIndexMembers(ctx context.Context, pool *pgxpool.Pool, table, indexNa
 			log.Error().Err(err).Msg("could not query snapshot for currentIndexMembers")
 			return map[string]indexMember{}
 		}
+		defer rows.Close()
 
 		for rows.Next() {
 			var ticker, figi string
@@ -188,8 +189,6 @@ func currentIndexMembers(ctx context.Context, pool *pgxpool.Pool, table, indexNa
 
 			result[ticker] = indexMember{CompositeFigi: figi, Weight: weight}
 		}
-
-		rows.Close()
 	}
 
 	// Apply changelog entries after the snapshot date up to asOfDate

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -136,6 +136,116 @@ func previousSnapshotTickers(ctx context.Context, pool *pgxpool.Pool, table, ind
 	return result
 }
 
+// currentIndexMembers reconstructs the true index membership as of a given date
+// by taking the most recent snapshot on or before asOfDate and applying all
+// changelog entries (adds, removes, weight-changes) between that snapshot and asOfDate.
+func currentIndexMembers(ctx context.Context, pool *pgxpool.Pool, table, indexName string, asOfDate time.Time) map[string]indexMember {
+	if pool == nil {
+		return map[string]indexMember{}
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("could not acquire db connection for currentIndexMembers")
+		return map[string]indexMember{}
+	}
+	defer conn.Release()
+
+	// Get the most recent snapshot on or before asOfDate
+	var snapshotDate time.Time
+
+	err = conn.QueryRow(ctx,
+		fmt.Sprintf(`SELECT COALESCE(MAX(snapshot_date), '0001-01-01') FROM %s_snapshot WHERE index_name = $1 AND snapshot_date <= $2`, table),
+		indexName, asOfDate,
+	).Scan(&snapshotDate)
+	if err != nil {
+		log.Error().Err(err).Msg("could not query snapshot date for currentIndexMembers")
+		return map[string]indexMember{}
+	}
+
+	result := make(map[string]indexMember)
+
+	if !snapshotDate.IsZero() {
+		// Load the snapshot
+		rows, err := conn.Query(ctx,
+			fmt.Sprintf(`SELECT ticker, composite_figi, weight FROM %s_snapshot WHERE index_name = $1 AND snapshot_date = $2`, table),
+			indexName, snapshotDate,
+		)
+		if err != nil {
+			log.Error().Err(err).Msg("could not query snapshot for currentIndexMembers")
+			return map[string]indexMember{}
+		}
+
+		for rows.Next() {
+			var ticker, figi string
+			var weight float64
+
+			if err := rows.Scan(&ticker, &figi, &weight); err != nil {
+				log.Error().Err(err).Msg("error scanning snapshot row in currentIndexMembers")
+				continue
+			}
+
+			result[ticker] = indexMember{CompositeFigi: figi, Weight: weight}
+		}
+
+		rows.Close()
+	}
+
+	// Apply changelog entries after the snapshot date up to asOfDate
+	changeRows, err := conn.Query(ctx,
+		fmt.Sprintf(`SELECT ticker, composite_figi, action, weight FROM %s_changelog WHERE index_name = $1 AND event_date > $2 AND event_date <= $3 ORDER BY event_date`, table),
+		indexName, snapshotDate, asOfDate,
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("could not query changelog for currentIndexMembers")
+		return result
+	}
+	defer changeRows.Close()
+
+	for changeRows.Next() {
+		var ticker, figi, action string
+		var weight float64
+
+		if err := changeRows.Scan(&ticker, &figi, &action, &weight); err != nil {
+			log.Error().Err(err).Msg("error scanning changelog row in currentIndexMembers")
+			continue
+		}
+
+		switch action {
+		case "add":
+			result[ticker] = indexMember{CompositeFigi: figi, Weight: weight}
+		case "remove":
+			delete(result, ticker)
+		case "weight-change":
+			if member, ok := result[ticker]; ok {
+				member.Weight = weight
+				result[ticker] = member
+			}
+		}
+	}
+
+	return result
+}
+
+// emitWeightChanges emits IndexChange observations with "weight-change" action.
+func emitWeightChanges(changes map[string]indexMember, indexName string, eventDate time.Time, subscription *data.Observation, out chan<- *data.Observation) {
+	for ticker, member := range changes {
+		out <- &data.Observation{
+			IndexChange: &data.IndexChange{
+				Ticker:        ticker,
+				CompositeFigi: member.CompositeFigi,
+				IndexName:     indexName,
+				EventDate:     eventDate,
+				Action:        "weight-change",
+				Weight:        member.Weight,
+			},
+			ObservationDate:  subscription.ObservationDate,
+			SubscriptionID:   subscription.SubscriptionID,
+			SubscriptionName: subscription.SubscriptionName,
+		}
+	}
+}
+
 // emitChangelog emits IndexChange observations for adds and removes.
 func emitChangelog(adds, removes map[string]indexMember, indexName string, eventDate time.Time, subscription *data.Observation, out chan<- *data.Observation) {
 	for ticker, member := range adds {

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -1,3 +1,17 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package provider
 
 import (

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -19,8 +19,8 @@ type indexMember struct {
 const weightChangeThreshold = 0.01
 
 // shouldTakeSnapshot returns true if a new snapshot should be taken based on the
-// configured frequency and the date of the last snapshot.
-func shouldTakeSnapshot(lastSnapshotDate time.Time, frequency string) bool {
+// configured frequency, the date of the last snapshot, and the current processing date.
+func shouldTakeSnapshot(lastSnapshotDate, currentDate time.Time, frequency string) bool {
 	if lastSnapshotDate.IsZero() {
 		return true
 	}
@@ -40,7 +40,7 @@ func shouldTakeSnapshot(lastSnapshotDate time.Time, frequency string) bool {
 		interval = 7 * 24 * time.Hour
 	}
 
-	return time.Since(lastSnapshotDate) >= interval
+	return currentDate.Sub(lastSnapshotDate) >= interval
 }
 
 // diffSnapshots compares current holdings against previous holdings

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -178,6 +178,7 @@ func currentIndexMembers(ctx context.Context, pool *pgxpool.Pool, table, indexNa
 
 		for rows.Next() {
 			var ticker, figi string
+
 			var weight float64
 
 			if err := rows.Scan(&ticker, &figi, &weight); err != nil {
@@ -204,6 +205,7 @@ func currentIndexMembers(ctx context.Context, pool *pgxpool.Pool, table, indexNa
 
 	for changeRows.Next() {
 		var ticker, figi, action string
+
 		var weight float64
 
 		if err := changeRows.Scan(&ticker, &figi, &action, &weight); err != nil {

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -246,6 +246,39 @@ func emitWeightChanges(changes map[string]indexMember, indexName string, eventDa
 	}
 }
 
+// tradingDays returns NYSE trading days between start and end (inclusive)
+// by calling the database's trading_days(DATE, DATE) function.
+func tradingDays(ctx context.Context, pool *pgxpool.Pool, start, end time.Time) ([]time.Time, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("database pool is nil")
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not acquire db connection for tradingDays: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, `SELECT dt FROM trading_days($1::date, $2::date) AS dt ORDER BY dt`, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("could not query trading days: %w", err)
+	}
+	defer rows.Close()
+
+	var days []time.Time
+
+	for rows.Next() {
+		var dt time.Time
+		if err := rows.Scan(&dt); err != nil {
+			return nil, fmt.Errorf("error scanning trading day: %w", err)
+		}
+
+		days = append(days, dt)
+	}
+
+	return days, nil
+}
+
 // emitChangelog emits IndexChange observations for adds and removes.
 func emitChangelog(adds, removes map[string]indexMember, indexName string, eventDate time.Time, subscription *data.Observation, out chan<- *data.Observation) {
 	for ticker, member := range adds {

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -10,6 +10,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// indexMember represents a constituent of an index with its FIGI and weight.
+type indexMember struct {
+	CompositeFigi string
+	Weight        float64
+}
+
+const weightChangeThreshold = 0.01
+
 // shouldTakeSnapshot returns true if a new snapshot should be taken based on the
 // configured frequency and the date of the last snapshot.
 func shouldTakeSnapshot(lastSnapshotDate time.Time, frequency string) bool {
@@ -35,21 +43,34 @@ func shouldTakeSnapshot(lastSnapshotDate time.Time, frequency string) bool {
 	return time.Since(lastSnapshotDate) >= interval
 }
 
-// diffSnapshots compares current holdings (ticker->figi) against previous holdings
-// and returns maps of added and removed tickers.
-func diffSnapshots(current, previous map[string]string) (added, removed map[string]string) {
-	added = make(map[string]string)
-	removed = make(map[string]string)
+// diffSnapshots compares current holdings against previous holdings
+// and returns maps of added, removed, and weight-changed tickers.
+// A weight change is significant when the absolute difference exceeds weightChangeThreshold.
+func diffSnapshots(current, previous map[string]indexMember) (added, removed, weightChanged map[string]indexMember) {
+	added = make(map[string]indexMember)
+	removed = make(map[string]indexMember)
+	weightChanged = make(map[string]indexMember)
 
-	for ticker, figi := range current {
-		if _, ok := previous[ticker]; !ok {
-			added[ticker] = figi
+	for ticker, member := range current {
+		prev, ok := previous[ticker]
+		if !ok {
+			added[ticker] = member
+			continue
+		}
+
+		delta := member.Weight - prev.Weight
+		if delta < 0 {
+			delta = -delta
+		}
+
+		if delta >= weightChangeThreshold-1e-9 {
+			weightChanged[ticker] = member
 		}
 	}
 
-	for ticker, figi := range previous {
+	for ticker, member := range previous {
 		if _, ok := current[ticker]; !ok {
-			removed[ticker] = figi
+			removed[ticker] = member
 		}
 	}
 
@@ -116,22 +137,16 @@ func previousSnapshotTickers(ctx context.Context, pool *pgxpool.Pool, table, ind
 }
 
 // emitChangelog emits IndexChange observations for adds and removes.
-// weightMap may be nil if weights are not available (e.g. Nasdaq).
-func emitChangelog(adds, removes map[string]string, indexName string, eventDate time.Time, weightMap map[string]float64, subscription *data.Observation, out chan<- *data.Observation) {
-	for ticker, figi := range adds {
-		var weight float64
-		if weightMap != nil {
-			weight = weightMap[ticker]
-		}
-
+func emitChangelog(adds, removes map[string]indexMember, indexName string, eventDate time.Time, subscription *data.Observation, out chan<- *data.Observation) {
+	for ticker, member := range adds {
 		out <- &data.Observation{
 			IndexChange: &data.IndexChange{
 				Ticker:        ticker,
-				CompositeFigi: figi,
+				CompositeFigi: member.CompositeFigi,
 				IndexName:     indexName,
 				EventDate:     eventDate,
 				Action:        "add",
-				Weight:        weight,
+				Weight:        member.Weight,
 			},
 			ObservationDate:  subscription.ObservationDate,
 			SubscriptionID:   subscription.SubscriptionID,
@@ -139,11 +154,11 @@ func emitChangelog(adds, removes map[string]string, indexName string, eventDate 
 		}
 	}
 
-	for ticker, figi := range removes {
+	for ticker, member := range removes {
 		out <- &data.Observation{
 			IndexChange: &data.IndexChange{
 				Ticker:        ticker,
-				CompositeFigi: figi,
+				CompositeFigi: member.CompositeFigi,
 				IndexName:     indexName,
 				EventDate:     eventDate,
 				Action:        "remove",

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -166,7 +166,6 @@ var _ = Describe("diffSnapshots", func() {
 	})
 })
 
-
 var _ = Describe("tradingDays", func() {
 	It("returns an error when pool is nil", func() {
 		start := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package provider
 
 import (

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -166,6 +166,16 @@ var _ = Describe("diffSnapshots", func() {
 	})
 })
 
+
+var _ = Describe("tradingDays", func() {
+	It("returns an error when pool is nil", func() {
+		start := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2026, 1, 9, 0, 0, 0, 0, time.UTC)
+		_, err := tradingDays(context.Background(), nil, start, end)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
 var _ = Describe("currentIndexMembers", func() {
 	It("returns empty map when pool is nil", func() {
 		asOf := time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -162,5 +163,13 @@ var _ = Describe("diffSnapshots", func() {
 		Expect(removes).To(HaveKey("MSFT"))
 		Expect(weightChanges).To(HaveLen(1))
 		Expect(weightChanges).To(HaveKey("AAPL"))
+	})
+})
+
+var _ = Describe("currentIndexMembers", func() {
+	It("returns empty map when pool is nil", func() {
+		asOf := time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)
+		result := currentIndexMembers(context.Background(), nil, "test_table", "sp500", asOf)
+		Expect(result).To(BeEmpty())
 	})
 })

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -1,17 +1,11 @@
 package provider
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-func TestIndexHelpers(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Index Helpers Suite")
-}
 
 var _ = Describe("shouldTakeSnapshot", func() {
 	It("returns true when no previous snapshot exists", func() {

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -55,35 +55,111 @@ var _ = Describe("shouldTakeSnapshot", func() {
 
 var _ = Describe("diffSnapshots", func() {
 	It("returns all as added when previous is empty", func() {
-		current := map[string]string{"AAPL": "BBG000B9XRY4", "MSFT": "BBG000BPH459"}
-		adds, removes := diffSnapshots(current, map[string]string{})
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, map[string]indexMember{})
 		Expect(adds).To(HaveLen(2))
 		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(BeEmpty())
 	})
 
 	It("returns all as removed when current is empty", func() {
-		previous := map[string]string{"AAPL": "BBG000B9XRY4"}
-		adds, removes := diffSnapshots(map[string]string{}, previous)
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(map[string]indexMember{}, previous)
 		Expect(adds).To(BeEmpty())
 		Expect(removes).To(HaveLen(1))
 		Expect(removes).To(HaveKey("AAPL"))
+		Expect(weightChanges).To(BeEmpty())
 	})
 
 	It("detects additions and removals", func() {
-		current := map[string]string{"AAPL": "BBG000B9XRY4", "GOOG": "BBG009S39JX6"}
-		previous := map[string]string{"AAPL": "BBG000B9XRY4", "MSFT": "BBG000BPH459"}
-		adds, removes := diffSnapshots(current, previous)
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"GOOG": {CompositeFigi: "BBG009S39JX6", Weight: 0.03},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
 		Expect(adds).To(HaveLen(1))
 		Expect(adds).To(HaveKey("GOOG"))
 		Expect(removes).To(HaveLen(1))
 		Expect(removes).To(HaveKey("MSFT"))
+		Expect(weightChanges).To(BeEmpty())
 	})
 
 	It("returns empty when sets are identical", func() {
-		current := map[string]string{"AAPL": "BBG000B9XRY4"}
-		previous := map[string]string{"AAPL": "BBG000B9XRY4"}
-		adds, removes := diffSnapshots(current, previous)
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
 		Expect(adds).To(BeEmpty())
 		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("detects significant weight change above 0.01 threshold", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.065},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("AAPL"))
+		Expect(weightChanges["AAPL"].Weight).To(BeNumerically("~", 0.065, 0.0001))
+	})
+
+	It("ignores weight change below 0.01 threshold", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.055},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("detects weight change exactly at 0.01 boundary", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.06},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		_, _, weightChanges := diffSnapshots(current, previous)
+		Expect(weightChanges).To(HaveLen(1))
+	})
+
+	It("handles simultaneous adds, removes, and weight changes", func() {
+		current := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.08},
+			"GOOG": {CompositeFigi: "BBG009S39JX6", Weight: 0.03},
+		}
+		previous := map[string]indexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := diffSnapshots(current, previous)
+		Expect(adds).To(HaveLen(1))
+		Expect(adds).To(HaveKey("GOOG"))
+		Expect(removes).To(HaveLen(1))
+		Expect(removes).To(HaveKey("MSFT"))
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("AAPL"))
 	})
 })

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -8,48 +8,49 @@ import (
 )
 
 var _ = Describe("shouldTakeSnapshot", func() {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+
 	It("returns true when no previous snapshot exists", func() {
-		Expect(shouldTakeSnapshot(time.Time{}, "weekly")).To(BeTrue())
+		Expect(shouldTakeSnapshot(time.Time{}, now, "weekly")).To(BeTrue())
 	})
 
 	It("returns true when daily and last snapshot was yesterday", func() {
-		yesterday := time.Now().AddDate(0, 0, -1)
-		Expect(shouldTakeSnapshot(yesterday, "daily")).To(BeTrue())
+		yesterday := now.AddDate(0, 0, -1)
+		Expect(shouldTakeSnapshot(yesterday, now, "daily")).To(BeTrue())
 	})
 
 	It("returns false when daily and last snapshot was today", func() {
-		today := time.Now()
-		Expect(shouldTakeSnapshot(today, "daily")).To(BeFalse())
+		Expect(shouldTakeSnapshot(now, now, "daily")).To(BeFalse())
 	})
 
 	It("returns true when weekly and last snapshot was 8 days ago", func() {
-		eightDaysAgo := time.Now().AddDate(0, 0, -8)
-		Expect(shouldTakeSnapshot(eightDaysAgo, "weekly")).To(BeTrue())
+		eightDaysAgo := now.AddDate(0, 0, -8)
+		Expect(shouldTakeSnapshot(eightDaysAgo, now, "weekly")).To(BeTrue())
 	})
 
 	It("returns false when weekly and last snapshot was 3 days ago", func() {
-		threeDaysAgo := time.Now().AddDate(0, 0, -3)
-		Expect(shouldTakeSnapshot(threeDaysAgo, "weekly")).To(BeFalse())
+		threeDaysAgo := now.AddDate(0, 0, -3)
+		Expect(shouldTakeSnapshot(threeDaysAgo, now, "weekly")).To(BeFalse())
 	})
 
 	It("returns true when monthly and last snapshot was 32 days ago", func() {
-		thirtyTwoDaysAgo := time.Now().AddDate(0, 0, -32)
-		Expect(shouldTakeSnapshot(thirtyTwoDaysAgo, "monthly")).To(BeTrue())
+		thirtyTwoDaysAgo := now.AddDate(0, 0, -32)
+		Expect(shouldTakeSnapshot(thirtyTwoDaysAgo, now, "monthly")).To(BeTrue())
 	})
 
 	It("returns false when monthly and last snapshot was 15 days ago", func() {
-		fifteenDaysAgo := time.Now().AddDate(0, 0, -15)
-		Expect(shouldTakeSnapshot(fifteenDaysAgo, "monthly")).To(BeFalse())
+		fifteenDaysAgo := now.AddDate(0, 0, -15)
+		Expect(shouldTakeSnapshot(fifteenDaysAgo, now, "monthly")).To(BeFalse())
 	})
 
 	It("returns true when quarterly and last snapshot was 95 days ago", func() {
-		ninetyFiveDaysAgo := time.Now().AddDate(0, 0, -95)
-		Expect(shouldTakeSnapshot(ninetyFiveDaysAgo, "quarterly")).To(BeTrue())
+		ninetyFiveDaysAgo := now.AddDate(0, 0, -95)
+		Expect(shouldTakeSnapshot(ninetyFiveDaysAgo, now, "quarterly")).To(BeTrue())
 	})
 
 	It("defaults to weekly for unknown frequency", func() {
-		eightDaysAgo := time.Now().AddDate(0, 0, -8)
-		Expect(shouldTakeSnapshot(eightDaysAgo, "bogus")).To(BeTrue())
+		eightDaysAgo := now.AddDate(0, 0, -8)
+		Expect(shouldTakeSnapshot(eightDaysAgo, now, "bogus")).To(BeTrue())
 	})
 })
 

--- a/provider/integration_test.go
+++ b/provider/integration_test.go
@@ -21,7 +21,7 @@ func TestISharesDownloadAndParse(t *testing.T) {
 	ticker := "IWD"
 
 	client := resty.New().
-		SetTimeout(60 * time.Second).
+		SetTimeout(60*time.Second).
 		SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36").
 		SetHeader("Accept", "text/csv,text/plain,*/*")
 

--- a/provider/ishares.go
+++ b/provider/ishares.go
@@ -359,7 +359,12 @@ func downloadSingleISharesETF(
 		if i < len(dates)-1 {
 			delay := 5*time.Second + time.Duration(rand.IntN(41))*time.Second
 			logger.Info().Dur("Delay", delay).Msg("waiting between iShares historical requests")
-			time.Sleep(delay)
+
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return numObs, ctx.Err()
+			}
 		}
 	}
 

--- a/provider/ishares.go
+++ b/provider/ishares.go
@@ -237,27 +237,33 @@ func downloadSingleISharesETF(
 		Str("IndexName", etf.IndexName).
 		Msg("parsed iShares holdings")
 
-	// Build current holdings map (ticker -> figi) and weight map
-	currentHoldings := make(map[string]string, len(parseResult.Holdings))
-	weightMap := make(map[string]float64, len(parseResult.Holdings))
+	// Build current holdings map (ticker -> indexMember)
+	currentHoldings := make(map[string]indexMember, len(parseResult.Holdings))
 	for _, holding := range parseResult.Holdings {
 		if figi, ok := figiMap[holding.Ticker]; ok {
-			currentHoldings[holding.Ticker] = figi
+			currentHoldings[holding.Ticker] = indexMember{
+				CompositeFigi: figi,
+				Weight:        holding.Weight,
+			}
 		}
-		weightMap[holding.Ticker] = holding.Weight
 	}
 
 	// Get previous snapshot and emit changelog
 	table := subscription.DataTablesMap[data.IndexKey]
-	previous := previousSnapshotTickers(ctx, subscription.Library.Pool, table, etf.IndexName)
-	added, removed := diffSnapshots(currentHoldings, previous)
+	prevRaw := previousSnapshotTickers(ctx, subscription.Library.Pool, table, etf.IndexName)
+	previous := make(map[string]indexMember, len(prevRaw))
+	for ticker, figi := range prevRaw {
+		previous[ticker] = indexMember{CompositeFigi: figi}
+	}
+
+	added, removed, _ := diffSnapshots(currentHoldings, previous)
 
 	eventDate := parseResult.SnapshotDate
 	if eventDate.IsZero() {
 		eventDate = time.Now().UTC().Truncate(24 * time.Hour)
 	}
 
-	emitChangelog(added, removed, etf.IndexName, eventDate, weightMap, &data.Observation{
+	emitChangelog(added, removed, etf.IndexName, eventDate, &data.Observation{
 		ObservationDate:  time.Now(),
 		SubscriptionID:   subscription.ID,
 		SubscriptionName: subscription.Name,
@@ -273,14 +279,14 @@ func downloadSingleISharesETF(
 			snapshotDate = time.Now().UTC().Truncate(24 * time.Hour)
 		}
 
-		for t, figi := range currentHoldings {
+		for t, member := range currentHoldings {
 			out <- &data.Observation{
 				IndexSnapshot: &data.IndexSnapshot{
 					Ticker:        t,
-					CompositeFigi: figi,
+					CompositeFigi: member.CompositeFigi,
 					IndexName:     etf.IndexName,
 					SnapshotDate:  snapshotDate,
-					Weight:        weightMap[t],
+					Weight:        member.Weight,
 				},
 				ObservationDate:  time.Now(),
 				SubscriptionID:   subscription.ID,

--- a/provider/ishares.go
+++ b/provider/ishares.go
@@ -203,104 +203,167 @@ func downloadSingleISharesETF(
 ) (int, error) {
 	logger := zerolog.Ctx(ctx)
 	numObs := 0
+	table := subscription.DataTablesMap[data.IndexKey]
 
-	// Download CSV holdings file
-	csvURL := fmt.Sprintf(iSharesHoldingsURLTemplate, etf.ProductID, etf.Slug, ticker)
-	logger.Info().Str("URL", csvURL).Str("IndexName", etf.IndexName).Msg("downloading iShares holdings CSV")
+	lookback := LookbackFromContext(ctx, 14*24*time.Hour)
 
-	resp, err := client.R().SetContext(ctx).Get(csvURL)
-	if err != nil {
-		return 0, fmt.Errorf("HTTP request failed for %s: %w", etf.IndexName, err)
+	// Build the list of dates to fetch.
+	// Always includes today (empty asOfDate = current data).
+	type fetchDate struct {
+		date     time.Time
+		asOfDate string // empty means "today / no asOfDate param"
 	}
 
-	if resp.StatusCode() != 200 {
-		return 0, fmt.Errorf("HTTP %d for %s", resp.StatusCode(), etf.IndexName)
-	}
+	var dates []fetchDate
 
-	csvData := resp.Body()
-	logger.Info().Int("Bytes", len(csvData)).Str("IndexName", etf.IndexName).Msg("downloaded iShares holdings CSV")
+	startDate := time.Now().Add(-lookback)
+	yesterday := time.Now().AddDate(0, 0, -1).Truncate(24 * time.Hour)
 
-	// Parse the CSV data
-	parseResult, err := parseISharesCSV(csvData)
-	if err != nil {
-		return 0, fmt.Errorf("could not parse iShares CSV for %s: %w", etf.IndexName, err)
-	}
-
-	if len(parseResult.Holdings) == 0 {
-		logger.Warn().Str("IndexName", etf.IndexName).Msg("no holdings found in downloaded file")
-		return 0, nil
-	}
-
-	logger.Info().
-		Int("NumHoldings", len(parseResult.Holdings)).
-		Time("SnapshotDate", parseResult.SnapshotDate).
-		Str("IndexName", etf.IndexName).
-		Msg("parsed iShares holdings")
-
-	// Build current holdings map (ticker -> indexMember)
-	currentHoldings := make(map[string]indexMember, len(parseResult.Holdings))
-	for _, holding := range parseResult.Holdings {
-		if figi, ok := figiMap[holding.Ticker]; ok {
-			currentHoldings[holding.Ticker] = indexMember{
-				CompositeFigi: figi,
-				Weight:        holding.Weight,
+	if startDate.Before(yesterday) {
+		days, err := tradingDays(ctx, subscription.Library.Pool, startDate, yesterday)
+		if err != nil {
+			logger.Warn().Err(err).Msg("could not query trading days, falling back to today only")
+		} else {
+			for _, d := range days {
+				dates = append(dates, fetchDate{
+					date:     d,
+					asOfDate: d.Format("20060102"),
+				})
 			}
 		}
 	}
 
-	// Get previous snapshot and emit changelog
-	table := subscription.DataTablesMap[data.IndexKey]
-	prevRaw := previousSnapshotTickers(ctx, subscription.Library.Pool, table, etf.IndexName)
-	previous := make(map[string]indexMember, len(prevRaw))
-	for ticker, figi := range prevRaw {
-		previous[ticker] = indexMember{CompositeFigi: figi}
-	}
+	// Always fetch today's data last (no asOfDate)
+	dates = append(dates, fetchDate{
+		date: time.Now().UTC().Truncate(24 * time.Hour),
+	})
 
-	added, removed, _ := diffSnapshots(currentHoldings, previous)
+	// Load initial state from DB: last snapshot + changelog entries up to start
+	state := currentIndexMembers(ctx, subscription.Library.Pool, table, etf.IndexName, startDate)
+	memLastSnapshotDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, etf.IndexName)
 
-	eventDate := parseResult.SnapshotDate
-	if eventDate.IsZero() {
-		eventDate = time.Now().UTC().Truncate(24 * time.Hour)
-	}
-
-	emitChangelog(added, removed, etf.IndexName, eventDate, &data.Observation{
+	obsTemplate := &data.Observation{
 		ObservationDate:  time.Now(),
 		SubscriptionID:   subscription.ID,
 		SubscriptionName: subscription.Name,
-	}, out)
-	numObs += len(added) + len(removed)
+	}
 
-	// Check if a snapshot should be taken
-	lastDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, etf.IndexName)
-	if shouldTakeSnapshot(lastDate, eventDate, snapshotFrequency) {
-
-		snapshotDate := parseResult.SnapshotDate
-		if snapshotDate.IsZero() {
-			snapshotDate = time.Now().UTC().Truncate(24 * time.Hour)
+	for i, fd := range dates {
+		// Build URL
+		csvURL := fmt.Sprintf(iSharesHoldingsURLTemplate, etf.ProductID, etf.Slug, ticker)
+		if fd.asOfDate != "" {
+			csvURL += "&asOfDate=" + fd.asOfDate
 		}
 
-		for t, member := range currentHoldings {
-			out <- &data.Observation{
-				IndexSnapshot: &data.IndexSnapshot{
-					Ticker:        t,
-					CompositeFigi: member.CompositeFigi,
-					IndexName:     etf.IndexName,
-					SnapshotDate:  snapshotDate,
-					Weight:        member.Weight,
-				},
-				ObservationDate:  time.Now(),
-				SubscriptionID:   subscription.ID,
-				SubscriptionName: subscription.Name,
-			}
+		logger.Info().Str("URL", csvURL).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("downloading iShares holdings CSV")
 
-			numObs++
+		resp, err := client.R().SetContext(ctx).Get(csvURL)
+		if err != nil {
+			logger.Error().Err(err).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("HTTP request failed")
+			continue
+		}
+
+		if resp.StatusCode() != 200 {
+			logger.Error().Int("StatusCode", resp.StatusCode()).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("HTTP error")
+			continue
+		}
+
+		csvData := resp.Body()
+		logger.Info().Int("Bytes", len(csvData)).Str("IndexName", etf.IndexName).Msg("downloaded iShares holdings CSV")
+
+		parseResult, err := parseISharesCSV(csvData)
+		if err != nil {
+			logger.Error().Err(err).Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("could not parse CSV")
+			continue
+		}
+
+		if len(parseResult.Holdings) == 0 {
+			logger.Warn().Str("IndexName", etf.IndexName).Time("Date", fd.date).Msg("no holdings found")
+			continue
 		}
 
 		logger.Info().
-			Int("NumSnapshots", len(currentHoldings)).
+			Int("NumHoldings", len(parseResult.Holdings)).
+			Time("SnapshotDate", parseResult.SnapshotDate).
 			Str("IndexName", etf.IndexName).
-			Time("SnapshotDate", snapshotDate).
-			Msg("emitted index snapshots")
+			Msg("parsed iShares holdings")
+
+		// Build current holdings map
+		currentHoldings := make(map[string]indexMember, len(parseResult.Holdings))
+
+		for _, holding := range parseResult.Holdings {
+			figi := figiMap[holding.Ticker]
+			if figi != "" {
+				currentHoldings[holding.Ticker] = indexMember{
+					CompositeFigi: figi,
+					Weight:        holding.Weight,
+				}
+			}
+		}
+
+		// Diff against in-memory state
+		added, removed, weightChanged := diffSnapshots(currentHoldings, state)
+
+		eventDate := parseResult.SnapshotDate
+		if eventDate.IsZero() {
+			eventDate = fd.date
+		}
+
+		// Emit changelog: adds and removes
+		emitChangelog(added, removed, etf.IndexName, eventDate, obsTemplate, out)
+		numObs += len(added) + len(removed)
+
+		// Emit weight changes
+		emitWeightChanges(weightChanged, etf.IndexName, eventDate, obsTemplate, out)
+		numObs += len(weightChanged)
+
+		// Check if snapshot is due
+		if shouldTakeSnapshot(memLastSnapshotDate, eventDate, snapshotFrequency) {
+			for t, member := range currentHoldings {
+				out <- &data.Observation{
+					IndexSnapshot: &data.IndexSnapshot{
+						Ticker:        t,
+						CompositeFigi: member.CompositeFigi,
+						IndexName:     etf.IndexName,
+						SnapshotDate:  eventDate,
+						Weight:        member.Weight,
+					},
+					ObservationDate:  obsTemplate.ObservationDate,
+					SubscriptionID:   obsTemplate.SubscriptionID,
+					SubscriptionName: obsTemplate.SubscriptionName,
+				}
+
+				numObs++
+			}
+
+			memLastSnapshotDate = eventDate
+
+			logger.Info().
+				Int("NumSnapshots", len(currentHoldings)).
+				Str("IndexName", etf.IndexName).
+				Time("SnapshotDate", eventDate).
+				Msg("emitted index snapshots")
+		}
+
+		// Update in-memory state
+		for t, m := range added {
+			state[t] = m
+		}
+
+		for t := range removed {
+			delete(state, t)
+		}
+
+		for t, m := range weightChanged {
+			state[t] = m
+		}
+
+		// Rate-limit delay between requests (skip after last)
+		if i < len(dates)-1 {
+			delay := 5*time.Second + time.Duration(rand.IntN(41))*time.Second
+			logger.Info().Dur("Delay", delay).Msg("waiting between iShares historical requests")
+			time.Sleep(delay)
+		}
 	}
 
 	return numObs, nil

--- a/provider/ishares.go
+++ b/provider/ishares.go
@@ -19,6 +19,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math/rand/v2"
 	"strings"
 	"time"
@@ -346,17 +347,13 @@ func downloadSingleISharesETF(
 		}
 
 		// Update in-memory state
-		for t, m := range added {
-			state[t] = m
-		}
+		maps.Copy(state, added)
 
 		for t := range removed {
 			delete(state, t)
 		}
 
-		for t, m := range weightChanged {
-			state[t] = m
-		}
+		maps.Copy(state, weightChanged)
 
 		// Rate-limit delay between requests (skip after last)
 		if i < len(dates)-1 {

--- a/provider/ishares.go
+++ b/provider/ishares.go
@@ -272,7 +272,7 @@ func downloadSingleISharesETF(
 
 	// Check if a snapshot should be taken
 	lastDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, etf.IndexName)
-	if shouldTakeSnapshot(lastDate, snapshotFrequency) {
+	if shouldTakeSnapshot(lastDate, eventDate, snapshotFrequency) {
 
 		snapshotDate := parseResult.SnapshotDate
 		if snapshotDate.IsZero() {

--- a/provider/ishares_embed_test.go
+++ b/provider/ishares_embed_test.go
@@ -15,16 +15,9 @@
 package provider
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-func TestISharesEmbed(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "iShares Embed Suite")
-}
 
 var _ = Describe("iSharesETFMap", func() {
 	It("is populated with entries from the embedded JSON", func() {

--- a/provider/ishares_parser.go
+++ b/provider/ishares_parser.go
@@ -44,14 +44,17 @@ func parseISharesCSV(csvData []byte) (*iSharesParseResult, error) {
 
 	// Read all records
 	var records [][]string
+
 	for {
 		record, err := reader.Read()
 		if err == io.EOF {
 			break
 		}
+
 		if err != nil {
 			return nil, err
 		}
+
 		records = append(records, record)
 	}
 
@@ -62,12 +65,14 @@ func parseISharesCSV(csvData []byte) (*iSharesParseResult, error) {
 			if t, err := time.Parse("Jan 02, 2006", dateStr); err == nil {
 				result.SnapshotDate = t
 			}
+
 			break
 		}
 	}
 
 	// Find the header row (starts with "Ticker")
 	headerIdx := -1
+
 	for i, record := range records {
 		if len(record) > 0 && strings.TrimSpace(record[0]) == "Ticker" {
 			headerIdx = i
@@ -106,6 +111,7 @@ func parseISharesCSV(csvData []byte) (*iSharesParseResult, error) {
 		}
 
 		weightStr := strings.ReplaceAll(record[weightCol], ",", "")
+
 		weightPct, err := strconv.ParseFloat(strings.TrimSpace(weightStr), 64)
 		if err != nil {
 			continue

--- a/provider/nasdaq.go
+++ b/provider/nasdaq.go
@@ -219,7 +219,7 @@ func downloadNasdaqHoldings(ctx context.Context, subscription *library.Subscript
 
 	// Check if a snapshot should be taken
 	lastDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, "ndx100")
-	if shouldTakeSnapshot(lastDate, snapshotFrequency) {
+	if shouldTakeSnapshot(lastDate, eventDate, snapshotFrequency) {
 		snapshotDate := time.Now().UTC().Truncate(24 * time.Hour)
 
 		for ticker, member := range currentHoldings {

--- a/provider/nasdaq.go
+++ b/provider/nasdaq.go
@@ -201,6 +201,7 @@ func downloadNasdaqHoldings(ctx context.Context, subscription *library.Subscript
 	// Get previous snapshot and emit changelog
 	table := subscription.DataTablesMap[data.IndexKey]
 	prevRaw := previousSnapshotTickers(ctx, subscription.Library.Pool, table, "ndx100")
+
 	previous := make(map[string]indexMember, len(prevRaw))
 	for ticker, figi := range prevRaw {
 		previous[ticker] = indexMember{CompositeFigi: figi}

--- a/provider/nasdaq.go
+++ b/provider/nasdaq.go
@@ -187,22 +187,30 @@ func downloadNasdaqHoldings(ctx context.Context, subscription *library.Subscript
 
 	logger.Info().Int("NumHoldings", len(holdings)).Msg("parsed NDX-100 holdings")
 
-	// Build current holdings map (ticker -> figi)
-	currentHoldings := make(map[string]string, len(holdings))
+	// Build current holdings map (ticker -> indexMember)
+	currentHoldings := make(map[string]indexMember, len(holdings))
 	for _, holding := range holdings {
 		if figi, ok := figiMap[holding.Ticker]; ok {
-			currentHoldings[holding.Ticker] = figi
+			currentHoldings[holding.Ticker] = indexMember{
+				CompositeFigi: figi,
+				Weight:        holding.Weight,
+			}
 		}
 	}
 
 	// Get previous snapshot and emit changelog
 	table := subscription.DataTablesMap[data.IndexKey]
-	previous := previousSnapshotTickers(ctx, subscription.Library.Pool, table, "ndx100")
-	added, removed := diffSnapshots(currentHoldings, previous)
+	prevRaw := previousSnapshotTickers(ctx, subscription.Library.Pool, table, "ndx100")
+	previous := make(map[string]indexMember, len(prevRaw))
+	for ticker, figi := range prevRaw {
+		previous[ticker] = indexMember{CompositeFigi: figi}
+	}
+
+	added, removed, _ := diffSnapshots(currentHoldings, previous)
 
 	eventDate := time.Now().UTC().Truncate(24 * time.Hour)
 
-	emitChangelog(added, removed, "ndx100", eventDate, nil, &data.Observation{
+	emitChangelog(added, removed, "ndx100", eventDate, &data.Observation{
 		ObservationDate:  time.Now(),
 		SubscriptionID:   subscription.ID,
 		SubscriptionName: subscription.Name,
@@ -212,22 +220,16 @@ func downloadNasdaqHoldings(ctx context.Context, subscription *library.Subscript
 	// Check if a snapshot should be taken
 	lastDate := lastSnapshotDate(ctx, subscription.Library.Pool, table, "ndx100")
 	if shouldTakeSnapshot(lastDate, snapshotFrequency) {
-		// Build a weight map for quick lookup
-		weightMap := make(map[string]float64, len(holdings))
-		for _, holding := range holdings {
-			weightMap[holding.Ticker] = holding.Weight
-		}
-
 		snapshotDate := time.Now().UTC().Truncate(24 * time.Hour)
 
-		for ticker, figi := range currentHoldings {
+		for ticker, member := range currentHoldings {
 			out <- &data.Observation{
 				IndexSnapshot: &data.IndexSnapshot{
 					Ticker:        ticker,
-					CompositeFigi: figi,
+					CompositeFigi: member.CompositeFigi,
 					IndexName:     "ndx100",
 					SnapshotDate:  snapshotDate,
-					Weight:        weightMap[ticker],
+					Weight:        member.Weight,
 				},
 				ObservationDate:  time.Now(),
 				SubscriptionID:   subscription.ID,

--- a/provider/provider_suite_test.go
+++ b/provider/provider_suite_test.go
@@ -1,0 +1,13 @@
+package provider
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Provider Suite")
+}

--- a/provider/provider_suite_test.go
+++ b/provider/provider_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package provider
 
 import (

--- a/provider/sharadar_import.go
+++ b/provider/sharadar_import.go
@@ -84,6 +84,7 @@ func detectFileFormat(path string) (fileFormat, error) {
 // are normalized to lowercase. Each subsequent row is returned as a map[string]string.
 func parseCSV(r io.Reader) ([]map[string]string, error) {
 	cr := csv.NewReader(r)
+
 	headers, err := cr.Read()
 	if err != nil {
 		return nil, fmt.Errorf("read CSV headers: %w", err)
@@ -94,11 +95,13 @@ func parseCSV(r io.Reader) ([]map[string]string, error) {
 	}
 
 	var rows []map[string]string
+
 	for {
 		record, err := cr.Read()
 		if err == io.EOF {
 			break
 		}
+
 		if err != nil {
 			return nil, fmt.Errorf("read CSV row: %w", err)
 		}
@@ -109,6 +112,7 @@ func parseCSV(r io.Reader) ([]map[string]string, error) {
 				row[h] = record[i]
 			}
 		}
+
 		rows = append(rows, row)
 	}
 
@@ -158,6 +162,7 @@ func readCSVZipRows(path string) ([]map[string]string, error) {
 				return nil, fmt.Errorf("open CSV entry %s in ZIP %s: %w", f.Name, path, err)
 			}
 			defer rc.Close()
+
 			return parseCSV(rc)
 		}
 	}
@@ -189,28 +194,36 @@ func readParquetRows(path string) ([]map[string]string, error) {
 		if readCount > numRows {
 			readCount = numRows
 		}
+
 		batch, err := pr.ReadByNumber(readCount)
 		if err != nil {
 			return nil, fmt.Errorf("read parquet rows: %w", err)
 		}
+
 		for _, rawRow := range batch {
 			val := reflect.ValueOf(rawRow)
 			if val.Kind() == reflect.Ptr {
 				val = val.Elem()
 			}
+
 			if val.Kind() != reflect.Struct {
 				continue
 			}
+
 			typ := val.Type()
+
 			row := make(map[string]string, typ.NumField())
 			for j := 0; j < typ.NumField(); j++ {
 				name := strings.ToLower(typ.Field(j).Name)
 				row[name] = fmt.Sprintf("%v", val.Field(j).Interface())
 			}
+
 			rows = append(rows, row)
 		}
+
 		numRows -= readCount
 	}
+
 	return rows, nil
 }
 
@@ -241,7 +254,9 @@ func parseFloat(s string) float64 {
 	if s == "" || s == "<nil>" || s == "None" {
 		return 0
 	}
+
 	v, _ := strconv.ParseFloat(s, 64)
+
 	return v
 }
 
@@ -252,10 +267,12 @@ func parseInt(s string) int64 {
 	if s == "" || s == "<nil>" || s == "None" {
 		return 0
 	}
+
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return 0
 	}
+
 	return int64(f)
 }
 
@@ -462,10 +479,12 @@ func (sharadar *Sharadar) ImportFiles(ctx context.Context, sub *library.Subscrip
 
 	defer func() {
 		runSummary.EndTime = time.Now()
+
 		runSummary.NumObservations = numObs
 		if runSummary.Status != data.RunFailed {
 			runSummary.Status = data.RunSuccess
 		}
+
 		exit <- runSummary
 	}()
 
@@ -475,13 +494,16 @@ func (sharadar *Sharadar) ImportFiles(ctx context.Context, sub *library.Subscrip
 		rows, err := readFileRows(filePath)
 		if err != nil {
 			logger.Error().Err(err).Str("file", filePath).Msg("failed to read file")
+
 			runSummary.Status = data.RunFailed
+
 			return
 		}
 
 		logger.Info().Int("rows", len(rows)).Str("file", filePath).Msg("file loaded")
 
 		var n int
+
 		switch sub.Dataset {
 		case "Fundamentals":
 			n, err = importFundamentalsRows(ctx, sub, rows, out)
@@ -495,7 +517,9 @@ func (sharadar *Sharadar) ImportFiles(ctx context.Context, sub *library.Subscrip
 
 		if err != nil {
 			logger.Error().Err(err).Str("file", filePath).Msg("failed to import file")
+
 			runSummary.Status = data.RunFailed
+
 			return
 		}
 
@@ -525,6 +549,7 @@ func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows
 	}
 
 	count := 0
+
 	for i, row := range rows {
 		fundamental := mapRowToSharadarFundamental(row)
 		pvFundamental := fundamental.PvFundamental(figiMap)
@@ -572,6 +597,7 @@ func importMetricsRows(ctx context.Context, sub *library.Subscription, rows []ma
 	}
 
 	count := 0
+
 	for i, row := range rows {
 		metric := mapRowToSharadarMetric(row)
 		pvMetric := metric.PvMetric(figiMap, nyc)
@@ -644,6 +670,7 @@ func importTickersRows(ctx context.Context, sub *library.Subscription, rows []ma
 	}
 
 	count := 0
+
 	for _, asset := range allAssets {
 		out <- &data.Observation{
 			AssetObject:      asset,
@@ -651,6 +678,7 @@ func importTickersRows(ctx context.Context, sub *library.Subscription, rows []ma
 			SubscriptionID:   sub.ID,
 			SubscriptionName: sub.Name,
 		}
+
 		count++
 	}
 


### PR DESCRIPTION
## Summary

- Add `--lookback` support to the iShares index provider, matching the EOD provider's mechanism. Historical holdings are fetched via the `asOfDate` CSV parameter for each NYSE trading day in the lookback window.
- Introduce `indexMember` type carrying FIGI + weight, enabling weight-change detection (>= 0.01 absolute threshold) alongside existing add/remove tracking in the changelog.
- Add `currentIndexMembers` helper that reconstructs true index state from the last snapshot plus subsequent changelog entries, fixing a bug where `previousSnapshotTickers` ignored post-snapshot changes.
- Update `shouldTakeSnapshot` to accept a reference date instead of using wall-clock time, enabling correct snapshot gating during historical backfill.
- Fix duplicate Ginkgo `RunSpecs` in the provider package that caused "Rerunning Suite" errors.

## Test plan

- [ ] Verify `ginkgo run -race ./...` passes (61 provider specs, 8 library specs)
- [ ] Verify `golangci-lint run ./...` reports 0 issues
- [ ] Test backfill with `pvdata run --lookback 30d` against an iShares subscription
- [ ] Verify changelog entries include adds, removes, and weight-changes
- [ ] Verify snapshots are taken at the configured `snapshotFrequency` interval
- [ ] Verify the provider still works without `--lookback` (default 14d behavior)