### PR TITLE
Stream file imports instead of loading into memory

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,14 +48,15 @@ linters:
       - legacy
 
     # Excluding configuration per-path, per-linter, per-text and per-source.
-    #rules:
-    #  # Exclude some linters from running on tests files.
-    #  - path: _test\.go
-    #    linters:
-    #      - gocyclo
-    #      - errcheck
-    #      - dupl
-    #      - gosec
+    rules:
+      # Streaming helpers added alongside existing batch readers; callers will
+      # be wired up in subsequent tasks.
+      - linters:
+          - unused
+        text: "func stream(CSV|CSVRows|CSVZstRows|CSVZipRows|ParquetRows|FileRows) is unused"
+      - linters:
+          - unused
+        text: "const rowChannelBuffer is unused"
 
 
 formatters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,16 +48,7 @@ linters:
       - legacy
 
     # Excluding configuration per-path, per-linter, per-text and per-source.
-    rules:
-      # Streaming helpers added alongside existing batch readers; callers will
-      # be wired up in subsequent tasks.
-      - linters:
-          - unused
-        text: "func stream(CSV|CSVRows|CSVZstRows|CSVZipRows|ParquetRows|FileRows) is unused"
-      - linters:
-          - unused
-        text: "const rowChannelBuffer is unused"
-
+    rules: []
 
 formatters:
   # Enable specific formatter.

--- a/docs/superpowers/plans/2026-04-06-streaming-file-import.md
+++ b/docs/superpowers/plans/2026-04-06-streaming-file-import.md
@@ -1,0 +1,950 @@
+# Streaming File Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor Sharadar file import to stream rows through a channel instead of loading entire files into memory, reducing memory from O(all rows) to O(buffer size) for 36M+ row files.
+
+**Architecture:** Replace `readFileRows` (returns `[]map[string]string`) with `streamFileRows` (returns `<-chan RowResult`). Reader goroutines send rows as they're read; consumers range over the channel. Parquet reads in 10k batches, CSV reads line-by-line. SP500 and Tickers imports (small files) collect rows locally from the channel since they need multi-pass logic.
+
+**Tech Stack:** Go, parquet-go (xitongsys), encoding/csv, zstd, archive/zip
+
+---
+
+### Task 1: Add RowResult Type and streamCSV
+
+**Files:**
+- Modify: `provider/sharadar/sharadar_import.go:225-262`
+
+- [ ] **Step 1: Write failing test for streamCSV**
+
+Add to `provider/sharadar/sharadar_import_test.go`:
+
+```go
+var _ = Describe("streamCSV", func() {
+	It("streams CSV rows with lowercase headers", func() {
+		csvData := "Ticker,Date,Value\nAAPL,2023-01-01,150.00\nMSFT,2023-01-02,250.00\n"
+		r := strings.NewReader(csvData)
+		ch := make(chan RowResult, 10)
+
+		ctx := context.Background()
+		go streamCSV(ctx, r, ch)
+
+		var rows []map[string]string
+		for rr := range ch {
+			Expect(rr.Err).NotTo(HaveOccurred())
+			rows = append(rows, rr.Row)
+		}
+
+		Expect(rows).To(HaveLen(2))
+		Expect(rows[0]["ticker"]).To(Equal("AAPL"))
+		Expect(rows[0]["date"]).To(Equal("2023-01-01"))
+		Expect(rows[1]["ticker"]).To(Equal("MSFT"))
+	})
+
+	It("streams empty result for headers-only CSV", func() {
+		r := strings.NewReader("Ticker,Date\n")
+		ch := make(chan RowResult, 10)
+
+		ctx := context.Background()
+		go streamCSV(ctx, r, ch)
+
+		var rows []map[string]string
+		for rr := range ch {
+			Expect(rr.Err).NotTo(HaveOccurred())
+			rows = append(rows, rr.Row)
+		}
+
+		Expect(rows).To(BeEmpty())
+	})
+
+	It("sends error on malformed CSV", func() {
+		r := strings.NewReader("Ticker,Date\n\"unclosed quote")
+		ch := make(chan RowResult, 10)
+
+		ctx := context.Background()
+		go streamCSV(ctx, r, ch)
+
+		var gotErr bool
+		for rr := range ch {
+			if rr.Err != nil {
+				gotErr = true
+			}
+		}
+
+		Expect(gotErr).To(BeTrue())
+	})
+
+	It("stops when context is cancelled", func() {
+		// Create CSV with many rows
+		var b strings.Builder
+		b.WriteString("Ticker\n")
+		for i := 0; i < 1000; i++ {
+			b.WriteString("AAPL\n")
+		}
+
+		r := strings.NewReader(b.String())
+		ch := make(chan RowResult) // unbuffered to force blocking
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go streamCSV(ctx, r, ch)
+
+		// Read one row then cancel
+		rr := <-ch
+		Expect(rr.Err).NotTo(HaveOccurred())
+		cancel()
+
+		// Drain remaining (should stop quickly)
+		count := 1
+		for range ch {
+			count++
+		}
+
+		// Should have stopped well before 1000
+		Expect(count).To(BeNumerically("<", 1000))
+	})
+})
+```
+
+Add imports at top of test file: `"context"`, `"strings"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "streamCSV" ./provider/sharadar/`
+Expected: FAIL (RowResult and streamCSV undefined)
+
+- [ ] **Step 3: Implement RowResult and streamCSV**
+
+Add the `RowResult` type near the top of `provider/sharadar/sharadar_import.go` (after the imports, before `parseCSV`):
+
+```go
+// RowResult carries a single row or an error from a streaming file reader.
+type RowResult struct {
+	Row map[string]string
+	Err error
+}
+```
+
+Add `streamCSV` below the existing `parseCSV` function (keep `parseCSV` for now -- it will be removed in a later task):
+
+```go
+// streamCSV reads CSV data from r and sends each row to out as a map[string]string.
+// Header names are normalized to lowercase. The channel is closed when reading
+// completes or the context is cancelled.
+func streamCSV(ctx context.Context, r io.Reader, out chan<- RowResult) {
+	defer close(out)
+
+	cr := csv.NewReader(r)
+
+	headers, err := cr.Read()
+	if err != nil {
+		select {
+		case out <- RowResult{Err: fmt.Errorf("read CSV headers: %w", err)}:
+		case <-ctx.Done():
+		}
+
+		return
+	}
+
+	for i, h := range headers {
+		headers[i] = strings.ToLower(strings.TrimSpace(h))
+	}
+
+	for {
+		record, err := cr.Read()
+		if err == io.EOF {
+			return
+		}
+
+		if err != nil {
+			select {
+			case out <- RowResult{Err: fmt.Errorf("read CSV row: %w", err)}:
+			case <-ctx.Done():
+			}
+
+			return
+		}
+
+		row := make(map[string]string, len(headers))
+		for i, h := range headers {
+			if i < len(record) {
+				row[h] = record[i]
+			}
+		}
+
+		select {
+		case out <- RowResult{Row: row}:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "streamCSV" ./provider/sharadar/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/sharadar/sharadar_import.go provider/sharadar/sharadar_import_test.go
+git commit -m "feat: add RowResult type and streamCSV for streaming file reads"
+```
+
+---
+
+### Task 2: Add streamParquetRows
+
+**Files:**
+- Modify: `provider/sharadar/sharadar_import.go`
+- Modify: `provider/sharadar/sharadar_import_test.go`
+
+- [ ] **Step 1: Write test for streamParquetRows**
+
+Add to `provider/sharadar/sharadar_import_test.go`, replacing the existing `readParquetRows` tests:
+
+```go
+var _ = Describe("streamParquetRows", func() {
+	It("streams parquet rows if test file exists", func() {
+		parquetPath := "../../data/sharadar/sharadar_metrics_20231228.parquet"
+		if _, err := os.Stat(parquetPath); os.IsNotExist(err) {
+			Skip("test parquet file not available")
+		}
+
+		ch := make(chan RowResult, 100)
+		ctx := context.Background()
+
+		go streamParquetRows(ctx, parquetPath, ch)
+
+		var rows []map[string]string
+		for rr := range ch {
+			Expect(rr.Err).NotTo(HaveOccurred())
+			rows = append(rows, rr.Row)
+		}
+
+		Expect(rows).NotTo(BeEmpty())
+		Expect(rows[0]).To(HaveKey("ticker"))
+	})
+
+	It("streams SP500 parquet rows if test file exists", func() {
+		parquetPath := "../../data/sharadar/sharadar_sp500_20231228.parquet"
+		if _, err := os.Stat(parquetPath); os.IsNotExist(err) {
+			Skip("test parquet file not available")
+		}
+
+		ch := make(chan RowResult, 100)
+		ctx := context.Background()
+
+		go streamParquetRows(ctx, parquetPath, ch)
+
+		var rows []map[string]string
+		for rr := range ch {
+			Expect(rr.Err).NotTo(HaveOccurred())
+			rows = append(rows, rr.Row)
+		}
+
+		Expect(rows).NotTo(BeEmpty())
+		Expect(rows[0]).To(HaveKey("ticker"))
+		Expect(rows[0]).To(HaveKey("action"))
+	})
+})
+```
+
+- [ ] **Step 2: Implement streamParquetRows**
+
+Add below `streamCSV` in `sharadar_import.go`:
+
+```go
+// streamParquetRows reads a parquet file and sends each row to out as a
+// map[string]string. Column names are normalized to lowercase. Reads in
+// batches of 10,000 internally but sends one row at a time.
+func streamParquetRows(ctx context.Context, path string, out chan<- RowResult) {
+	defer close(out)
+
+	fr, err := local.NewLocalFileReader(path)
+	if err != nil {
+		select {
+		case out <- RowResult{Err: fmt.Errorf("open parquet %s: %w", path, err)}:
+		case <-ctx.Done():
+		}
+
+		return
+	}
+	defer fr.Close()
+
+	pr, err := reader.NewParquetReader(fr, nil, 4)
+	if err != nil {
+		select {
+		case out <- RowResult{Err: fmt.Errorf("create parquet reader for %s: %w", path, err)}:
+		case <-ctx.Done():
+		}
+
+		return
+	}
+	defer pr.ReadStop()
+
+	numRows := int(pr.GetNumRows())
+	batchSize := 10000
+
+	for numRows > 0 {
+		readCount := batchSize
+		if readCount > numRows {
+			readCount = numRows
+		}
+
+		batch, err := pr.ReadByNumber(readCount)
+		if err != nil {
+			select {
+			case out <- RowResult{Err: fmt.Errorf("read parquet rows: %w", err)}:
+			case <-ctx.Done():
+			}
+
+			return
+		}
+
+		for _, rawRow := range batch {
+			val := reflect.ValueOf(rawRow)
+			if val.Kind() == reflect.Ptr {
+				val = val.Elem()
+			}
+
+			if val.Kind() != reflect.Struct {
+				continue
+			}
+
+			typ := val.Type()
+
+			row := make(map[string]string, typ.NumField())
+			for j := 0; j < typ.NumField(); j++ {
+				name := strings.ToLower(typ.Field(j).Name)
+				field := val.Field(j)
+
+				if field.Kind() == reflect.Ptr {
+					if field.IsNil() {
+						row[name] = ""
+
+						continue
+					}
+
+					field = field.Elem()
+				}
+
+				row[name] = fmt.Sprintf("%v", field.Interface())
+			}
+
+			select {
+			case out <- RowResult{Row: row}:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		numRows -= readCount
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "streamParquetRows" ./provider/sharadar/`
+Expected: PASS (or Skip if test files not available)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add provider/sharadar/sharadar_import.go provider/sharadar/sharadar_import_test.go
+git commit -m "feat: add streamParquetRows for streaming parquet reads"
+```
+
+---
+
+### Task 3: Add streamFileRows and CSV Variant Streamers
+
+**Files:**
+- Modify: `provider/sharadar/sharadar_import.go`
+- Modify: `provider/sharadar/sharadar_import_test.go`
+
+- [ ] **Step 1: Write test for streamFileRows with CSV**
+
+Add to test file:
+
+```go
+var _ = Describe("streamFileRows", func() {
+	It("streams rows from a plain CSV file", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "test.csv")
+
+		content := "Ticker,Date,Value\nAAPL,2023-01-01,150.00\nMSFT,2023-01-02,250.00\n"
+		Expect(os.WriteFile(path, []byte(content), 0600)).To(Succeed())
+
+		ctx := context.Background()
+		ch := streamFileRows(ctx, path)
+
+		var rows []map[string]string
+		for rr := range ch {
+			Expect(rr.Err).NotTo(HaveOccurred())
+			rows = append(rows, rr.Row)
+		}
+
+		Expect(rows).To(HaveLen(2))
+		Expect(rows[0]["ticker"]).To(Equal("AAPL"))
+		Expect(rows[1]["ticker"]).To(Equal("MSFT"))
+	})
+
+	It("sends error for unsupported format", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "test.xlsx")
+		Expect(os.WriteFile(path, []byte("data"), 0600)).To(Succeed())
+
+		ctx := context.Background()
+		ch := streamFileRows(ctx, path)
+
+		rr := <-ch
+		Expect(rr.Err).To(HaveOccurred())
+	})
+})
+```
+
+- [ ] **Step 2: Implement streamFileRows and CSV variant streamers**
+
+Add to `sharadar_import.go`:
+
+```go
+// streamCSVRows opens a plain CSV file and streams its rows.
+func streamCSVRows(ctx context.Context, path string, out chan<- RowResult) {
+	f, err := os.Open(path)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("open CSV %s: %w", path, err)}
+		close(out)
+
+		return
+	}
+	defer f.Close()
+
+	streamCSV(ctx, f, out)
+}
+
+// streamCSVZstRows opens a zstd-compressed CSV file and streams its rows.
+func streamCSVZstRows(ctx context.Context, path string, out chan<- RowResult) {
+	f, err := os.Open(path)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("open CSV.zst %s: %w", path, err)}
+		close(out)
+
+		return
+	}
+	defer f.Close()
+
+	zr, err := zstd.NewReader(f)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("create zstd reader for %s: %w", path, err)}
+		close(out)
+
+		return
+	}
+	defer zr.Close()
+
+	streamCSV(ctx, zr, out)
+}
+
+// streamCSVZipRows opens a zip archive and streams rows from the first CSV entry.
+func streamCSVZipRows(ctx context.Context, path string, out chan<- RowResult) {
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("open ZIP %s: %w", path, err)}
+		close(out)
+
+		return
+	}
+	defer zr.Close()
+
+	for _, f := range zr.File {
+		if strings.HasSuffix(strings.ToLower(f.Name), ".csv") {
+			rc, err := f.Open()
+			if err != nil {
+				out <- RowResult{Err: fmt.Errorf("open CSV entry %s in ZIP %s: %w", f.Name, path, err)}
+				close(out)
+
+				return
+			}
+			defer rc.Close()
+
+			streamCSV(ctx, rc, out)
+
+			return
+		}
+	}
+
+	out <- RowResult{Err: fmt.Errorf("no CSV entry found in ZIP %s", path)}
+	close(out)
+}
+
+const rowChannelBuffer = 10000
+
+// streamFileRows detects the file format and returns a channel that yields rows
+// as they are read. The channel is closed when reading completes or on error.
+func streamFileRows(ctx context.Context, path string) <-chan RowResult {
+	ch := make(chan RowResult, rowChannelBuffer)
+
+	format, err := detectFileFormat(path)
+	if err != nil {
+		go func() {
+			ch <- RowResult{Err: err}
+			close(ch)
+		}()
+
+		return ch
+	}
+
+	switch format {
+	case fileFormatParquet:
+		go streamParquetRows(ctx, path, ch)
+	case fileFormatCSV:
+		go streamCSVRows(ctx, path, ch)
+	case fileFormatCSVZst:
+		go streamCSVZstRows(ctx, path, ch)
+	case fileFormatCSVZip:
+		go streamCSVZipRows(ctx, path, ch)
+	default:
+		go func() {
+			ch <- RowResult{Err: fmt.Errorf("unsupported file format for %q", path)}
+			close(ch)
+		}()
+	}
+
+	return ch
+}
+```
+
+Note: `streamCSVRows`, `streamCSVZstRows`, and `streamCSVZipRows` do NOT call `defer close(out)` themselves -- `streamCSV` handles closing the channel. They only close + send error on the early-return paths before `streamCSV` is called.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "streamFileRows" ./provider/sharadar/`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add provider/sharadar/sharadar_import.go provider/sharadar/sharadar_import_test.go
+git commit -m "feat: add streamFileRows with CSV variant streamers"
+```
+
+---
+
+### Task 4: Convert Import Functions to Channel Consumers
+
+**Files:**
+- Modify: `provider/sharadar/sharadar_import.go:688-777` (importFundamentalsRows, importMetricsRows)
+
+- [ ] **Step 1: Convert importFundamentalsRows**
+
+Change the signature and body of `importFundamentalsRows` from:
+
+```go
+func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows []map[string]string, out chan<- *data.Observation) (int, error) {
+```
+
+To:
+
+```go
+func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
+	logger := zerolog.Ctx(ctx)
+
+	conn, err := sub.Library.Pool.Acquire(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("could not acquire database connection: %w", err)
+	}
+	defer conn.Release()
+
+	assets, err := data.ActiveAssets(ctx, conn)
+	if err != nil {
+		return 0, fmt.Errorf("could not load active assets: %w", err)
+	}
+
+	figiMap := make(map[string]string, len(assets))
+	for _, asset := range assets {
+		figiMap[asset.Ticker] = asset.CompositeFigi
+	}
+
+	count := 0
+
+	for rr := range rows {
+		if rr.Err != nil {
+			return count, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		fundamental := mapRowToSharadarFundamental(rr.Row)
+		pvFundamental := fundamental.PvFundamental(figiMap)
+
+		out <- &data.Observation{
+			Fundamental:      pvFundamental,
+			ObservationDate:  time.Now(),
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		count++
+
+		if count%10000 == 0 {
+			logger.Info().Int("rows_processed", count).Msg("fundamentals import progress")
+		}
+	}
+
+	return count, nil
+}
+```
+
+- [ ] **Step 2: Convert importMetricsRows**
+
+Change the signature and body of `importMetricsRows` from:
+
+```go
+func importMetricsRows(ctx context.Context, sub *library.Subscription, rows []map[string]string, out chan<- *data.Observation) (int, error) {
+```
+
+To:
+
+```go
+func importMetricsRows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
+	logger := zerolog.Ctx(ctx)
+
+	conn, err := sub.Library.Pool.Acquire(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("could not acquire database connection: %w", err)
+	}
+	defer conn.Release()
+
+	assets, err := data.ActiveAssets(ctx, conn)
+	if err != nil {
+		return 0, fmt.Errorf("could not load active assets: %w", err)
+	}
+
+	figiMap := make(map[string]string, len(assets))
+	for _, asset := range assets {
+		figiMap[asset.Ticker] = asset.CompositeFigi
+	}
+
+	nyc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		return 0, fmt.Errorf("could not load NYC timezone: %w", err)
+	}
+
+	count := 0
+
+	for rr := range rows {
+		if rr.Err != nil {
+			return count, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		metric := mapRowToSharadarMetric(rr.Row)
+		pvMetric := metric.PvMetric(figiMap, nyc)
+
+		out <- &data.Observation{
+			Metric:           pvMetric,
+			ObservationDate:  time.Now(),
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		count++
+
+		if count%10000 == 0 {
+			logger.Info().Int("rows_processed", count).Msg("metrics import progress")
+		}
+	}
+
+	return count, nil
+}
+```
+
+- [ ] **Step 3: Convert importTickersRows**
+
+Change `importTickersRows` signature to accept `<-chan RowResult`. Since it needs multi-pass logic (FIGI enrichment batching then emission), drain the channel into a local slice. Tickers files are small (thousands of rows).
+
+```go
+func importTickersRows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
+	logger := zerolog.Ctx(ctx)
+
+	// Drain channel into slice -- tickers files are small (thousands of rows)
+	var rowSlice []map[string]string
+
+	for rr := range rows {
+		if rr.Err != nil {
+			return 0, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		rowSlice = append(rowSlice, rr.Row)
+	}
+
+	enrichAssets := make([]*data.Asset, 0, 5000)
+	allAssets := make([]*data.Asset, 0, len(rowSlice))
+
+	for _, row := range rowSlice {
+		if row["table"] != "SF1" {
+			continue
+		}
+
+		ticker := mapRowToSharadarTicker(row)
+
+		if ticker.Exchange == "" {
+			continue
+		}
+
+		pvAsset := ticker.ToAsset()
+
+		if pvAsset.PrimaryExchange == data.OTCExchange ||
+			pvAsset.PrimaryExchange == data.IndexExchange ||
+			pvAsset.PrimaryExchange == data.UnknownExchange ||
+			pvAsset.AssetType == data.INDEX ||
+			pvAsset.AssetType == data.UnknownAsset {
+			continue
+		}
+
+		if pvAsset.Active {
+			enrichAssets = append(enrichAssets, pvAsset)
+		}
+
+		allAssets = append(allAssets, pvAsset)
+
+		if len(enrichAssets) >= 5000 {
+			log.Info().Int("batch_size", len(enrichAssets)).Msg("enriching asset batch with FIGI")
+			figi.Enrich(enrichAssets...)
+			enrichAssets = enrichAssets[:0]
+		}
+	}
+
+	if len(enrichAssets) > 0 {
+		log.Info().Int("batch_size", len(enrichAssets)).Msg("enriching final asset batch with FIGI")
+		figi.Enrich(enrichAssets...)
+	}
+
+	count := 0
+
+	for _, asset := range allAssets {
+		out <- &data.Observation{
+			AssetObject:      asset,
+			ObservationDate:  time.Now(),
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		count++
+	}
+
+	logger.Info().Int("assets", count).Msg("tickers import complete")
+
+	return count, nil
+}
+```
+
+- [ ] **Step 4: Convert importSP500Rows**
+
+Same approach -- drain channel into slice since SP500 files are small and the function needs multi-pass logic:
+
+Change signature from `rows []map[string]string` to `rows <-chan RowResult`. Add drain at the beginning:
+
+```go
+func importSP500Rows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
+	logger := zerolog.Ctx(ctx)
+
+	// Drain channel into slice -- SP500 files are small
+	var rowSlice []map[string]string
+
+	for rr := range rows {
+		if rr.Err != nil {
+			return 0, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		rowSlice = append(rowSlice, rr.Row)
+	}
+
+	// ... rest of function unchanged but uses rowSlice instead of rows ...
+```
+
+Replace all references to `rows` with `rowSlice` in the rest of the function body (the 4 `for _, row := range rows` loops become `for _, row := range rowSlice`). The `len(rows)` call in `allAssets := make([]*data.Asset, 0, len(rows))` if present becomes `len(rowSlice)`.
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && go build ./...`
+Expected: FAIL -- `ImportFiles` still calls `readFileRows` which returns `[]map[string]string`, and the import functions now expect channels. This will be fixed in the next task.
+
+- [ ] **Step 6: Commit (work in progress)**
+
+Don't commit yet -- proceed to Task 5 to update ImportFiles so the build succeeds.
+
+---
+
+### Task 5: Update ImportFiles Orchestrator and Remove Old Functions
+
+**Files:**
+- Modify: `provider/sharadar/sharadar_import.go:622-686` (ImportFiles)
+
+- [ ] **Step 1: Update ImportFiles to use streamFileRows**
+
+Replace the body of the `for _, filePath := range files` loop in `ImportFiles`:
+
+From:
+```go
+		logger.Info().Str("file", filePath).Msg("reading file")
+
+		rows, err := readFileRows(filePath)
+		if err != nil {
+			logger.Error().Err(err).Str("file", filePath).Msg("failed to read file")
+
+			runSummary.Status = data.RunFailed
+
+			return
+		}
+
+		logger.Info().Int("rows", len(rows)).Str("file", filePath).Msg("file loaded")
+
+		var n int
+
+		switch sub.Dataset {
+		case "Fundamentals":
+			n, err = importFundamentalsRows(ctx, sub, rows, out)
+		case "Metrics":
+			n, err = importMetricsRows(ctx, sub, rows, out)
+		case "Stock Tickers":
+			n, err = importTickersRows(ctx, sub, rows, out)
+		case "SP500":
+			n, err = importSP500Rows(ctx, sub, rows, out)
+		default:
+			err = fmt.Errorf("unsupported dataset %q for file import", sub.Dataset)
+		}
+```
+
+To:
+```go
+		logger.Info().Str("file", filePath).Msg("streaming file")
+
+		rowChan := streamFileRows(ctx, filePath)
+
+		var n int
+
+		switch sub.Dataset {
+		case "Fundamentals":
+			n, err = importFundamentalsRows(ctx, sub, rowChan, out)
+		case "Metrics":
+			n, err = importMetricsRows(ctx, sub, rowChan, out)
+		case "Stock Tickers":
+			n, err = importTickersRows(ctx, sub, rowChan, out)
+		case "SP500":
+			n, err = importSP500Rows(ctx, sub, rowChan, out)
+		default:
+			err = fmt.Errorf("unsupported dataset %q for file import", sub.Dataset)
+		}
+```
+
+- [ ] **Step 2: Remove old functions**
+
+Delete these functions from `sharadar_import.go`:
+- `parseCSV` (lines 227-262)
+- `readCSVRows` (lines 264-273)
+- `readCSVZstRows` (lines 275-290)
+- `readCSVZipRows` (lines 292-313)
+- `readParquetRows` (lines 315-383)
+- `readFileRows` (lines 385-404)
+
+- [ ] **Step 3: Update readCSVHeaders to use streamCSV internally**
+
+Check if `DetectSharadarDataset` or `countFileRows` still uses `parseCSV` or `readCSVRows`. If `DetectSharadarDataset` reads headers only, it may use its own header-reading logic. Verify and fix any remaining references to the deleted functions.
+
+Look at `DetectSharadarDataset` and `countFileRows` -- if they call `readFileRows` or `readCSVRows`, they need to be updated. `countFileRows` likely needs to stream too or can use the format-specific counters. `DetectSharadarDataset` only reads headers so it should be fine.
+
+- [ ] **Step 4: Update existing tests**
+
+Update `readCSVRows` tests to test `streamFileRows` instead. The `readParquetRows` tests are already replaced in Task 2. Update the `readCSVRows` describe block:
+
+```go
+var _ = Describe("streamFileRows with CSV", func() {
+	It("streams CSV rows with lowercase headers", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "test.csv")
+
+		content := "Ticker,Date,Value\nAAPL,2023-01-01,150.00\nMSFT,2023-01-02,250.00\n"
+		Expect(os.WriteFile(path, []byte(content), 0600)).To(Succeed())
+
+		ctx := context.Background()
+		ch := streamFileRows(ctx, path)
+
+		var rows []map[string]string
+		for rr := range ch {
+			Expect(rr.Err).NotTo(HaveOccurred())
+			rows = append(rows, rr.Row)
+		}
+
+		Expect(rows).To(HaveLen(2))
+		Expect(rows[0]["ticker"]).To(Equal("AAPL"))
+		Expect(rows[0]["date"]).To(Equal("2023-01-01"))
+		Expect(rows[0]["value"]).To(Equal("150.00"))
+		Expect(rows[1]["ticker"]).To(Equal("MSFT"))
+	})
+
+	It("streams empty result for CSV with only headers", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "empty.csv")
+
+		Expect(os.WriteFile(path, []byte("Ticker,Date\n"), 0600)).To(Succeed())
+
+		ctx := context.Background()
+		ch := streamFileRows(ctx, path)
+
+		var rows []map[string]string
+		for rr := range ch {
+			Expect(rr.Err).NotTo(HaveOccurred())
+			rows = append(rows, rr.Row)
+		}
+
+		Expect(rows).To(BeEmpty())
+	})
+})
+```
+
+- [ ] **Step 5: Verify build and tests**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && go build ./... && ginkgo run -race ./provider/sharadar/`
+Expected: PASS
+
+- [ ] **Step 6: Run lint**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && golangci-lint run --fix ./...`
+Expected: 0 issues (or auto-fixed)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add provider/sharadar/sharadar_import.go provider/sharadar/sharadar_import_test.go
+git commit -m "feat: switch ImportFiles to streaming row channel, remove batch readers"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:** (no new files)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race ./...`
+Expected: PASS
+
+- [ ] **Step 2: Run full lint**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && golangci-lint run --fix ./...`
+Expected: 0 issues
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && make build`
+Expected: no errors
+
+- [ ] **Step 4: Commit any remaining fixes**
+
+```bash
+git add -A
+git commit -m "chore: final lint fixes for streaming file import"
+```

--- a/docs/superpowers/specs/2026-04-06-streaming-file-import-design.md
+++ b/docs/superpowers/specs/2026-04-06-streaming-file-import-design.md
@@ -1,0 +1,99 @@
+# Streaming File Import
+
+## Overview
+
+Refactor Sharadar file import to stream rows through a channel instead of loading the entire file into memory. Currently `readFileRows` returns `[]map[string]string` containing all rows (36M+ for large imports), causing excessive memory usage. The fix streams rows from readers to consumers via a buffered channel so memory is bounded by the channel buffer size rather than file size.
+
+## Current Problem
+
+`readFileRows` calls `readParquetRows` or `parseCSV`, both of which accumulate every row into a `[]map[string]string` slice before returning. For a 36M row metrics file, this means 36M `map[string]string` allocations live simultaneously. The `importMetricsRows`/`importFundamentalsRows` functions then iterate the slice, converting and sending to the observation channel -- but the original slice isn't freed until the function returns.
+
+## Design
+
+### Row Channel Type
+
+```go
+type RowResult struct {
+    Row map[string]string
+    Err error
+}
+```
+
+Errors are sent on the same channel as rows. When an error is sent, the reader closes the channel immediately after. Consumers check each `RowResult.Err` and abort if non-nil.
+
+### Reader Functions
+
+All reader functions change from returning `[]map[string]string` to accepting a `chan<- RowResult` and running as goroutines. They close the channel when done.
+
+**`streamCSV(r io.Reader, out chan<- RowResult)`** -- reads headers, then sends one `RowResult` per CSV row. On error, sends `RowResult{Err: err}` and returns (deferred close handles the channel).
+
+**`streamParquetRows(path string, out chan<- RowResult)`** -- opens parquet reader, reads in 10k batches (existing behavior), sends each row to the channel as it's converted to `map[string]string`. At most 10k maps are being converted at a time.
+
+**`streamCSVRows`, `streamCSVZstRows`, `streamCSVZipRows`** -- open the file/decompressor, call `streamCSV` with the appropriate `io.Reader`. These run as the goroutine body (handle file open/close within the goroutine).
+
+**`streamFileRows(path string) <-chan RowResult`** -- replaces `readFileRows`. Creates a buffered channel (capacity 10000), detects format, launches the appropriate stream function as a goroutine, returns the receive-only channel.
+
+### Consumer Functions
+
+**`importMetricsRows`** and **`importFundamentalsRows`** change signature from `rows []map[string]string` to `rows <-chan RowResult`. They range over the channel. Progress logging changes from `len(rows)` total to just reporting rows processed every 10k (no total available upfront, which is fine).
+
+**`importTickersRows`** -- this function does a single pass over rows, accumulating `allAssets` and batching FIGI enrichment every 5000 active assets. It changes to ranging over the channel. The `allAssets` slice is still needed because assets are emitted to the output channel only after all FIGI enrichment is complete. This is acceptable because ticker files are small (thousands of rows, not millions).
+
+**`importSP500Rows`** -- this function makes two passes over the rows: first to collect unique tickers, then to build snapshots and changes. To avoid loading all rows into memory, restructure into a single pass: collect unique tickers and accumulate row data simultaneously. Alternatively, since SP500 files are small (~500 constituents * ~25 years = ~12.5k rows for snapshots), it can read from the channel into a local slice. This is acceptable because SP500 files are never large.
+
+### ImportFiles Orchestrator
+
+Changes from:
+```go
+rows, err := readFileRows(filePath)
+// ... log len(rows)
+switch sub.Dataset {
+case "Fundamentals":
+    n, err = importFundamentalsRows(ctx, sub, rows, out)
+```
+
+To:
+```go
+rowChan := streamFileRows(filePath)
+switch sub.Dataset {
+case "Fundamentals":
+    n, err = importFundamentalsRows(ctx, sub, rowChan, out)
+```
+
+The row count log line moves into each import function, logged at completion with the total count.
+
+### Error Handling
+
+If a reader goroutine encounters an error (corrupt file, I/O failure), it sends `RowResult{Err: err}` on the channel and closes it. The consumer detects this, stops processing, and returns the error. The goroutine cleans up its file handles via defers.
+
+If the consumer encounters an error (e.g., mapping failure), it stops reading from the channel. The reader goroutine will block on a full channel send, then exit when the channel is garbage collected. To handle this cleanly, the reader should use `select` with a context cancellation to avoid leaking the goroutine.
+
+Updated signatures:
+
+```go
+func streamFileRows(ctx context.Context, path string) <-chan RowResult
+```
+
+All stream functions accept `ctx context.Context` and check `ctx.Done()` between sends:
+
+```go
+select {
+case out <- RowResult{Row: row}:
+case <-ctx.Done():
+    return
+}
+```
+
+The `ImportFiles` function already has a context it can pass through.
+
+### Channel Buffer Size
+
+10,000 rows. This matches the parquet internal batch size and provides enough buffering for the reader to stay ahead of the consumer without holding significant memory. At ~10 fields per metrics row, 10k maps is roughly 1-2 MB -- negligible compared to the current 36M rows in memory.
+
+### What Does NOT Change
+
+- `mapRowToSharadarMetric`, `mapRowToSharadarFundamental`, etc. -- these still accept `map[string]string` and return structs. No change.
+- `parseFloat`, `parseInt` -- no change.
+- `detectFileFormat`, `countFileRows` -- no change.
+- The observation output channel pattern -- no change.
+- Test structure -- existing tests that call import functions with slices will need to be updated to send rows through a channel instead.

--- a/provider/sharadar/sharadar_import.go
+++ b/provider/sharadar/sharadar_import.go
@@ -38,6 +38,12 @@ import (
 	"github.com/xitongsys/parquet-go/reader"
 )
 
+// RowResult carries a single row or an error from a streaming file reader.
+type RowResult struct {
+	Row map[string]string
+	Err error
+}
+
 // fileFormat represents the format of a data file.
 type fileFormat int
 
@@ -400,6 +406,58 @@ func readFileRows(path string) ([]map[string]string, error) {
 		return readCSVZipRows(path)
 	default:
 		return nil, fmt.Errorf("unsupported file format for %q", path)
+	}
+}
+
+// streamCSV reads CSV data from r and sends each row to out as a RowResult.
+// Headers are normalized to lowercase. The channel is closed via defer when
+// reading is complete or an error occurs. Cancellation is supported via ctx.
+func streamCSV(ctx context.Context, r io.Reader, out chan<- RowResult) {
+	defer close(out)
+
+	cr := csv.NewReader(r)
+
+	headers, err := cr.Read()
+	if err != nil {
+		select {
+		case out <- RowResult{Err: fmt.Errorf("read CSV headers: %w", err)}:
+		case <-ctx.Done():
+		}
+
+		return
+	}
+
+	for i, h := range headers {
+		headers[i] = strings.ToLower(strings.TrimSpace(h))
+	}
+
+	for {
+		record, err := cr.Read()
+		if err == io.EOF {
+			return
+		}
+
+		if err != nil {
+			select {
+			case out <- RowResult{Err: fmt.Errorf("read CSV row: %w", err)}:
+			case <-ctx.Done():
+			}
+
+			return
+		}
+
+		row := make(map[string]string, len(headers))
+		for i, h := range headers {
+			if i < len(record) {
+				row[h] = record[i]
+			}
+		}
+
+		select {
+		case out <- RowResult{Row: row}:
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/provider/sharadar/sharadar_import.go
+++ b/provider/sharadar/sharadar_import.go
@@ -553,6 +553,132 @@ func streamParquetRows(ctx context.Context, path string, out chan<- RowResult) {
 	}
 }
 
+// streamCSVRows opens a plain CSV file and streams rows to out via streamCSV.
+// On open error, an error RowResult is sent and the channel is closed.
+// streamCSV is responsible for closing the channel in the non-error path.
+func streamCSVRows(ctx context.Context, path string, out chan<- RowResult) {
+	f, err := os.Open(path)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("open CSV %s: %w", path, err)}
+
+		close(out)
+
+		return
+	}
+
+	defer f.Close()
+
+	streamCSV(ctx, f, out)
+}
+
+// streamCSVZstRows opens a zstd-compressed CSV file and streams rows to out via streamCSV.
+// On open/decompress error, an error RowResult is sent and the channel is closed.
+// streamCSV is responsible for closing the channel in the non-error path.
+func streamCSVZstRows(ctx context.Context, path string, out chan<- RowResult) {
+	f, err := os.Open(path)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("open CSV.zst %s: %w", path, err)}
+
+		close(out)
+
+		return
+	}
+
+	defer f.Close()
+
+	zr, err := zstd.NewReader(f)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("create zstd reader for %s: %w", path, err)}
+
+		close(out)
+
+		return
+	}
+
+	defer zr.Close()
+
+	streamCSV(ctx, zr, out)
+}
+
+// streamCSVZipRows opens a zip archive, finds the first .csv entry, and streams
+// its rows to out via streamCSV. On error before streamCSV is called, an error
+// RowResult is sent and the channel is closed. streamCSV handles close(out).
+func streamCSVZipRows(ctx context.Context, path string, out chan<- RowResult) {
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		out <- RowResult{Err: fmt.Errorf("open ZIP %s: %w", path, err)}
+
+		close(out)
+
+		return
+	}
+
+	defer zr.Close()
+
+	for _, f := range zr.File {
+		if strings.HasSuffix(strings.ToLower(f.Name), ".csv") {
+			rc, err := f.Open()
+			if err != nil {
+				out <- RowResult{Err: fmt.Errorf("open CSV entry %s in ZIP %s: %w", f.Name, path, err)}
+
+				close(out)
+
+				return
+			}
+
+			defer rc.Close()
+
+			streamCSV(ctx, rc, out)
+
+			return
+		}
+	}
+
+	out <- RowResult{Err: fmt.Errorf("no CSV entry found in ZIP %s", path)}
+
+	close(out)
+}
+
+// rowChannelBuffer is the buffer size used for channels returned by streamFileRows.
+const rowChannelBuffer = 10000
+
+// streamFileRows detects the file format of path and returns a channel that
+// receives RowResult values as rows are read in a background goroutine.
+// The channel is closed when all rows have been sent or an error occurs.
+func streamFileRows(ctx context.Context, path string) <-chan RowResult {
+	ch := make(chan RowResult, rowChannelBuffer)
+
+	format, err := detectFileFormat(path)
+	if err != nil {
+		go func() {
+			ch <- RowResult{Err: err}
+
+			close(ch)
+		}()
+
+		return ch
+	}
+
+	switch format {
+	case fileFormatParquet:
+		go streamParquetRows(ctx, path, ch)
+	case fileFormatCSV:
+		go streamCSVRows(ctx, path, ch)
+	case fileFormatCSVZst:
+		go streamCSVZstRows(ctx, path, ch)
+	case fileFormatCSVZip:
+		go streamCSVZipRows(ctx, path, ch)
+	default:
+		go func() {
+			ch <- RowResult{Err: fmt.Errorf("unsupported file format for %q", path)}
+
+			close(ch)
+		}()
+	}
+
+	return ch
+}
+
 // parseFloat converts a string to float64, treating empty/"<nil>"/"None" as 0.
 func parseFloat(s string) float64 {
 	s = strings.TrimSpace(s)

--- a/provider/sharadar/sharadar_import.go
+++ b/provider/sharadar/sharadar_import.go
@@ -228,187 +228,6 @@ func detectFileFormat(path string) (fileFormat, error) {
 	}
 }
 
-// parseCSV reads CSV data from r. The first row is used as headers; header names
-// are normalized to lowercase. Each subsequent row is returned as a map[string]string.
-func parseCSV(r io.Reader) ([]map[string]string, error) {
-	cr := csv.NewReader(r)
-
-	headers, err := cr.Read()
-	if err != nil {
-		return nil, fmt.Errorf("read CSV headers: %w", err)
-	}
-
-	for i, h := range headers {
-		headers[i] = strings.ToLower(strings.TrimSpace(h))
-	}
-
-	var rows []map[string]string
-
-	for {
-		record, err := cr.Read()
-		if err == io.EOF {
-			break
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("read CSV row: %w", err)
-		}
-
-		row := make(map[string]string, len(headers))
-		for i, h := range headers {
-			if i < len(record) {
-				row[h] = record[i]
-			}
-		}
-
-		rows = append(rows, row)
-	}
-
-	return rows, nil
-}
-
-// readCSVRows opens a plain CSV file and returns its rows as maps.
-func readCSVRows(path string) ([]map[string]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open CSV %s: %w", path, err)
-	}
-	defer f.Close()
-
-	return parseCSV(f)
-}
-
-// readCSVZstRows opens a zstd-compressed CSV file and returns its rows as maps.
-func readCSVZstRows(path string) ([]map[string]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open CSV.zst %s: %w", path, err)
-	}
-	defer f.Close()
-
-	zr, err := zstd.NewReader(f)
-	if err != nil {
-		return nil, fmt.Errorf("create zstd reader for %s: %w", path, err)
-	}
-	defer zr.Close()
-
-	return parseCSV(zr)
-}
-
-// readCSVZipRows opens a zip archive, finds the first .csv entry, and returns its rows as maps.
-func readCSVZipRows(path string) ([]map[string]string, error) {
-	zr, err := zip.OpenReader(path)
-	if err != nil {
-		return nil, fmt.Errorf("open ZIP %s: %w", path, err)
-	}
-	defer zr.Close()
-
-	for _, f := range zr.File {
-		if strings.HasSuffix(strings.ToLower(f.Name), ".csv") {
-			rc, err := f.Open()
-			if err != nil {
-				return nil, fmt.Errorf("open CSV entry %s in ZIP %s: %w", f.Name, path, err)
-			}
-			defer rc.Close()
-
-			return parseCSV(rc)
-		}
-	}
-
-	return nil, fmt.Errorf("no CSV entry found in ZIP %s", path)
-}
-
-// readParquetRows reads a parquet file and returns its rows as maps.
-// Column names are normalized to lowercase.
-func readParquetRows(path string) ([]map[string]string, error) {
-	fr, err := local.NewLocalFileReader(path)
-	if err != nil {
-		return nil, fmt.Errorf("open parquet %s: %w", path, err)
-	}
-	defer fr.Close()
-
-	pr, err := reader.NewParquetReader(fr, nil, 4)
-	if err != nil {
-		return nil, fmt.Errorf("create parquet reader for %s: %w", path, err)
-	}
-	defer pr.ReadStop()
-
-	numRows := int(pr.GetNumRows())
-	rows := make([]map[string]string, 0, numRows)
-
-	batchSize := 10000
-	for numRows > 0 {
-		readCount := batchSize
-		if readCount > numRows {
-			readCount = numRows
-		}
-
-		batch, err := pr.ReadByNumber(readCount)
-		if err != nil {
-			return nil, fmt.Errorf("read parquet rows: %w", err)
-		}
-
-		for _, rawRow := range batch {
-			val := reflect.ValueOf(rawRow)
-			if val.Kind() == reflect.Ptr {
-				val = val.Elem()
-			}
-
-			if val.Kind() != reflect.Struct {
-				continue
-			}
-
-			typ := val.Type()
-
-			row := make(map[string]string, typ.NumField())
-			for j := 0; j < typ.NumField(); j++ {
-				name := strings.ToLower(typ.Field(j).Name)
-				field := val.Field(j)
-
-				// Dereference pointer fields (nullable parquet columns)
-				if field.Kind() == reflect.Ptr {
-					if field.IsNil() {
-						row[name] = ""
-
-						continue
-					}
-
-					field = field.Elem()
-				}
-
-				row[name] = fmt.Sprintf("%v", field.Interface())
-			}
-
-			rows = append(rows, row)
-		}
-
-		numRows -= readCount
-	}
-
-	return rows, nil
-}
-
-// readFileRows dispatches to the appropriate reader based on the file format.
-func readFileRows(path string) ([]map[string]string, error) {
-	format, err := detectFileFormat(path)
-	if err != nil {
-		return nil, err
-	}
-
-	switch format {
-	case fileFormatParquet:
-		return readParquetRows(path)
-	case fileFormatCSV:
-		return readCSVRows(path)
-	case fileFormatCSVZst:
-		return readCSVZstRows(path)
-	case fileFormatCSVZip:
-		return readCSVZipRows(path)
-	default:
-		return nil, fmt.Errorf("unsupported file format for %q", path)
-	}
-}
-
 // streamCSV reads CSV data from r and sends each row to out as a RowResult.
 // Headers are normalized to lowercase. The channel is closed via defer when
 // reading is complete or an error occurs. Cancellation is supported via ctx.
@@ -920,30 +739,24 @@ func (sharadar *Sharadar) ImportFiles(ctx context.Context, sub *library.Subscrip
 	}()
 
 	for _, filePath := range files {
-		logger.Info().Str("file", filePath).Msg("reading file")
+		logger.Info().Str("file", filePath).Msg("streaming file")
 
-		rows, err := readFileRows(filePath)
-		if err != nil {
-			logger.Error().Err(err).Str("file", filePath).Msg("failed to read file")
+		rowChan := streamFileRows(ctx, filePath)
 
-			runSummary.Status = data.RunFailed
-
-			return
-		}
-
-		logger.Info().Int("rows", len(rows)).Str("file", filePath).Msg("file loaded")
-
-		var n int
+		var (
+			n   int
+			err error
+		)
 
 		switch sub.Dataset {
 		case "Fundamentals":
-			n, err = importFundamentalsRows(ctx, sub, rows, out)
+			n, err = importFundamentalsRows(ctx, sub, rowChan, out)
 		case "Metrics":
-			n, err = importMetricsRows(ctx, sub, rows, out)
+			n, err = importMetricsRows(ctx, sub, rowChan, out)
 		case "Stock Tickers":
-			n, err = importTickersRows(ctx, sub, rows, out)
+			n, err = importTickersRows(ctx, sub, rowChan, out)
 		case "SP500":
-			n, err = importSP500Rows(ctx, sub, rows, out)
+			n, err = importSP500Rows(ctx, sub, rowChan, out)
 		default:
 			err = fmt.Errorf("unsupported dataset %q for file import", sub.Dataset)
 		}
@@ -962,7 +775,7 @@ func (sharadar *Sharadar) ImportFiles(ctx context.Context, sub *library.Subscrip
 }
 
 // importFundamentalsRows processes rows for the Fundamentals dataset.
-func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows []map[string]string, out chan<- *data.Observation) (int, error) {
+func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
 	logger := zerolog.Ctx(ctx)
 
 	conn, err := sub.Library.Pool.Acquire(ctx)
@@ -983,8 +796,12 @@ func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows
 
 	count := 0
 
-	for i, row := range rows {
-		fundamental := mapRowToSharadarFundamental(row)
+	for rr := range rows {
+		if rr.Err != nil {
+			return 0, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		fundamental := mapRowToSharadarFundamental(rr.Row)
 		pvFundamental := fundamental.PvFundamental(figiMap)
 
 		out <- &data.Observation{
@@ -996,8 +813,8 @@ func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows
 
 		count++
 
-		if (i+1)%10000 == 0 {
-			logger.Info().Int("rows_processed", i+1).Int("total_rows", len(rows)).Msg("fundamentals import progress")
+		if count%10000 == 0 {
+			logger.Info().Int("rows_processed", count).Msg("fundamentals import progress")
 		}
 	}
 
@@ -1005,7 +822,7 @@ func importFundamentalsRows(ctx context.Context, sub *library.Subscription, rows
 }
 
 // importMetricsRows processes rows for the Metrics dataset.
-func importMetricsRows(ctx context.Context, sub *library.Subscription, rows []map[string]string, out chan<- *data.Observation) (int, error) {
+func importMetricsRows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
 	logger := zerolog.Ctx(ctx)
 
 	conn, err := sub.Library.Pool.Acquire(ctx)
@@ -1031,8 +848,12 @@ func importMetricsRows(ctx context.Context, sub *library.Subscription, rows []ma
 
 	count := 0
 
-	for i, row := range rows {
-		metric := mapRowToSharadarMetric(row)
+	for rr := range rows {
+		if rr.Err != nil {
+			return 0, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		metric := mapRowToSharadarMetric(rr.Row)
 		pvMetric := metric.PvMetric(figiMap, nyc)
 
 		out <- &data.Observation{
@@ -1044,8 +865,8 @@ func importMetricsRows(ctx context.Context, sub *library.Subscription, rows []ma
 
 		count++
 
-		if (i+1)%10000 == 0 {
-			logger.Info().Int("rows_processed", i+1).Int("total_rows", len(rows)).Msg("metrics import progress")
+		if count%10000 == 0 {
+			logger.Info().Int("rows_processed", count).Msg("metrics import progress")
 		}
 	}
 
@@ -1053,13 +874,23 @@ func importMetricsRows(ctx context.Context, sub *library.Subscription, rows []ma
 }
 
 // importTickersRows processes rows for the Stock Tickers dataset.
-func importTickersRows(ctx context.Context, sub *library.Subscription, rows []map[string]string, out chan<- *data.Observation) (int, error) {
+func importTickersRows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
 	logger := zerolog.Ctx(ctx)
 
-	enrichAssets := make([]*data.Asset, 0, 5000)
-	allAssets := make([]*data.Asset, 0, len(rows))
+	var rowSlice []map[string]string
 
-	for _, row := range rows {
+	for rr := range rows {
+		if rr.Err != nil {
+			return 0, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		rowSlice = append(rowSlice, rr.Row)
+	}
+
+	enrichAssets := make([]*data.Asset, 0, 5000)
+	allAssets := make([]*data.Asset, 0, len(rowSlice))
+
+	for _, row := range rowSlice {
 		// Only process SF1 table rows
 		if row["table"] != "SF1" {
 			continue
@@ -1125,8 +956,18 @@ const sp500IndexTicker = "SPX"
 // importSP500Rows processes rows for the SP500 dataset.
 // Rows with action "current" or "historical" are grouped by date into IndexSnapshots.
 // Rows with action "added" or "removed" become IndexChange observations.
-func importSP500Rows(ctx context.Context, sub *library.Subscription, rows []map[string]string, out chan<- *data.Observation) (int, error) {
+func importSP500Rows(ctx context.Context, sub *library.Subscription, rows <-chan RowResult, out chan<- *data.Observation) (int, error) {
 	logger := zerolog.Ctx(ctx)
+
+	var rowSlice []map[string]string
+
+	for rr := range rows {
+		if rr.Err != nil {
+			return 0, fmt.Errorf("reading file: %w", rr.Err)
+		}
+
+		rowSlice = append(rowSlice, rr.Row)
+	}
 
 	conn, err := sub.Library.Pool.Acquire(ctx)
 	if err != nil {
@@ -1150,7 +991,7 @@ func importSP500Rows(ctx context.Context, sub *library.Subscription, rows []map[
 	// Step 2: Collect all unique tickers from the data
 	uniqueTickers := make(map[string]string) // ticker -> name
 
-	for _, row := range rows {
+	for _, row := range rowSlice {
 		ticker := strings.TrimSpace(row["ticker"])
 
 		name := strings.TrimSpace(row["name"])
@@ -1212,7 +1053,7 @@ func importSP500Rows(ctx context.Context, sub *library.Subscription, rows []map[
 	// is incomplete and must not be imported.
 	var earliestHistoricalDate string
 
-	for _, row := range rows {
+	for _, row := range rowSlice {
 		if strings.TrimSpace(row["action"]) == "historical" {
 			dateStr := strings.TrimSpace(row["date"])
 			if earliestHistoricalDate == "" || dateStr < earliestHistoricalDate {
@@ -1230,7 +1071,7 @@ func importSP500Rows(ctx context.Context, sub *library.Subscription, rows []map[
 	// Seed membership from the earliest historical snapshot
 	membership := make(map[string]string) // ticker -> compositeFigi
 
-	for _, row := range rows {
+	for _, row := range rowSlice {
 		if strings.TrimSpace(row["action"]) == "historical" && strings.TrimSpace(row["date"]) == earliestHistoricalDate {
 			ticker := strings.TrimSpace(row["ticker"])
 			if ticker != "" {
@@ -1242,7 +1083,7 @@ func importSP500Rows(ctx context.Context, sub *library.Subscription, rows []map[
 	// Collect changelog rows on or after the earliest historical date
 	var changes []*data.IndexChange
 
-	for _, row := range rows {
+	for _, row := range rowSlice {
 		action := strings.TrimSpace(row["action"])
 		ticker := strings.TrimSpace(row["ticker"])
 		dateStr := strings.TrimSpace(row["date"])

--- a/provider/sharadar/sharadar_import.go
+++ b/provider/sharadar/sharadar_import.go
@@ -461,6 +461,98 @@ func streamCSV(ctx context.Context, r io.Reader, out chan<- RowResult) {
 	}
 }
 
+// streamParquetRows opens a parquet file and sends each row to out as a RowResult.
+// Rows are read in batches of 10 000. Column names are normalized to lowercase.
+// The channel is closed via defer when reading is complete or an error occurs.
+// Cancellation is supported via ctx.
+func streamParquetRows(ctx context.Context, path string, out chan<- RowResult) {
+	defer close(out)
+
+	fr, err := local.NewLocalFileReader(path)
+	if err != nil {
+		select {
+		case out <- RowResult{Err: fmt.Errorf("open parquet %s: %w", path, err)}:
+		case <-ctx.Done():
+		}
+
+		return
+	}
+
+	defer fr.Close()
+
+	pr, err := reader.NewParquetReader(fr, nil, 4)
+	if err != nil {
+		select {
+		case out <- RowResult{Err: fmt.Errorf("create parquet reader for %s: %w", path, err)}:
+		case <-ctx.Done():
+		}
+
+		return
+	}
+
+	defer pr.ReadStop()
+
+	numRows := int(pr.GetNumRows())
+	batchSize := 10000
+
+	for numRows > 0 {
+		readCount := batchSize
+		if readCount > numRows {
+			readCount = numRows
+		}
+
+		batch, err := pr.ReadByNumber(readCount)
+		if err != nil {
+			select {
+			case out <- RowResult{Err: fmt.Errorf("read parquet rows from %s: %w", path, err)}:
+			case <-ctx.Done():
+			}
+
+			return
+		}
+
+		for _, rawRow := range batch {
+			val := reflect.ValueOf(rawRow)
+			if val.Kind() == reflect.Ptr {
+				val = val.Elem()
+			}
+
+			if val.Kind() != reflect.Struct {
+				continue
+			}
+
+			typ := val.Type()
+
+			row := make(map[string]string, typ.NumField())
+			for j := 0; j < typ.NumField(); j++ {
+				name := strings.ToLower(typ.Field(j).Name)
+				field := val.Field(j)
+
+				// Dereference pointer fields (nullable parquet columns)
+				if field.Kind() == reflect.Ptr {
+					if field.IsNil() {
+						row[name] = ""
+
+						continue
+					}
+
+					field = field.Elem()
+				}
+
+				row[name] = fmt.Sprintf("%v", field.Interface())
+			}
+
+			select {
+			case out <- RowResult{Row: row}:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		numRows -= readCount
+	}
+}
+
 // parseFloat converts a string to float64, treating empty/"<nil>"/"None" as 0.
 func parseFloat(s string) float64 {
 	s = strings.TrimSpace(s)

--- a/provider/sharadar/sharadar_import_test.go
+++ b/provider/sharadar/sharadar_import_test.go
@@ -126,64 +126,6 @@ var _ = Describe("detectFileFormat", func() {
 	})
 })
 
-var _ = Describe("readCSVRows", func() {
-	It("reads CSV rows into maps with lowercase headers", func() {
-		dir := GinkgoT().TempDir()
-		path := filepath.Join(dir, "test.csv")
-
-		content := "Ticker,Date,Value\nAAPL,2023-01-01,150.00\nMSFT,2023-01-02,250.00\n"
-		Expect(os.WriteFile(path, []byte(content), 0600)).To(Succeed())
-
-		rows, err := readCSVRows(path)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(rows).To(HaveLen(2))
-		Expect(rows[0]["ticker"]).To(Equal("AAPL"))
-		Expect(rows[0]["date"]).To(Equal("2023-01-01"))
-		Expect(rows[0]["value"]).To(Equal("150.00"))
-		Expect(rows[1]["ticker"]).To(Equal("MSFT"))
-	})
-
-	It("returns empty slice for CSV with only headers", func() {
-		dir := GinkgoT().TempDir()
-		path := filepath.Join(dir, "empty.csv")
-
-		Expect(os.WriteFile(path, []byte("Ticker,Date\n"), 0600)).To(Succeed())
-
-		rows, err := readCSVRows(path)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(rows).To(BeEmpty())
-	})
-})
-
-var _ = Describe("readParquetRows", func() {
-	It("reads parquet rows if test file exists", func() {
-		parquetPath := "../../data/sharadar/sharadar_metrics_20231228.parquet"
-		if _, err := os.Stat(parquetPath); os.IsNotExist(err) {
-			Skip("test parquet file not available")
-		}
-
-		rows, err := readParquetRows(parquetPath)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(rows).NotTo(BeEmpty())
-		// Each row should have a ticker key
-		Expect(rows[0]).To(HaveKey("ticker"))
-	})
-
-	It("reads SP500 parquet rows if test file exists", func() {
-		parquetPath := "../../data/sharadar/sharadar_sp500_20231228.parquet"
-		if _, err := os.Stat(parquetPath); os.IsNotExist(err) {
-			Skip("test parquet file not available")
-		}
-
-		rows, err := readParquetRows(parquetPath)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(rows).NotTo(BeEmpty())
-		Expect(rows[0]).To(HaveKey("ticker"))
-		Expect(rows[0]).To(HaveKey("action"))
-		Expect(rows[0]).To(HaveKey("date"))
-	})
-})
-
 var _ = Describe("mapRowToSharadarMetric", func() {
 	It("maps a row to a sharadarMetric struct", func() {
 		row := map[string]string{

--- a/provider/sharadar/sharadar_import_test.go
+++ b/provider/sharadar/sharadar_import_test.go
@@ -15,8 +15,10 @@
 package sharadar
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -323,5 +325,89 @@ var _ = Describe("mapRowToSharadarTicker", func() {
 		Expect(ticker).NotTo(BeNil())
 		Expect(ticker.LastUpdated).To(Equal(time.Time{}))
 		Expect(ticker.FirstAdded).To(Equal(time.Time{}))
+	})
+})
+
+var _ = Describe("streamCSV", func() {
+	It("streams rows with lowercase headers from a string reader", func() {
+		ctx := context.Background()
+		out := make(chan RowResult, 10)
+		input := "Ticker,Date,Value\nAAPL,2023-01-01,150.00\nMSFT,2023-01-02,250.00\n"
+
+		go streamCSV(ctx, strings.NewReader(input), out)
+
+		var rows []map[string]string
+		for r := range out {
+			Expect(r.Err).NotTo(HaveOccurred())
+			rows = append(rows, r.Row)
+		}
+
+		Expect(rows).To(HaveLen(2))
+		Expect(rows[0]["ticker"]).To(Equal("AAPL"))
+		Expect(rows[0]["date"]).To(Equal("2023-01-01"))
+		Expect(rows[0]["value"]).To(Equal("150.00"))
+		Expect(rows[1]["ticker"]).To(Equal("MSFT"))
+	})
+
+	It("streams empty result for headers-only CSV", func() {
+		ctx := context.Background()
+		out := make(chan RowResult, 10)
+		input := "Ticker,Date\n"
+
+		go streamCSV(ctx, strings.NewReader(input), out)
+
+		var rows []map[string]string
+		for r := range out {
+			Expect(r.Err).NotTo(HaveOccurred())
+			rows = append(rows, r.Row)
+		}
+
+		Expect(rows).To(BeEmpty())
+	})
+
+	It("sends error on malformed CSV", func() {
+		ctx := context.Background()
+		out := make(chan RowResult, 10)
+		// A bare quote mid-field triggers a parse error in encoding/csv
+		input := "Ticker,Date\nAA\"PL,2023-01-01\n"
+
+		go streamCSV(ctx, strings.NewReader(input), out)
+
+		var errResult RowResult
+		for r := range out {
+			if r.Err != nil {
+				errResult = r
+			}
+		}
+
+		Expect(errResult.Err).To(HaveOccurred())
+	})
+
+	It("stops when context is cancelled", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Unbuffered channel so sender blocks after consumer stops reading.
+		out := make(chan RowResult)
+
+		// Build a large CSV so many rows would be sent without cancellation.
+		var sb strings.Builder
+		sb.WriteString("ticker,date\n")
+		for i := 0; i < 1000; i++ {
+			sb.WriteString("AAPL,2023-01-01\n")
+		}
+
+		go streamCSV(ctx, strings.NewReader(sb.String()), out)
+
+		// Read one row, then cancel.
+		<-out
+		cancel()
+
+		// Drain remaining rows; channel must close eventually.
+		count := 1
+		for range out {
+			count++
+		}
+
+		Expect(count).To(BeNumerically("<", 1000))
 	})
 })

--- a/provider/sharadar/sharadar_import_test.go
+++ b/provider/sharadar/sharadar_import_test.go
@@ -411,3 +411,67 @@ var _ = Describe("streamCSV", func() {
 		Expect(count).To(BeNumerically("<", 1000))
 	})
 })
+
+var _ = Describe("streamParquetRows", func() {
+	It("streams parquet rows if test file exists", func() {
+		parquetPath := "../../data/sharadar/sharadar_metrics_20231228.parquet"
+		if _, err := os.Stat(parquetPath); os.IsNotExist(err) {
+			Skip("test parquet file not available")
+		}
+
+		ctx := context.Background()
+		ch := make(chan RowResult, 10000)
+
+		go streamParquetRows(ctx, parquetPath, ch)
+
+		var rows []map[string]string
+		for r := range ch {
+			Expect(r.Err).NotTo(HaveOccurred())
+			rows = append(rows, r.Row)
+		}
+
+		Expect(rows).NotTo(BeEmpty())
+		Expect(rows[0]).To(HaveKey("ticker"))
+	})
+
+	It("streams SP500 parquet rows if test file exists", func() {
+		parquetPath := "../../data/sharadar/sharadar_sp500_20231228.parquet"
+		if _, err := os.Stat(parquetPath); os.IsNotExist(err) {
+			Skip("test parquet file not available")
+		}
+
+		ctx := context.Background()
+		ch := make(chan RowResult, 10000)
+
+		go streamParquetRows(ctx, parquetPath, ch)
+
+		var rows []map[string]string
+		for r := range ch {
+			Expect(r.Err).NotTo(HaveOccurred())
+			rows = append(rows, r.Row)
+		}
+
+		Expect(rows).NotTo(BeEmpty())
+		Expect(rows[0]).To(HaveKey("ticker"))
+		Expect(rows[0]).To(HaveKey("action"))
+		Expect(rows[0]).To(HaveKey("date"))
+	})
+
+	It("sends error for non-existent parquet file", func() {
+		ctx := context.Background()
+		ch := make(chan RowResult, 10)
+
+		go streamParquetRows(ctx, "/nonexistent/path/file.parquet", ch)
+
+		var firstResult RowResult
+		for r := range ch {
+			firstResult = r
+			break
+		}
+		// drain
+		for range ch {
+		}
+
+		Expect(firstResult.Err).To(HaveOccurred())
+	})
+})

--- a/provider/sharadar/sharadar_import_test.go
+++ b/provider/sharadar/sharadar_import_test.go
@@ -475,3 +475,41 @@ var _ = Describe("streamParquetRows", func() {
 		Expect(firstResult.Err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("streamFileRows", func() {
+	It("streams rows from a plain CSV file", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "test.csv")
+		content := "Ticker,Date,Value\nAAPL,2023-01-01,150.00\nMSFT,2023-01-02,250.00\n"
+		Expect(os.WriteFile(path, []byte(content), 0600)).To(Succeed())
+
+		ctx := context.Background()
+		ch := streamFileRows(ctx, path)
+
+		var rows []map[string]string
+		for r := range ch {
+			Expect(r.Err).NotTo(HaveOccurred())
+			rows = append(rows, r.Row)
+		}
+
+		Expect(rows).To(HaveLen(2))
+		Expect(rows[0]["ticker"]).To(Equal("AAPL"))
+		Expect(rows[1]["ticker"]).To(Equal("MSFT"))
+	})
+
+	It("sends error for unsupported file format", func() {
+		ctx := context.Background()
+		ch := streamFileRows(ctx, "/tmp/data.xlsx")
+
+		var firstResult RowResult
+		for r := range ch {
+			firstResult = r
+			break
+		}
+		// drain
+		for range ch {
+		}
+
+		Expect(firstResult.Err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## Summary

- Replaces batch file readers (`readFileRows` returning `[]map[string]string`) with streaming channel-based readers (`streamFileRows` returning `<-chan RowResult`)
- CSV readers send one row at a time; parquet reader sends in 10k-row internal batches but one row at a time to the channel
- Memory usage drops from O(all rows) to O(channel buffer = 10k rows) -- critical for 36M+ row imports
- All streaming readers support context cancellation to avoid goroutine leaks
- `importMetricsRows` and `importFundamentalsRows` consume directly from channel (true streaming)
- `importTickersRows` and `importSP500Rows` drain to local slice (small files, need multi-pass logic)

## Test plan

- [ ] `make test` -- all suites pass
- [ ] `make lint` -- 0 issues
- [ ] Import a large Sharadar metrics file and monitor memory usage (should stay bounded)
- [ ] Import a fundamentals file and verify data matches expected output
- [ ] Import a tickers file and verify FIGI enrichment still works
- [ ] Import an SP500 file and verify snapshots/changelog generated correctly