### PR TITLE
feat(pvindex): add us-tradable investable universe provider

### DIFF
--- a/checks/audit_runner_test.go
+++ b/checks/audit_runner_test.go
@@ -29,11 +29,11 @@ type stubAuditCheck struct {
 	results []checks.CheckResult
 }
 
-func (s *stubAuditCheck) Name() string                  { return "stub-audit" }
-func (s *stubAuditCheck) Description() string           { return "stub" }
-func (s *stubAuditCheck) Phase() checks.CheckPhase      { return checks.PhaseAudit }
+func (s *stubAuditCheck) Name() string                   { return "stub-audit" }
+func (s *stubAuditCheck) Description() string            { return "stub" }
+func (s *stubAuditCheck) Phase() checks.CheckPhase       { return checks.PhaseAudit }
 func (s *stubAuditCheck) Severity() checks.CheckSeverity { return checks.SeverityWarning }
-func (s *stubAuditCheck) DataTypes() []string           { return []string{"fundamental"} }
+func (s *stubAuditCheck) DataTypes() []string            { return []string{"fundamental"} }
 func (s *stubAuditCheck) Audit(_ context.Context, _ *pgxpool.Pool, _ string, _ *time.Time, _ *time.Duration) ([]checks.CheckResult, error) {
 	return s.results, nil
 }

--- a/cmd/providers_register.go
+++ b/cmd/providers_register.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/penny-vault/pvdata/provider/legacy"
 	_ "github.com/penny-vault/pvdata/provider/massive"
 	_ "github.com/penny-vault/pvdata/provider/nasdaq"
+	_ "github.com/penny-vault/pvdata/provider/pvindex"
 	_ "github.com/penny-vault/pvdata/provider/sec"
 	_ "github.com/penny-vault/pvdata/provider/sharadar"
 	_ "github.com/penny-vault/pvdata/provider/tiingo"

--- a/docs/superpowers/plans/2026-04-07-pvindex-tradable-universe.md
+++ b/docs/superpowers/plans/2026-04-07-pvindex-tradable-universe.md
@@ -1,0 +1,2712 @@
+# pvindex Tradable Universe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a new `provider/pvindex/` package that computes a daily-recomputed investable universe of US-listed common stocks (`us-tradable`) by reading from canonical published views (`eod`, `metrics`, `assets`) and emitting `IndexSnapshot` and `IndexChange` observations using the existing index data types.
+
+**Architecture:** Derived provider — reads from the canonical published views rather than fetching externally. Filter chain (asset master → rolling stats → percentile baseline → data availability → share-class dedup → percentile filter → liquidity → price → cap-weight). Backfill runs in 63-trading-day chunks with one bulk EOD/metric query per chunk and an in-memory rolling-window median per FIGI. Annual snapshots + daily changelog with relative weight-change threshold.
+
+**Tech Stack:** Go, jackc/pgx/v5 (Postgres), Ginkgo v2 + Gomega (testing), zerolog (logging). Reuses existing `provider/index_helpers.go` (with one new helper variant).
+
+**Spec:** `docs/superpowers/specs/2026-04-07-pvindex-tradable-universe-design.md`
+
+---
+
+## File Structure
+
+```
+provider/pvindex/
+  pvindex.go              # Provider struct, init(), Name/Description/ConfigDescription, Datasets, Fetch entry point
+  date_range.go           # computeDateRange (queries eod and metrics views)
+  loader.go               # Database loaders for assets, eod, metrics chunks
+  filter.go               # Pure filter functions (LP suffix, asset master, contiguity, share-class dedup, percentile, liquidity, price, cap-weight)
+  rolling.go              # Rolling-window median dollar volume computation
+  chunk.go                # Per-chunk processor: orchestrates day-by-day universe computation and observation emission
+  pvindex_suite_test.go   # Ginkgo suite registration
+  pvindex_test.go         # Provider interface tests
+  filter_test.go          # Filter function unit tests
+  rolling_test.go         # Rolling median unit tests
+  chunk_test.go           # Chunk processor unit tests (with synthetic in-memory data)
+  integration_test.go     # Build tag `integration` — DB-backed end-to-end test
+  testdata/
+    universe_2023_jan.golden.json  # Expected universe constituents for golden integration test
+```
+
+Modified files:
+- `provider/index_helpers.go` — add `DiffSnapshotsWithThreshold` and `DiffOptions` type
+- `provider/index_helpers_test.go` — add tests for the new helper
+- `cmd/providers_register.go` — add blank import for pvindex
+
+---
+
+### Task 1: Helper — DiffSnapshotsWithThreshold
+
+Add a relative-threshold variant of `DiffSnapshots` to `provider/index_helpers.go`. Existing `DiffSnapshots` is unchanged. The new function takes a `DiffOptions` struct with absolute and relative thresholds; a weight is considered changed when `|delta| >= max(absoluteThreshold, prev.Weight * relativeThreshold)`.
+
+**Files:**
+- Modify: `provider/index_helpers.go` (after line 98, the existing `DiffSnapshots` function)
+- Modify: `provider/index_helpers_test.go` (after the existing `diffSnapshots` Describe block)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `provider/index_helpers_test.go`:
+
+```go
+var _ = Describe("diffSnapshotsWithThreshold", func() {
+	It("matches DiffSnapshots when only AbsoluteThreshold is set", func() {
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.06},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{AbsoluteThreshold: 0.01})
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("MSFT"))
+	})
+
+	It("uses relative threshold when set", func() {
+		// AAPL prev=0.0003, current=0.00040. delta=0.0001, prev*0.25 = 0.000075
+		// 0.0001 >= 0.000075 -> CHANGED
+		// MSFT prev=0.0003, current=0.00031. delta=0.00001, prev*0.25 = 0.000075
+		// 0.00001 < 0.000075 -> NOT changed
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.00040},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.00031},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.00030},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.00030},
+		}
+		adds, removes, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{RelativeThreshold: 0.25})
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("AAPL"))
+		Expect(weightChanges).NotTo(HaveKey("MSFT"))
+	})
+
+	It("uses max(absolute, prev*relative) when both are set", func() {
+		// prev=0.10, current=0.108. delta=0.008.
+		// abs=0.01, prev*rel=0.10*0.25=0.025. max=0.025. 0.008 < 0.025 -> NOT changed.
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.108},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.10},
+		}
+		_, _, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{AbsoluteThreshold: 0.01, RelativeThreshold: 0.25})
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("detects adds and removes regardless of threshold mode", func() {
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"NEW1": {CompositeFigi: "BBG000NEW001", Weight: 0.01},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"OLD1": {CompositeFigi: "BBG000OLD001", Weight: 0.02},
+		}
+		adds, removes, _ := DiffSnapshotsWithThreshold(current, previous, DiffOptions{RelativeThreshold: 0.25})
+		Expect(adds).To(HaveKey("NEW1"))
+		Expect(removes).To(HaveKey("OLD1"))
+	})
+
+	It("treats prev.Weight=0 as falling back to absolute threshold", func() {
+		// prev weight is 0, so prev*rel = 0. max(abs, 0) = abs. delta must clear absolute.
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.005},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.0},
+		}
+		_, _, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{AbsoluteThreshold: 0.01, RelativeThreshold: 0.25})
+		Expect(weightChanges).To(BeEmpty())
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "diffSnapshotsWithThreshold" ./provider/`
+Expected: FAIL with "undefined: DiffSnapshotsWithThreshold" / "undefined: DiffOptions"
+
+- [ ] **Step 3: Add the implementation**
+
+In `provider/index_helpers.go`, immediately after the existing `DiffSnapshots` function (right before `// LastSnapshotDate` on line ~100), add:
+
+```go
+// DiffOptions configures DiffSnapshotsWithThreshold weight-change detection.
+// A weight is considered changed when |delta| >= max(AbsoluteThreshold, prev.Weight * RelativeThreshold).
+// If RelativeThreshold is 0, only the absolute threshold applies.
+type DiffOptions struct {
+	AbsoluteThreshold float64 // absolute weight delta required (e.g., 0.01)
+	RelativeThreshold float64 // fraction of previous weight (e.g., 0.25 = 25%)
+}
+
+// DiffSnapshotsWithThreshold compares current holdings against previous holdings using
+// configurable thresholds for weight-change detection. Adds and removes are reported
+// regardless of threshold settings.
+func DiffSnapshotsWithThreshold(current, previous map[string]IndexMember, opts DiffOptions) (added, removed, weightChanged map[string]IndexMember) {
+	added = make(map[string]IndexMember)
+	removed = make(map[string]IndexMember)
+	weightChanged = make(map[string]IndexMember)
+
+	for ticker, member := range current {
+		prev, ok := previous[ticker]
+		if !ok {
+			added[ticker] = member
+			continue
+		}
+
+		delta := member.Weight - prev.Weight
+		if delta < 0 {
+			delta = -delta
+		}
+
+		threshold := opts.AbsoluteThreshold
+
+		relTh := prev.Weight * opts.RelativeThreshold
+		if relTh > threshold {
+			threshold = relTh
+		}
+
+		if delta >= threshold-1e-12 && delta > 0 {
+			// Note: we keep the legacy >= behavior of DiffSnapshots; the -1e-12 avoids
+			// strict floating-point edge cases when threshold == 0 + delta == 0.
+			weightChanged[ticker] = member
+		}
+	}
+
+	for ticker, member := range previous {
+		if _, ok := current[ticker]; !ok {
+			removed[ticker] = member
+		}
+	}
+
+	return
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "diffSnapshotsWithThreshold" ./provider/`
+Expected: PASS for all 5 specs.
+
+Also rerun the existing diffSnapshots tests to confirm no regression:
+Run: `ginkgo run -race --focus "diffSnapshots" ./provider/`
+Expected: PASS, no failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/index_helpers.go provider/index_helpers_test.go
+git commit -m "feat(provider): add DiffSnapshotsWithThreshold for relative weight thresholds"
+```
+
+---
+
+### Task 2: Package Skeleton + Suite + Provider Registration
+
+Create the empty package, Ginkgo suite, and a stub Provider implementation that registers itself. This task does not yet implement Fetch — it returns an empty dataset map for now so the provider can compile and register.
+
+**Files:**
+- Create: `provider/pvindex/pvindex.go`
+- Create: `provider/pvindex/pvindex_suite_test.go`
+- Create: `provider/pvindex/pvindex_test.go`
+- Modify: `cmd/providers_register.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `provider/pvindex/pvindex_suite_test.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPvindex(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pvindex Suite")
+}
+```
+
+Create `provider/pvindex/pvindex_test.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/provider"
+)
+
+var _ = Describe("pvindex Provider", func() {
+	It("registers itself in the provider map", func() {
+		p, ok := provider.Map["pvindex"]
+		Expect(ok).To(BeTrue())
+		Expect(p.Name()).To(Equal("pvindex"))
+	})
+
+	It("returns a non-empty description", func() {
+		p := provider.Map["pvindex"]
+		Expect(p.Description()).NotTo(BeEmpty())
+	})
+
+	It("declares the US Tradable Universe dataset", func() {
+		p := provider.Map["pvindex"]
+		datasets := p.Datasets()
+		Expect(datasets).To(HaveKey("US Tradable Universe"))
+	})
+
+	It("US Tradable Universe dataset emits IndexSnapshot and IndexChangelog data types", func() {
+		p := provider.Map["pvindex"]
+		ds := p.Datasets()["US Tradable Universe"]
+		Expect(ds.DataTypes).To(HaveLen(2))
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race ./provider/pvindex/`
+Expected: FAIL — package does not exist / no Go files in directory.
+
+- [ ] **Step 3: Create the package skeleton**
+
+Create `provider/pvindex/pvindex.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"context"
+	"time"
+
+	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/library"
+	"github.com/penny-vault/pvdata/provider"
+)
+
+// Pvindex is a derived provider that computes investable universes by reading from
+// the canonical published views (eod, metrics, assets) rather than fetching from an
+// external source.
+type Pvindex struct{}
+
+func init() {
+	provider.Register("pvindex", &Pvindex{})
+}
+
+func (p *Pvindex) Name() string {
+	return "pvindex"
+}
+
+func (p *Pvindex) Description() string {
+	return "Derived index provider that computes investable universes from canonical EOD, metric, and asset views."
+}
+
+func (p *Pvindex) ConfigDescription() map[string]string {
+	return map[string]string{
+		"index_ticker":        "Optional. Override the index ticker (default: us-tradable).",
+		"start_date_override": "Optional. Force a later start date in YYYY-MM-DD format. Used for testing or selective backfill.",
+		"chunk_size_days":     "Optional. Number of trading days per processing chunk (default: 63).",
+	}
+}
+
+func (p *Pvindex) Datasets() map[string]provider.Dataset {
+	return map[string]provider.Dataset{
+		"US Tradable Universe": {
+			Name:        "US Tradable Universe",
+			Description: "Daily-recomputed investable universe of US common stocks: structural + liquidity + size + price filters with annual cap-weighted snapshots.",
+			DataTypes: []*data.DataType{
+				data.DataTypes[data.IndexSnapshotKey],
+				data.DataTypes[data.IndexChangelogKey],
+			},
+			DateRange: func() (time.Time, time.Time) {
+				// Stub: real implementation lands in Task 4.
+				return time.Date(1999, 4, 30, 0, 0, 0, 0, time.UTC), time.Now().UTC()
+			},
+			TTL:   0,
+			Fetch: fetchTradableUniverse,
+		},
+	}
+}
+
+// fetchTradableUniverse is the dataset Fetch entry point. Real implementation lands in Task 12.
+func fetchTradableUniverse(ctx context.Context, sub *library.Subscription, out chan<- *data.Observation, exit chan<- data.RunSummary) {
+	exit <- data.RunSummary{
+		StartTime:        time.Now(),
+		EndTime:          time.Now(),
+		SubscriptionID:   sub.ID,
+		SubscriptionName: sub.Name,
+		Status:           data.RunSuccess,
+	}
+}
+```
+
+- [ ] **Step 4: Register the package via blank import**
+
+Modify `cmd/providers_register.go`. Current contents around line 19:
+
+```go
+	_ "github.com/penny-vault/pvdata/provider/fred"
+	_ "github.com/penny-vault/pvdata/provider/ishares"
+	_ "github.com/penny-vault/pvdata/provider/legacy"
+	_ "github.com/penny-vault/pvdata/provider/massive"
+	_ "github.com/penny-vault/pvdata/provider/nasdaq"
+	_ "github.com/penny-vault/pvdata/provider/sharadar"
+	_ "github.com/penny-vault/pvdata/provider/tiingo"
+	_ "github.com/penny-vault/pvdata/provider/tradingview"
+	_ "github.com/penny-vault/pvdata/provider/zacks"
+```
+
+Insert `_ "github.com/penny-vault/pvdata/provider/pvindex"` in alphabetical order (after `nasdaq`, before `sharadar`):
+
+```go
+	_ "github.com/penny-vault/pvdata/provider/fred"
+	_ "github.com/penny-vault/pvdata/provider/ishares"
+	_ "github.com/penny-vault/pvdata/provider/legacy"
+	_ "github.com/penny-vault/pvdata/provider/massive"
+	_ "github.com/penny-vault/pvdata/provider/nasdaq"
+	_ "github.com/penny-vault/pvdata/provider/pvindex"
+	_ "github.com/penny-vault/pvdata/provider/sharadar"
+	_ "github.com/penny-vault/pvdata/provider/tiingo"
+	_ "github.com/penny-vault/pvdata/provider/tradingview"
+	_ "github.com/penny-vault/pvdata/provider/zacks"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `ginkgo run -race ./provider/pvindex/`
+Expected: PASS for all 4 specs.
+
+Also build the full binary to ensure registration didn't break anything:
+Run: `go build ./...`
+Expected: clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add provider/pvindex/pvindex.go provider/pvindex/pvindex_suite_test.go provider/pvindex/pvindex_test.go cmd/providers_register.go
+git commit -m "feat(pvindex): add provider skeleton with stub dataset"
+```
+
+---
+
+### Task 3: LP Suffix Matcher
+
+Pure function that returns true if a stock name ends in an LP suffix. Used by the asset master filter.
+
+**Files:**
+- Create: `provider/pvindex/filter.go`
+- Create: `provider/pvindex/filter_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `provider/pvindex/filter_test.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isLPName", func() {
+	DescribeTable("LP suffix detection",
+		func(name string, expected bool) {
+			Expect(isLPName(name)).To(Equal(expected))
+		},
+		Entry("Enterprise Products LP", "Enterprise Products Partners LP", true),
+		Entry("Energy Transfer LP", "Energy Transfer LP", true),
+		Entry("MPLX LP", "MPLX LP", true),
+		Entry("Brookfield Infrastructure L.P.", "Brookfield Infrastructure L.P.", true),
+		Entry("L.P. with trailing whitespace", "Some Partnership L.P.   ", true),
+		Entry("LLP suffix", "Big Law LLP", true),
+		Entry("Limited Partnership full word", "Foo Limited Partnership", true),
+		Entry("L P with space", "ABC Investments L P", true),
+		Entry("lower case lp", "enterprise products lp", true),
+		Entry("Marsh & McLennan Companies (negative - not LP)", "Marsh & McLennan Companies", false),
+		Entry("Apple Inc (negative)", "Apple Inc.", false),
+		Entry("MetLife Inc (negative)", "MetLife Inc", false),
+		Entry("LP in middle of name (negative)", "LP Holdings Corporation", false),
+		Entry("Compass Plc (negative - similar shape)", "Compass Group plc", false),
+		Entry("Empty name (negative)", "", false),
+	)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "isLPName" ./provider/pvindex/`
+Expected: FAIL with "undefined: isLPName".
+
+- [ ] **Step 3: Implement isLPName**
+
+Create `provider/pvindex/filter.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"strings"
+)
+
+// lpSuffixes is the list of legal-form suffixes that identify a limited partnership.
+// Matched as case-insensitive whole-word suffixes against the trimmed asset name.
+var lpSuffixes = []string{
+	" LP",
+	" L.P.",
+	" L P",
+	" LLP",
+	" LIMITED PARTNERSHIP",
+}
+
+// isLPName returns true if the asset name ends in a recognized LP suffix.
+// Suffix matching is case-insensitive and whitespace-tolerant.
+func isLPName(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return false
+	}
+
+	upper := strings.ToUpper(trimmed)
+	for _, suffix := range lpSuffixes {
+		if strings.HasSuffix(upper, suffix) {
+			return true
+		}
+	}
+
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "isLPName" ./provider/pvindex/`
+Expected: PASS for all 15 entries.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/filter.go provider/pvindex/filter_test.go
+git commit -m "feat(pvindex): add LP suffix matcher"
+```
+
+---
+
+### Task 4: Asset Master Filter
+
+Pure function that filters a slice of `*data.Asset` to candidates passing the structural filter (active=true, asset_type=CS, exchange whitelist, not LP).
+
+**Files:**
+- Modify: `provider/pvindex/filter.go`
+- Modify: `provider/pvindex/filter_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `provider/pvindex/filter_test.go`:
+
+```go
+import (
+	"github.com/penny-vault/pvdata/data"
+)
+
+var _ = Describe("filterAssetMaster", func() {
+	mkAsset := func(ticker, name, exch string, atype data.AssetType, active bool) *data.Asset {
+		return &data.Asset{
+			Ticker:          ticker,
+			Name:            name,
+			PrimaryExchange: data.Exchange(exch),
+			AssetType:       atype,
+			Active:          active,
+		}
+	}
+
+	It("keeps active US common stocks on whitelisted exchanges", func() {
+		input := []*data.Asset{
+			mkAsset("AAPL", "Apple Inc.", "NASDAQ", data.CommonStock, true),
+			mkAsset("BAC", "Bank of America Corporation", "NYSE", data.CommonStock, true),
+			mkAsset("XOM", "Exxon Mobil Corporation", "XNYS", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(HaveLen(3))
+	})
+
+	It("excludes inactive assets", func() {
+		input := []*data.Asset{
+			mkAsset("DEAD", "Dead Co", "NYSE", data.CommonStock, false),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
+
+	It("excludes non-CS asset types", func() {
+		input := []*data.Asset{
+			mkAsset("SPY", "SPDR S&P 500 ETF", "NYSE ARCA", data.ETF, true),
+			mkAsset("PCQ", "PIMCO California Muni", "NYSE", data.CEF, true),
+			mkAsset("BABA", "Alibaba ADR", "NYSE", data.ADRC, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
+
+	It("excludes OTC and unknown exchanges", func() {
+		input := []*data.Asset{
+			mkAsset("FOO", "Foo Inc", "OTC", data.CommonStock, true),
+			mkAsset("BAR", "Bar Inc", "NMFQS", data.CommonStock, true),
+			mkAsset("BAZ", "Baz Inc", "UNK", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
+
+	It("accepts both display-name and MIC code formats for whitelisted exchanges", func() {
+		input := []*data.Asset{
+			mkAsset("A", "Alpha Inc", "NASDAQ", data.CommonStock, true),
+			mkAsset("B", "Beta Inc", "XNAS", data.CommonStock, true),
+			mkAsset("C", "Gamma Inc", "NYSE", data.CommonStock, true),
+			mkAsset("D", "Delta Inc", "XNYS", data.CommonStock, true),
+			mkAsset("E", "Epsilon Inc", "NYSE MKT", data.CommonStock, true),
+			mkAsset("F", "Zeta Inc", "XASE", data.CommonStock, true),
+			mkAsset("G", "Eta Inc", "AMEX", data.CommonStock, true),
+			mkAsset("H", "Theta Inc", "NYSE ARCA", data.CommonStock, true),
+			mkAsset("I", "Iota Inc", "ARCX", data.CommonStock, true),
+			mkAsset("J", "Kappa Inc", "BATS", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(HaveLen(10))
+	})
+
+	It("excludes LPs", func() {
+		input := []*data.Asset{
+			mkAsset("EPD", "Enterprise Products Partners LP", "NYSE", data.CommonStock, true),
+			mkAsset("ET", "Energy Transfer LP", "NYSE", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "filterAssetMaster" ./provider/pvindex/`
+Expected: FAIL with "undefined: filterAssetMaster".
+
+- [ ] **Step 3: Implement filterAssetMaster**
+
+Append to `provider/pvindex/filter.go`:
+
+```go
+import (
+	"github.com/penny-vault/pvdata/data"
+)
+
+// allowedExchanges is the whitelist of US-listed common stock exchanges.
+// Both display-name and MIC code formats are accepted, because the assets table
+// currently contains a mix of both. See "Known limitation: exchange field inconsistency"
+// in the design spec.
+var allowedExchanges = map[data.Exchange]struct{}{
+	"NASDAQ":    {},
+	"XNAS":      {},
+	"NYSE":      {},
+	"XNYS":      {},
+	"NYSE MKT":  {},
+	"XASE":      {},
+	"AMEX":      {},
+	"NYSE ARCA": {},
+	"ARCX":      {},
+	"BATS":      {},
+}
+
+// filterAssetMaster returns the subset of assets passing the structural filter:
+// active = true, asset_type = CS, primary_exchange in whitelist, name does not match
+// an LP suffix.
+func filterAssetMaster(assets []*data.Asset) []*data.Asset {
+	out := make([]*data.Asset, 0, len(assets))
+
+	for _, a := range assets {
+		if !a.Active {
+			continue
+		}
+
+		if a.AssetType != data.CommonStock {
+			continue
+		}
+
+		if _, ok := allowedExchanges[a.PrimaryExchange]; !ok {
+			continue
+		}
+
+		if isLPName(a.Name) {
+			continue
+		}
+
+		out = append(out, a)
+	}
+
+	return out
+}
+```
+
+Note: the `import` block at the top of `filter.go` already has `"strings"` from Task 3 — add `"github.com/penny-vault/pvdata/data"` to the same block. Likewise for `filter_test.go`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "filterAssetMaster" ./provider/pvindex/`
+Expected: PASS for all 6 specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/filter.go provider/pvindex/filter_test.go
+git commit -m "feat(pvindex): add asset master structural filter"
+```
+
+---
+
+### Task 5: Rolling-Window Stats
+
+Compute `(day_count, median_dv)` per FIGI from a slice of EOD rows over a sliding window. Used by every downstream filter.
+
+**Files:**
+- Create: `provider/pvindex/rolling.go`
+- Create: `provider/pvindex/rolling_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `provider/pvindex/rolling_test.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("rollingStats", func() {
+	mkRow := func(date string, close, vol float64) eodRow {
+		t, _ := time.Parse("2006-01-02", date)
+		return eodRow{Date: t, Close: close, Volume: vol}
+	}
+
+	It("returns count and median over a window with all rows in range", func() {
+		rows := []eodRow{
+			mkRow("2024-01-02", 10, 100), // dv=1000
+			mkRow("2024-01-03", 20, 100), // dv=2000
+			mkRow("2024-01-04", 30, 100), // dv=3000
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-04")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(3))
+		Expect(stats.medianDV).To(Equal(2000.0))
+	})
+
+	It("ignores rows outside the window", func() {
+		rows := []eodRow{
+			mkRow("2023-12-30", 10, 100),
+			mkRow("2024-01-02", 20, 100), // dv=2000
+			mkRow("2024-01-03", 30, 100), // dv=3000
+			mkRow("2024-01-05", 40, 100),
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-02")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-04")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(2))
+		Expect(stats.medianDV).To(Equal(2500.0))
+	})
+
+	It("returns zero stats for empty input", func() {
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-31")
+		stats := rollingStats(nil, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(0))
+		Expect(stats.medianDV).To(Equal(0.0))
+	})
+
+	It("computes median correctly for odd-count window", func() {
+		rows := []eodRow{
+			mkRow("2024-01-01", 10, 100), // dv=1000
+			mkRow("2024-01-02", 20, 100), // dv=2000
+			mkRow("2024-01-03", 30, 100), // dv=3000
+			mkRow("2024-01-04", 40, 100), // dv=4000
+			mkRow("2024-01-05", 50, 100), // dv=5000
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-05")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(5))
+		Expect(stats.medianDV).To(Equal(3000.0))
+	})
+
+	It("computes median correctly for even-count window", func() {
+		rows := []eodRow{
+			mkRow("2024-01-01", 10, 100), // dv=1000
+			mkRow("2024-01-02", 20, 100), // dv=2000
+			mkRow("2024-01-03", 30, 100), // dv=3000
+			mkRow("2024-01-04", 40, 100), // dv=4000
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-04")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(4))
+		Expect(stats.medianDV).To(Equal(2500.0))
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "rollingStats" ./provider/pvindex/`
+Expected: FAIL with "undefined: eodRow / undefined: rollingStats".
+
+- [ ] **Step 3: Implement rolling.go**
+
+Create `provider/pvindex/rolling.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"sort"
+	"time"
+)
+
+// eodRow is the in-memory representation of one EOD row used by the rolling-window
+// computation. We do not reuse data.Eod because it carries OHLC fields we don't need
+// and we want a tightly-packed struct for the chunk loader's memory budget.
+type eodRow struct {
+	Date   time.Time
+	Close  float64
+	Volume float64
+}
+
+// stats holds the rolling-window statistics for a single FIGI.
+type stats struct {
+	dayCount int
+	medianDV float64
+}
+
+// rollingStats computes (count, median dollar volume) over the rows whose Date
+// falls within [windowStart, windowEnd] inclusive. Rows are assumed to be sorted by
+// date but the implementation does not require it. Returns zero values if no rows
+// fall in the window.
+func rollingStats(rows []eodRow, windowStart, windowEnd time.Time) stats {
+	if len(rows) == 0 {
+		return stats{}
+	}
+
+	dvs := make([]float64, 0, len(rows))
+
+	for _, r := range rows {
+		if r.Date.Before(windowStart) || r.Date.After(windowEnd) {
+			continue
+		}
+
+		dvs = append(dvs, r.Close*r.Volume)
+	}
+
+	if len(dvs) == 0 {
+		return stats{}
+	}
+
+	sort.Float64s(dvs)
+
+	var median float64
+
+	mid := len(dvs) / 2
+	if len(dvs)%2 == 1 {
+		median = dvs[mid]
+	} else {
+		median = (dvs[mid-1] + dvs[mid]) / 2
+	}
+
+	return stats{dayCount: len(dvs), medianDV: median}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "rollingStats" ./provider/pvindex/`
+Expected: PASS for all 5 specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/rolling.go provider/pvindex/rolling_test.go
+git commit -m "feat(pvindex): add rolling-window dollar volume stats"
+```
+
+---
+
+### Task 6: Share-Class Deduplication
+
+Group candidates by `cik` (or `composite_figi` for null CIK) and keep the row with the highest median dollar volume per group.
+
+**Files:**
+- Modify: `provider/pvindex/filter.go`
+- Modify: `provider/pvindex/filter_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `provider/pvindex/filter_test.go`:
+
+```go
+var _ = Describe("dedupShareClasses", func() {
+	mkAssetWithCIK := func(ticker, cik, figi string) *data.Asset {
+		return &data.Asset{
+			Ticker:        ticker,
+			CompositeFigi: figi,
+			CIK:           cik,
+		}
+	}
+
+	It("keeps the highest-DV share class within a CIK group", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("GOOGL", "0001652044", "BBG009S39JX6"),
+			mkAssetWithCIK("GOOG", "0001652044", "BBG009S3NB30"),
+		}
+		dvByFigi := map[string]float64{
+			"BBG009S39JX6": 1_500_000_000, // GOOGL
+			"BBG009S3NB30": 2_500_000_000, // GOOG (higher)
+		}
+		out := dedupShareClasses(assets, dvByFigi)
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Ticker).To(Equal("GOOG"))
+	})
+
+	It("treats null CIK rows as singleton groups", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("XYZ", "", "BBGXYZ00001"),
+			mkAssetWithCIK("ABC", "", "BBGABC00001"),
+		}
+		dvByFigi := map[string]float64{
+			"BBGXYZ00001": 100,
+			"BBGABC00001": 200,
+		}
+		out := dedupShareClasses(assets, dvByFigi)
+		Expect(out).To(HaveLen(2))
+	})
+
+	It("breaks ties by ticker for determinism", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("AAA", "0001234567", "BBGAAA00001"),
+			mkAssetWithCIK("BBB", "0001234567", "BBGBBB00001"),
+		}
+		dvByFigi := map[string]float64{
+			"BBGAAA00001": 1000,
+			"BBGBBB00001": 1000,
+		}
+		out := dedupShareClasses(assets, dvByFigi)
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Ticker).To(Equal("AAA"))
+	})
+
+	It("handles assets with zero dollar volume", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("ZERO", "0001111111", "BBGZERO0001"),
+		}
+		out := dedupShareClasses(assets, map[string]float64{})
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Ticker).To(Equal("ZERO"))
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "dedupShareClasses" ./provider/pvindex/`
+Expected: FAIL with "undefined: dedupShareClasses".
+
+- [ ] **Step 3: Implement dedupShareClasses**
+
+Append to `provider/pvindex/filter.go`:
+
+```go
+// dedupShareClasses groups assets by CIK (or composite_figi as fallback for null CIK)
+// and keeps the row with the highest median dollar volume per group. Ties are broken
+// alphabetically by ticker for deterministic output.
+func dedupShareClasses(assets []*data.Asset, dvByFigi map[string]float64) []*data.Asset {
+	type bestRow struct {
+		asset *data.Asset
+		dv    float64
+	}
+
+	groups := make(map[string]bestRow, len(assets))
+
+	for _, a := range assets {
+		key := a.CIK
+		if key == "" {
+			key = a.CompositeFigi
+		}
+
+		dv := dvByFigi[a.CompositeFigi]
+
+		current, exists := groups[key]
+		if !exists {
+			groups[key] = bestRow{asset: a, dv: dv}
+			continue
+		}
+
+		if dv > current.dv || (dv == current.dv && a.Ticker < current.asset.Ticker) {
+			groups[key] = bestRow{asset: a, dv: dv}
+		}
+	}
+
+	out := make([]*data.Asset, 0, len(groups))
+	for _, b := range groups {
+		out = append(out, b.asset)
+	}
+
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "dedupShareClasses" ./provider/pvindex/`
+Expected: PASS for all 4 specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/filter.go provider/pvindex/filter_test.go
+git commit -m "feat(pvindex): add share-class deduplication"
+```
+
+---
+
+### Task 7: Cap-Weight Assignment
+
+Pure function that takes a slice of `(figi, market_cap)` and produces normalized cap weights summing to 1.0.
+
+**Files:**
+- Modify: `provider/pvindex/filter.go`
+- Modify: `provider/pvindex/filter_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `provider/pvindex/filter_test.go`:
+
+```go
+var _ = Describe("assignCapWeights", func() {
+	It("normalizes weights to sum to 1.0", func() {
+		caps := map[string]int64{
+			"BBG000A": 1_000_000_000,
+			"BBG000B": 2_000_000_000,
+			"BBG000C": 7_000_000_000,
+		}
+		weights := assignCapWeights(caps)
+		Expect(weights).To(HaveLen(3))
+		Expect(weights["BBG000A"]).To(BeNumerically("~", 0.10, 1e-9))
+		Expect(weights["BBG000B"]).To(BeNumerically("~", 0.20, 1e-9))
+		Expect(weights["BBG000C"]).To(BeNumerically("~", 0.70, 1e-9))
+	})
+
+	It("returns weights summing to 1.0 within float tolerance", func() {
+		caps := map[string]int64{
+			"A": 333, "B": 333, "C": 333, "D": 1,
+		}
+		weights := assignCapWeights(caps)
+		var sum float64
+		for _, w := range weights {
+			sum += w
+		}
+		Expect(sum).To(BeNumerically("~", 1.0, 1e-9))
+	})
+
+	It("returns empty map for empty input", func() {
+		Expect(assignCapWeights(nil)).To(BeEmpty())
+		Expect(assignCapWeights(map[string]int64{})).To(BeEmpty())
+	})
+
+	It("returns empty map when total cap is zero", func() {
+		caps := map[string]int64{"A": 0, "B": 0}
+		Expect(assignCapWeights(caps)).To(BeEmpty())
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "assignCapWeights" ./provider/pvindex/`
+Expected: FAIL with "undefined: assignCapWeights".
+
+- [ ] **Step 3: Implement assignCapWeights**
+
+Append to `provider/pvindex/filter.go`:
+
+```go
+// assignCapWeights computes market-cap-weighted weights from a map of composite_figi
+// to market_cap. Weights are normalized to sum to 1.0. Returns an empty map if the
+// input is empty or the total market cap is zero.
+func assignCapWeights(caps map[string]int64) map[string]float64 {
+	if len(caps) == 0 {
+		return map[string]float64{}
+	}
+
+	var total int64
+	for _, c := range caps {
+		total += c
+	}
+
+	if total <= 0 {
+		return map[string]float64{}
+	}
+
+	weights := make(map[string]float64, len(caps))
+
+	totalF := float64(total)
+	for figi, c := range caps {
+		weights[figi] = float64(c) / totalF
+	}
+
+	return weights
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "assignCapWeights" ./provider/pvindex/`
+Expected: PASS for all 4 specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/filter.go provider/pvindex/filter_test.go
+git commit -m "feat(pvindex): add cap-weight assignment"
+```
+
+---
+
+### Task 8: Percentile Computation
+
+Pure function that computes the Nth percentile of an int64 slice, used for both the 25th and 80th percentile thresholds.
+
+**Files:**
+- Modify: `provider/pvindex/filter.go`
+- Modify: `provider/pvindex/filter_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `provider/pvindex/filter_test.go`:
+
+```go
+var _ = Describe("percentileInt64", func() {
+	It("computes 25th percentile of a known distribution", func() {
+		// 100 values from 1 to 100. 25th percentile = 25 (linear interpolation between 25 and 26 = 25.75 with type-7)
+		// Use simple sorting interpretation: percentileInt64 returns the lowest value at or above
+		// the cutoff index. For an unambiguous test, use a clearly indexable set.
+		vals := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+		// 25th percentile of 10 values: index = (10 * 0.25) = 2.5 -> ceil to 3 -> vals[2] = 30
+		Expect(percentileInt64(vals, 0.25)).To(Equal(int64(30)))
+	})
+
+	It("computes 80th percentile of a known distribution", func() {
+		vals := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+		// 80th percentile of 10 values: index = (10 * 0.80) = 8 -> vals[7] = 80 (zero-indexed)
+		Expect(percentileInt64(vals, 0.80)).To(Equal(int64(80)))
+	})
+
+	It("returns zero for empty input", func() {
+		Expect(percentileInt64(nil, 0.5)).To(Equal(int64(0)))
+		Expect(percentileInt64([]int64{}, 0.5)).To(Equal(int64(0)))
+	})
+
+	It("returns the only element for single-element input", func() {
+		Expect(percentileInt64([]int64{42}, 0.25)).To(Equal(int64(42)))
+		Expect(percentileInt64([]int64{42}, 0.80)).To(Equal(int64(42)))
+	})
+
+	It("does not modify the input slice", func() {
+		vals := []int64{50, 10, 30, 20, 40}
+		_ = percentileInt64(vals, 0.5)
+		Expect(vals).To(Equal([]int64{50, 10, 30, 20, 40}))
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "percentileInt64" ./provider/pvindex/`
+Expected: FAIL with "undefined: percentileInt64".
+
+- [ ] **Step 3: Implement percentileInt64**
+
+Append to `provider/pvindex/filter.go`. Add `"math"` and `"sort"` to the existing import block at the top of `filter.go` (the file already has `"strings"` from Task 3 and `"github.com/penny-vault/pvdata/data"` from Task 4).
+
+```go
+// percentileInt64 returns the value at the given percentile (0..1) of the input slice.
+// Uses the "nearest rank" method: for n values, the rank index = ceil(n*p), clamped
+// to [1, n]. The returned value is sorted[rank-1]. Does not modify the input slice.
+// Returns 0 for empty input.
+func percentileInt64(values []int64, p float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+
+	if len(values) == 1 {
+		return values[0]
+	}
+
+	sorted := make([]int64, len(values))
+	copy(sorted, values)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	rank := int(math.Ceil(float64(len(sorted)) * p))
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > len(sorted) {
+		rank = len(sorted)
+	}
+
+	return sorted[rank-1]
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "percentileInt64" ./provider/pvindex/`
+Expected: PASS for all 5 specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/filter.go provider/pvindex/filter_test.go
+git commit -m "feat(pvindex): add nearest-rank percentile helper"
+```
+
+---
+
+### Task 9: Per-Day Universe Computation
+
+Orchestrates the filter chain for a single date `D`. Takes pre-loaded asset, EOD, and metric data and produces the universe `map[composite_figi]IndexMember` with cap-weights.
+
+**Files:**
+- Create: `provider/pvindex/chunk.go`
+- Create: `provider/pvindex/chunk_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `provider/pvindex/chunk_test.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/data"
+)
+
+var _ = Describe("computeUniverseForDate", func() {
+	// Helper: build a contiguous EOD slice for one FIGI from startDate going N days forward.
+	// All trading days are simulated as consecutive calendar days for simplicity in tests.
+	mkEodSeries := func(startDate string, n int, close, volume float64) []eodRow {
+		t, _ := time.Parse("2006-01-02", startDate)
+		out := make([]eodRow, n)
+		for i := 0; i < n; i++ {
+			out[i] = eodRow{Date: t.AddDate(0, 0, i), Close: close, Volume: volume}
+		}
+		return out
+	}
+
+	mkCSAsset := func(ticker, cik, figi, name string) *data.Asset {
+		return &data.Asset{
+			Ticker:          ticker,
+			Name:            name,
+			CompositeFigi:   figi,
+			CIK:             cik,
+			AssetType:       data.CommonStock,
+			PrimaryExchange: "NASDAQ",
+			Active:          true,
+		}
+	}
+
+	It("includes a stock that passes all filters", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		// 200-day window: 2024-06-15 to 2024-12-30 (using calendar days for simplicity).
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("AAPL", "0000320193", "BBG000B9XRY4", "Apple Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000B9XRY4": mkEodSeries("2024-06-14", 200, 100.0, 100_000), // dv = 10M
+		}
+		mcapByFigi := map[string]int64{
+			"BBG000B9XRY4": 3_000_000_000_000, // $3T
+		}
+		// Build a broad market cap pool that has AAPL and one tiny stock for percentile baseline.
+		broadMcaps := []int64{1_000_000, 3_000_000_000_000}
+		// Trading days = the 200-day window matches our calendar exactly.
+		tradingDayCount := 200
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: tradingDayCount,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(HaveKey("AAPL"))
+		Expect(universe["AAPL"].Weight).To(BeNumerically("~", 1.0, 1e-9))
+	})
+
+	It("excludes a stock with insufficient EOD history (under 30 days)", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("NEW", "0001111111", "BBG000NEW001", "New Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000NEW001": mkEodSeries(evalDate.AddDate(0, 0, -20).Format("2006-01-02"), 20, 50.0, 100_000),
+		}
+		mcapByFigi := map[string]int64{"BBG000NEW001": 50_000_000_000}
+		broadMcaps := []int64{50_000_000_000, 1_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("includes a stock via early-entry path (50 days, top quintile market cap)", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("BIGIPO", "0002222222", "BBG000BIGIPO", "BigIPO Inc.")}
+		// 50 contiguous days ending day-1
+		eodByFigi := map[string][]eodRow{
+			"BBG000BIGIPO": mkEodSeries(evalDate.AddDate(0, 0, -50).Format("2006-01-02"), 50, 200.0, 100_000), // dv = 20M
+		}
+		mcapByFigi := map[string]int64{"BBG000BIGIPO": 80_000_000_000}
+		// Broad market cap pool: BIGIPO at $80B is in top 20% of [1B, 5B, 10B, 80B] (80th percentile).
+		broadMcaps := []int64{1_000_000_000, 5_000_000_000, 10_000_000_000, 80_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(HaveKey("BIGIPO"))
+	})
+
+	It("excludes a stock via early-entry path when market cap is below top quintile", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("SMALLIPO", "0003333333", "BBG000SMALLIPO", "SmallIPO Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000SMALLIPO": mkEodSeries(evalDate.AddDate(0, 0, -50).Format("2006-01-02"), 50, 10.0, 100_000),
+		}
+		mcapByFigi := map[string]int64{"BBG000SMALLIPO": 500_000_000} // $500M
+		// Broad market cap pool: SMALLIPO at $500M is bottom of [500M, 5B, 10B, 80B], not top 20%.
+		broadMcaps := []int64{500_000_000, 5_000_000_000, 10_000_000_000, 80_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock with low ADV", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("ILLIQ", "0004444444", "BBG000ILLIQ01", "Illiquid Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000ILLIQ01": mkEodSeries("2024-06-14", 200, 10.0, 1_000), // dv = 10K
+		}
+		mcapByFigi := map[string]int64{"BBG000ILLIQ01": 100_000_000_000}
+		broadMcaps := []int64{100_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock with prior_close below $2", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("CHEAP", "0005555555", "BBG000CHEAP01", "Cheap Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000CHEAP01": mkEodSeries("2024-06-14", 200, 1.5, 10_000_000), // dv = 15M, but price < $2
+		}
+		mcapByFigi := map[string]int64{"BBG000CHEAP01": 100_000_000_000}
+		broadMcaps := []int64{100_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock below the 25th percentile market cap cutoff", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("TINY", "0006666666", "BBG000TINY001", "Tiny Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000TINY001": mkEodSeries("2024-06-14", 200, 10.0, 1_000_000), // dv = 10M, passes ADV
+		}
+		mcapByFigi := map[string]int64{"BBG000TINY001": 50_000_000} // $50M
+		// Broad pool with TINY at the bottom: 25th percentile is well above 50M.
+		broadMcaps := []int64{50_000_000, 1_000_000_000, 5_000_000_000, 10_000_000_000, 80_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock with insufficient EOD rows after a gap", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		// Build 200 consecutive calendar days starting 2024-06-15, then drop the middle row.
+		// After removal, only ~198 rows fall inside the window, so the stock fails the standard-path
+		// dayCount threshold (< 200). BroadMarketCaps is set so the stock is also below the
+		// 80th-percentile early-entry threshold, so neither path admits it.
+		series := mkEodSeries("2024-06-15", 200, 100.0, 100_000)
+		series = append(series[:100], series[101:]...)
+
+		assets := []*data.Asset{mkCSAsset("GAPPY", "0007777777", "BBG000GAPPY01", "Gappy Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000GAPPY01": series,
+		}
+		mcapByFigi := map[string]int64{"BBG000GAPPY01": 100_000_000_000} // $100B
+		// 80th percentile of [100B, 500B, 1T, 2T, 5T] = ceil(5*0.8)=4 -> sorted[3] = 2T.
+		// GAPPY's 100B is well below the 2T early-entry cutoff.
+		broadMcaps := []int64{100_000_000_000, 500_000_000_000, 1_000_000_000_000, 2_000_000_000_000, 5_000_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "computeUniverseForDate" ./provider/pvindex/`
+Expected: FAIL with "undefined: perDayInput / undefined: computeUniverseForDate".
+
+- [ ] **Step 3: Implement chunk.go (initial scope: per-day computation only)**
+
+Create `provider/pvindex/chunk.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"time"
+
+	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/provider"
+)
+
+const (
+	// minDayCountStandard is the standard contiguity threshold (200 trading days).
+	minDayCountStandard = 200
+	// minDayCountEarlyEntry is the minimum data required for the IPO early-entry path.
+	minDayCountEarlyEntry = 30
+	// liquidityThresholdUSD is the minimum 200-day median dollar volume.
+	liquidityThresholdUSD = 2_500_000.0
+	// priceFloorUSD is the minimum prior-day close.
+	priceFloorUSD = 2.0
+	// sizePercentile is the 25th percentile cutoff for market cap.
+	sizePercentile = 0.25
+	// earlyEntryPercentile is the top quintile threshold (80th percentile).
+	earlyEntryPercentile = 0.80
+)
+
+// perDayInput is the data needed to compute the universe for a single date.
+// Loaded once per chunk and reused across days.
+type perDayInput struct {
+	Date            time.Time
+	WindowStart     time.Time // inclusive lower bound for the 200-day rolling window
+	WindowEnd       time.Time // inclusive upper bound (= D - 1 trading day)
+	TradingDayCount int       // expected count of trading days in [WindowStart, WindowEnd]
+	Assets          []*data.Asset
+	EodByFigi       map[string][]eodRow
+	MarketCapByFigi map[string]int64
+	BroadMarketCaps []int64 // all market caps in the broad CS pool on D, used for percentile thresholds
+}
+
+// computeUniverseForDate runs the full filter chain for a single trading day and
+// returns the resulting universe as map[ticker]IndexMember with cap-weights assigned.
+func computeUniverseForDate(in perDayInput) map[string]provider.IndexMember {
+	// Step 1 (asset master) is assumed to have already been applied to in.Assets.
+
+	// Step 3: rolling stats per FIGI.
+	statsByFigi := make(map[string]stats, len(in.Assets))
+
+	for _, a := range in.Assets {
+		rows := in.EodByFigi[a.CompositeFigi]
+		statsByFigi[a.CompositeFigi] = rollingStats(rows, in.WindowStart, in.WindowEnd)
+	}
+
+	// Step 4: percentile baseline for early-entry threshold.
+	sizeCutoff := percentileInt64(in.BroadMarketCaps, sizePercentile)
+	earlyEntryCutoff := percentileInt64(in.BroadMarketCaps, earlyEntryPercentile)
+
+	// Step 5: data availability.
+	type candidate struct {
+		asset      *data.Asset
+		priorClose float64
+		marketCap  int64
+		medianDV   float64
+	}
+
+	candidates := make([]candidate, 0, len(in.Assets))
+
+	for _, a := range in.Assets {
+		st := statsByFigi[a.CompositeFigi]
+
+		mcap, hasMcap := in.MarketCapByFigi[a.CompositeFigi]
+		if !hasMcap || mcap <= 0 {
+			continue
+		}
+
+		standardEligible := st.dayCount >= minDayCountStandard
+		earlyEligible := st.dayCount >= minDayCountEarlyEntry && st.dayCount < minDayCountStandard && mcap >= earlyEntryCutoff
+
+		if !standardEligible && !earlyEligible {
+			continue
+		}
+
+		// Contiguity check for standard path: dayCount must equal expected trading day count.
+		// For early-entry, we require dayCount of contiguous days from the listing date,
+		// which is implicit (all available rows in the window count toward dayCount).
+		if standardEligible && st.dayCount != in.TradingDayCount {
+			continue
+		}
+
+		// Prior close = most recent in-window EOD close.
+		priorClose := mostRecentClose(in.EodByFigi[a.CompositeFigi], in.WindowEnd)
+
+		candidates = append(candidates, candidate{
+			asset:      a,
+			priorClose: priorClose,
+			marketCap:  mcap,
+			medianDV:   st.medianDV,
+		})
+	}
+
+	// Step 6: share-class deduplication.
+	dvByFigi := make(map[string]float64, len(candidates))
+	assetsForDedup := make([]*data.Asset, 0, len(candidates))
+	candByFigi := make(map[string]candidate, len(candidates))
+
+	for _, c := range candidates {
+		dvByFigi[c.asset.CompositeFigi] = c.medianDV
+		assetsForDedup = append(assetsForDedup, c.asset)
+		candByFigi[c.asset.CompositeFigi] = c
+	}
+
+	deduped := dedupShareClasses(assetsForDedup, dvByFigi)
+
+	// Step 7: market cap percentile filter.
+	survivors := make([]candidate, 0, len(deduped))
+
+	for _, a := range deduped {
+		c := candByFigi[a.CompositeFigi]
+		if c.marketCap < sizeCutoff {
+			continue
+		}
+		survivors = append(survivors, c)
+	}
+
+	// Step 8: liquidity filter.
+	liquidSurvivors := make([]candidate, 0, len(survivors))
+	for _, c := range survivors {
+		if c.medianDV < liquidityThresholdUSD {
+			continue
+		}
+		liquidSurvivors = append(liquidSurvivors, c)
+	}
+
+	// Step 9: price guard rail.
+	priceSurvivors := make([]candidate, 0, len(liquidSurvivors))
+	for _, c := range liquidSurvivors {
+		if c.priorClose < priceFloorUSD {
+			continue
+		}
+		priceSurvivors = append(priceSurvivors, c)
+	}
+
+	// Step 10: cap weights.
+	caps := make(map[string]int64, len(priceSurvivors))
+	for _, c := range priceSurvivors {
+		caps[c.asset.CompositeFigi] = c.marketCap
+	}
+
+	weights := assignCapWeights(caps)
+
+	universe := make(map[string]provider.IndexMember, len(priceSurvivors))
+	for _, c := range priceSurvivors {
+		universe[c.asset.Ticker] = provider.IndexMember{
+			CompositeFigi: c.asset.CompositeFigi,
+			Weight:        weights[c.asset.CompositeFigi],
+		}
+	}
+
+	return universe
+}
+
+// mostRecentClose returns the close price of the most recent EOD row at or before the
+// given date, or 0 if no such row exists.
+func mostRecentClose(rows []eodRow, asOf time.Time) float64 {
+	var (
+		bestDate  time.Time
+		bestClose float64
+	)
+
+	for _, r := range rows {
+		if r.Date.After(asOf) {
+			continue
+		}
+		if r.Date.After(bestDate) {
+			bestDate = r.Date
+			bestClose = r.Close
+		}
+	}
+
+	return bestClose
+}
+
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "computeUniverseForDate" ./provider/pvindex/`
+Expected: PASS for all 8 specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/chunk.go provider/pvindex/chunk_test.go
+git commit -m "feat(pvindex): add per-day universe computation"
+```
+
+---
+
+### Task 10: DB Loaders
+
+Database functions that read from the canonical published views. These are tested via integration tests against the real DB (no unit tests — the loaders are thin SQL wrappers).
+
+**Files:**
+- Create: `provider/pvindex/loader.go`
+
+- [ ] **Step 1: Create loader.go with four loader functions**
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/penny-vault/pvdata/data"
+	"github.com/rs/zerolog/log"
+)
+
+// loadCandidateAssets reads all rows from the `assets` view and returns those passing
+// the structural filter (active, CS, exchange whitelist, not LP).
+func loadCandidateAssets(ctx context.Context, pool *pgxpool.Pool) ([]*data.Asset, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadCandidateAssets: %w", err)
+	}
+	defer conn.Release()
+
+	all, err := data.ActiveAssets(ctx, conn, "assets")
+	if err != nil {
+		return nil, fmt.Errorf("load active assets: %w", err)
+	}
+
+	filtered := filterAssetMaster(all)
+
+	log.Debug().
+		Int("total_active", len(all)).
+		Int("after_structural_filter", len(filtered)).
+		Msg("loaded candidate assets")
+
+	return filtered, nil
+}
+
+// loadEodChunk reads EOD rows for the given FIGIs over [start, end] inclusive from
+// the `eod` published view. Returns a map keyed by composite_figi.
+func loadEodChunk(ctx context.Context, pool *pgxpool.Pool, figis []string, start, end time.Time) (map[string][]eodRow, error) {
+	if len(figis) == 0 {
+		return map[string][]eodRow{}, nil
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadEodChunk: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`SELECT composite_figi, event_date, close, volume
+		 FROM eod
+		 WHERE event_date BETWEEN $1 AND $2
+		   AND composite_figi = ANY($3)
+		 ORDER BY composite_figi, event_date`,
+		start, end, figis,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query eod chunk: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string][]eodRow)
+
+	for rows.Next() {
+		var (
+			figi    string
+			date    time.Time
+			closeP  float64
+			volume  float64
+		)
+
+		if err := rows.Scan(&figi, &date, &closeP, &volume); err != nil {
+			return nil, fmt.Errorf("scan eod row: %w", err)
+		}
+
+		out[figi] = append(out[figi], eodRow{Date: date, Close: closeP, Volume: volume})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate eod rows: %w", err)
+	}
+
+	return out, nil
+}
+
+// loadMarketCapAsOf reads the most recent market_cap on or before `asOf` for each FIGI
+// in the input. Used to populate per-day market cap lookups within a chunk.
+func loadMarketCapAsOf(ctx context.Context, pool *pgxpool.Pool, figis []string, asOf time.Time) (map[string]int64, error) {
+	if len(figis) == 0 {
+		return map[string]int64{}, nil
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadMarketCapAsOf: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`SELECT DISTINCT ON (composite_figi) composite_figi, market_cap
+		 FROM metrics
+		 WHERE composite_figi = ANY($1)
+		   AND event_date <= $2
+		   AND market_cap > 0
+		 ORDER BY composite_figi, event_date DESC`,
+		figis, asOf,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query market_cap: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]int64)
+
+	for rows.Next() {
+		var (
+			figi string
+			mcap int64
+		)
+
+		if err := rows.Scan(&figi, &mcap); err != nil {
+			return nil, fmt.Errorf("scan metric row: %w", err)
+		}
+
+		out[figi] = mcap
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate metric rows: %w", err)
+	}
+
+	return out, nil
+}
+
+// loadBroadMarketCaps returns the market caps of all CS rows on the broad pool baseline:
+// active CS on whitelisted exchanges with a metric row on or before `asOf`. Used as the
+// percentile baseline for the size and early-entry filters.
+func loadBroadMarketCaps(ctx context.Context, pool *pgxpool.Pool, asOf time.Time) ([]int64, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadBroadMarketCaps: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`WITH latest AS (
+		   SELECT DISTINCT ON (m.composite_figi) m.composite_figi, m.market_cap
+		   FROM metrics m
+		   JOIN assets a USING (composite_figi)
+		   WHERE a.active = true
+		     AND a.asset_type = 'CS'
+		     AND a.primary_exchange IN ('NASDAQ','NYSE','NYSE MKT','NYSE ARCA','BATS','AMEX','XNAS','XNYS','XASE','ARCX')
+		     AND m.event_date <= $1
+		     AND m.market_cap > 0
+		   ORDER BY m.composite_figi, m.event_date DESC
+		 )
+		 SELECT market_cap FROM latest`,
+		asOf,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query broad market caps: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]int64, 0, 5000)
+
+	for rows.Next() {
+		var mcap int64
+		if err := rows.Scan(&mcap); err != nil {
+			return nil, fmt.Errorf("scan broad mcap row: %w", err)
+		}
+		out = append(out, mcap)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate broad mcap rows: %w", err)
+	}
+
+	return out, nil
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./provider/pvindex/...`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add provider/pvindex/loader.go
+git commit -m "feat(pvindex): add canonical-view loaders for assets, eod, metrics"
+```
+
+---
+
+### Task 11: Date Range and Chunk Iteration
+
+Compute the dataset date range and iterate trading days in chunks.
+
+**Files:**
+- Create: `provider/pvindex/date_range.go`
+
+- [ ] **Step 1: Create date_range.go**
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// computeDateRange returns the [start, end] date range for the universe computation:
+// start = 200 trading days after MIN(metrics.event_date)
+// end = LEAST(MAX(eod.event_date), MAX(metrics.event_date))
+func computeDateRange(ctx context.Context, pool *pgxpool.Pool) (time.Time, time.Time, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("acquire conn for computeDateRange: %w", err)
+	}
+	defer conn.Release()
+
+	var (
+		minMetric, maxMetric, maxEod time.Time
+	)
+
+	if err := conn.QueryRow(ctx, `SELECT MIN(event_date), MAX(event_date) FROM metrics`).Scan(&minMetric, &maxMetric); err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("query metric date range: %w", err)
+	}
+
+	if err := conn.QueryRow(ctx, `SELECT MAX(event_date) FROM eod`).Scan(&maxEod); err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("query eod max date: %w", err)
+	}
+
+	// Find the 200th trading day after minMetric.
+	var startDate time.Time
+	if err := conn.QueryRow(ctx,
+		`SELECT dt FROM trading_days($1::date, $1::date + INTERVAL '400 days') AS t(dt)
+		 ORDER BY dt LIMIT 1 OFFSET 199`,
+		minMetric,
+	).Scan(&startDate); err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("compute start date: %w", err)
+	}
+
+	endDate := maxMetric
+	if maxEod.Before(endDate) {
+		endDate = maxEod
+	}
+
+	return startDate, endDate, nil
+}
+
+// chunkTradingDays loads trading days in [start, end] from the database and splits them
+// into fixed-size chunks. Each chunk is a slice of trading days.
+func chunkTradingDays(ctx context.Context, pool *pgxpool.Pool, start, end time.Time, chunkSize int) ([][]time.Time, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for chunkTradingDays: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, `SELECT dt FROM trading_days($1::date, $2::date) AS t(dt) ORDER BY dt`, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query trading days: %w", err)
+	}
+	defer rows.Close()
+
+	var allDays []time.Time
+
+	for rows.Next() {
+		var dt time.Time
+		if err := rows.Scan(&dt); err != nil {
+			return nil, fmt.Errorf("scan trading day: %w", err)
+		}
+		allDays = append(allDays, dt)
+	}
+
+	if len(allDays) == 0 {
+		return nil, nil
+	}
+
+	chunks := make([][]time.Time, 0, (len(allDays)/chunkSize)+1)
+	for i := 0; i < len(allDays); i += chunkSize {
+		end := i + chunkSize
+		if end > len(allDays) {
+			end = len(allDays)
+		}
+		chunks = append(chunks, allDays[i:end])
+	}
+
+	return chunks, nil
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./provider/pvindex/...`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add provider/pvindex/date_range.go
+git commit -m "feat(pvindex): add date range and trading-day chunking"
+```
+
+---
+
+### Task 12: Chunk Processor and Fetch Wiring
+
+The top-level orchestration. For each chunk: load EOD/metric/asset data once, iterate trading days, compute universe, diff against prior state, emit observations. Replaces the stub `fetchTradableUniverse` from Task 2.
+
+**Files:**
+- Modify: `provider/pvindex/chunk.go` (add `processChunk`)
+- Modify: `provider/pvindex/pvindex.go` (rewrite `fetchTradableUniverse` to call into chunk processor)
+
+- [ ] **Step 1: Append processChunk to chunk.go**
+
+Add to `provider/pvindex/chunk.go`:
+
+```go
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/penny-vault/pvdata/library"
+	"github.com/rs/zerolog"
+)
+
+// processChunk executes the universe computation for one chunk of trading days.
+// It loads source data once, iterates days, computes the universe, diffs against the
+// prior state, and emits observations to `out`. The prior state is loaded from the DB
+// at chunk start and maintained in memory across the chunk's days.
+func processChunk(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	sub *library.Subscription,
+	indexTicker string,
+	tradingDays []time.Time,
+	candidates []*data.Asset,
+	out chan<- *data.Observation,
+) error {
+	if len(tradingDays) == 0 {
+		return nil
+	}
+
+	logger := zerolog.Ctx(ctx)
+
+	chunkStart := tradingDays[0]
+	chunkEnd := tradingDays[len(tradingDays)-1]
+
+	// 200 trading days of EOD prefix before the chunk start.
+	loadStart := chunkStart.AddDate(0, 0, -400) // ~400 calendar days covers 200 trading days comfortably
+
+	figis := make([]string, len(candidates))
+	for i, a := range candidates {
+		figis[i] = a.CompositeFigi
+	}
+
+	logger.Info().
+		Time("chunk_start", chunkStart).
+		Time("chunk_end", chunkEnd).
+		Int("trading_days", len(tradingDays)).
+		Int("candidate_assets", len(candidates)).
+		Msg("loading chunk data")
+
+	eodByFigi, err := loadEodChunk(ctx, pool, figis, loadStart, chunkEnd)
+	if err != nil {
+		return fmt.Errorf("load eod chunk: %w", err)
+	}
+
+	// Reconstruct prior state from DB at chunk start.
+	prevState := provider.CurrentIndexMembers(
+		ctx,
+		pool,
+		sub.DataTablesMap[data.IndexSnapshotKey],
+		sub.DataTablesMap[data.IndexChangelogKey],
+		indexTicker,
+		chunkStart.AddDate(0, 0, -1),
+	)
+
+	for _, d := range tradingDays {
+		// Determine the trailing 200-trading-day window ending d-1.
+		windowDays, err := loadTrailingWindow(ctx, pool, d, minDayCountStandard)
+		if err != nil {
+			return fmt.Errorf("load trailing window for %s: %w", d.Format("2006-01-02"), err)
+		}
+		if len(windowDays) < minDayCountEarlyEntry {
+			logger.Warn().Time("date", d).Msg("insufficient trading days for window; skipping")
+			continue
+		}
+
+		windowStart := windowDays[0]
+		windowEnd := windowDays[len(windowDays)-1]
+
+		mcapByFigi, err := loadMarketCapAsOf(ctx, pool, figis, d)
+		if err != nil {
+			return fmt.Errorf("load market cap for %s: %w", d.Format("2006-01-02"), err)
+		}
+
+		broadMcaps, err := loadBroadMarketCaps(ctx, pool, d)
+		if err != nil {
+			return fmt.Errorf("load broad mcaps for %s: %w", d.Format("2006-01-02"), err)
+		}
+
+		input := perDayInput{
+			Date:            d,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: len(windowDays),
+			Assets:          candidates,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		newState := computeUniverseForDate(input)
+
+		adds, removes, weightChanges := provider.DiffSnapshotsWithThreshold(
+			newState,
+			prevState,
+			provider.DiffOptions{RelativeThreshold: 0.25},
+		)
+
+		ticker := indexTicker
+		obsTemplate := &data.Observation{
+			ObservationDate:  d,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		provider.EmitChangelog(adds, removes, ticker, d, obsTemplate, out)
+		provider.EmitWeightChanges(weightChanges, ticker, d, obsTemplate, out)
+
+		// Emit annual snapshot if a year has elapsed since the last in-DB snapshot,
+		// or if no snapshot has ever been taken (cold start).
+		lastSnapshot := provider.LastSnapshotDate(ctx, pool, sub.DataTablesMap[data.IndexSnapshotKey], indexTicker)
+		if provider.ShouldTakeSnapshot(lastSnapshot, d, "yearly") {
+			constituents := make([]data.IndexConstituent, 0, len(newState))
+			for tk, m := range newState {
+				constituents = append(constituents, data.IndexConstituent{
+					Ticker:        tk,
+					CompositeFigi: m.CompositeFigi,
+					Weight:        m.Weight,
+				})
+			}
+
+			out <- &data.Observation{
+				IndexSnapshot: &data.IndexSnapshot{
+					IndexTicker:  indexTicker,
+					SnapshotDate: d,
+					Constituents: constituents,
+				},
+				ObservationDate:  d,
+				SubscriptionID:   sub.ID,
+				SubscriptionName: sub.Name,
+			}
+		}
+
+		// Apply emitted changes to prevState in memory for the next day's diff.
+		for tk := range removes {
+			delete(prevState, tk)
+		}
+		for tk, m := range adds {
+			prevState[tk] = m
+		}
+		for tk, m := range weightChanges {
+			prevState[tk] = m
+		}
+	}
+
+	return nil
+}
+
+// loadTrailingWindow returns the trailing 200 trading days ending at (date - 1 trading day).
+func loadTrailingWindow(ctx context.Context, pool *pgxpool.Pool, asOf time.Time, n int) ([]time.Time, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadTrailingWindow: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`SELECT dt FROM (
+		   SELECT dt FROM trading_days($1::date - INTERVAL '400 days', $1::date - INTERVAL '1 day') AS t(dt)
+		   ORDER BY dt DESC
+		   LIMIT $2
+		 ) sub
+		 ORDER BY dt`,
+		asOf, n,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query trailing window: %w", err)
+	}
+	defer rows.Close()
+
+	var out []time.Time
+
+	for rows.Next() {
+		var dt time.Time
+		if err := rows.Scan(&dt); err != nil {
+			return nil, fmt.Errorf("scan trailing window day: %w", err)
+		}
+		out = append(out, dt)
+	}
+
+	return out, nil
+}
+```
+
+Note: the `import` block at the top of `chunk.go` from Task 9 has only `time` and `data` and `provider`. After this addition, the imports should also include `context`, `fmt`, `github.com/jackc/pgx/v5/pgxpool`, `github.com/penny-vault/pvdata/library`, and `github.com/rs/zerolog`. Combine into a single import block.
+
+- [ ] **Step 2: Replace fetchTradableUniverse in pvindex.go**
+
+In `provider/pvindex/pvindex.go`, replace the stub `fetchTradableUniverse` function from Task 2 with the real implementation:
+
+```go
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/library"
+	"github.com/penny-vault/pvdata/provider"
+	"github.com/rs/zerolog"
+)
+
+const (
+	defaultIndexTicker = "us-tradable"
+	defaultChunkSize   = 63
+)
+
+func fetchTradableUniverse(ctx context.Context, sub *library.Subscription, out chan<- *data.Observation, exit chan<- data.RunSummary) {
+	logger := zerolog.Ctx(ctx)
+	pool := sub.Library.Pool
+
+	runSummary := data.RunSummary{
+		StartTime:        time.Now(),
+		SubscriptionID:   sub.ID,
+		SubscriptionName: sub.Name,
+		Status:           data.RunSuccess,
+	}
+
+	defer func() {
+		runSummary.EndTime = time.Now()
+		exit <- runSummary
+	}()
+
+	indexTicker := defaultIndexTicker
+	if v := sub.Config["index_ticker"]; v != "" {
+		indexTicker = v
+	}
+
+	chunkSize := defaultChunkSize
+	if v := sub.Config["chunk_size_days"]; v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			chunkSize = n
+		}
+	}
+
+	startDate, endDate, err := computeDateRange(ctx, pool)
+	if err != nil {
+		logger.Error().Err(err).Msg("compute date range failed")
+		runSummary.Status = data.RunFailed
+		return
+	}
+
+	// Honor start_date_override.
+	if v := sub.Config["start_date_override"]; v != "" {
+		if t, err := time.Parse("2006-01-02", v); err == nil && t.After(startDate) {
+			startDate = t
+		}
+	}
+
+	// Incremental: skip dates already covered.
+	highWater := provider.LastSnapshotDate(ctx, pool, sub.DataTablesMap[data.IndexSnapshotKey], indexTicker)
+	if !highWater.IsZero() && highWater.After(startDate) {
+		startDate = highWater.AddDate(0, 0, 1)
+	}
+
+	if startDate.After(endDate) {
+		logger.Info().Msg("no new dates to process")
+		return
+	}
+
+	candidates, err := loadCandidateAssets(ctx, pool)
+	if err != nil {
+		logger.Error().Err(err).Msg("load candidate assets failed")
+		runSummary.Status = data.RunFailed
+		return
+	}
+
+	chunks, err := chunkTradingDays(ctx, pool, startDate, endDate, chunkSize)
+	if err != nil {
+		logger.Error().Err(err).Msg("chunk trading days failed")
+		runSummary.Status = data.RunFailed
+		return
+	}
+
+	totalObs := 0
+	for _, chunk := range chunks {
+		if err := processChunk(ctx, pool, sub, indexTicker, chunk, candidates, out); err != nil {
+			logger.Error().Err(err).Time("chunk_start", chunk[0]).Msg("process chunk failed")
+			runSummary.Status = data.RunFailed
+			return
+		}
+		totalObs += len(chunk)
+	}
+
+	runSummary.NumObservations = totalObs
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `go build ./...`
+Expected: clean build.
+
+- [ ] **Step 4: Run unit tests to ensure nothing regressed**
+
+Run: `ginkgo run -race ./provider/pvindex/`
+Expected: PASS (the existing unit tests don't depend on processChunk, so they should still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/pvindex/chunk.go provider/pvindex/pvindex.go
+git commit -m "feat(pvindex): add chunk processor and Fetch wiring"
+```
+
+---
+
+### Task 13: Integration Test (SCOPED OUT)
+
+**This task was removed during execution.** Per project preference, pv-data does not have build-tag integration tests that depend on a real database connection. The filter-chain logic is covered by the unit tests in Task 9 with synthetic in-memory fixtures.
+
+The original integration test (a build-tag `integration_test.go` that called `pgxpool.New` and ran the loaders against `PV_TEST_DATABASE_URL`) did catch two real production bugs in the DB-side SQL: `trading_days(date, date)` was being called with `date + INTERVAL` arguments that resolve to `timestamp without time zone`, causing `function does not exist` errors at runtime. Both occurrences (in `computeDateRange` and `loadTrailingWindow`) were fixed in commit `a25e617` with explicit `::date` casts. The integration test itself was then removed.
+
+The loader functions (`loadCandidateAssets`, `loadEodChunk`, `loadMarketCapAsOf`, `loadBroadMarketCaps`, `computeDateRange`, `chunkTradingDays`, `loadTrailingWindow`) remain untested by automated tests. They are thin SQL wrappers and should be exercised manually via Task 14 step 5 (smoke test against real DB) before merging.
+
+Original spec preserved below for reference:
+
+**Files:**
+- Create: `provider/pvindex/integration_test.go`
+
+- [ ] **Step 1: Create the integration test**
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package pvindex
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("pvindex integration", Ordered, func() {
+	var (
+		ctx  context.Context
+		pool *pgxpool.Pool
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+
+		dburl := os.Getenv("PV_TEST_DATABASE_URL")
+		if dburl == "" {
+			Skip("PV_TEST_DATABASE_URL not set; skipping integration test")
+		}
+
+		var err error
+		pool, err = pgxpool.New(ctx, dburl)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		if pool != nil {
+			pool.Close()
+		}
+	})
+
+	It("computes a date range that brackets 1999 to today", func() {
+		start, end, err := computeDateRange(ctx, pool)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(start.Year()).To(BeNumerically(">=", 1999))
+		Expect(start.Year()).To(BeNumerically("<=", 2000))
+		Expect(end.After(start)).To(BeTrue())
+	})
+
+	It("loads candidate assets and finds at least 1000 of them", func() {
+		assets, err := loadCandidateAssets(ctx, pool)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(assets)).To(BeNumerically(">=", 1000))
+	})
+
+	It("loads broad market caps for a recent date", func() {
+		asOf, _ := time.Parse("2006-01-02", "2024-01-08")
+		caps, err := loadBroadMarketCaps(ctx, pool, asOf)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(caps)).To(BeNumerically(">=", 1000))
+	})
+
+	It("loads EOD chunk for one stock over 30 days", func() {
+		start, _ := time.Parse("2006-01-02", "2024-01-01")
+		end, _ := time.Parse("2006-01-02", "2024-01-31")
+		out, err := loadEodChunk(ctx, pool, []string{"BBG000B9XRY4"}, start, end) // AAPL
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(HaveKey("BBG000B9XRY4"))
+		Expect(len(out["BBG000B9XRY4"])).To(BeNumerically(">=", 15)) // ~20 trading days in Jan
+	})
+
+	// End-to-end test: actually compute the universe for one date and verify
+	// known stocks are included/excluded.
+	It("computes the universe for 2024-12-31 with expected membership", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart, _ := time.Parse("2006-01-02", "2024-03-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-12-30")
+
+		assets, err := loadCandidateAssets(ctx, pool)
+		Expect(err).ToNot(HaveOccurred())
+
+		figis := make([]string, len(assets))
+		for i, a := range assets {
+			figis[i] = a.CompositeFigi
+		}
+
+		eodByFigi, err := loadEodChunk(ctx, pool, figis, windowStart, windowEnd)
+		Expect(err).ToNot(HaveOccurred())
+
+		mcapByFigi, err := loadMarketCapAsOf(ctx, pool, figis, evalDate)
+		Expect(err).ToNot(HaveOccurred())
+
+		broadMcaps, err := loadBroadMarketCaps(ctx, pool, evalDate)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Approximate trading day count: count rows in the trading_days function for the window.
+		conn, err := pool.Acquire(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		defer conn.Release()
+
+		var tdCount int
+		err = conn.QueryRow(ctx, `SELECT COUNT(*) FROM trading_days($1::date, $2::date)`, windowStart, windowEnd).Scan(&tdCount)
+		Expect(err).ToNot(HaveOccurred())
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: tdCount,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+
+		// Sanity bounds.
+		Expect(len(universe)).To(BeNumerically(">", 500))
+		Expect(len(universe)).To(BeNumerically("<", 4000))
+
+		// AAPL must be in the universe.
+		Expect(universe).To(HaveKey("AAPL"))
+		// Weights sum to 1.0 within float tolerance.
+		var sum float64
+		for _, m := range universe {
+			sum += m.Weight
+		}
+		Expect(sum).To(BeNumerically("~", 1.0, 1e-6))
+	})
+})
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `PV_TEST_DATABASE_URL="postgres://pennyvault@localhost:5432/pvdb?sslmode=disable" ginkgo run -race --tags=integration ./provider/pvindex/`
+Expected: PASS for all 5 specs. The end-to-end test should report a universe size in the 1500-2500 range with weights summing to 1.0.
+
+If the database URL or credentials differ, adjust the env var. The test skips when `PV_TEST_DATABASE_URL` is unset.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add provider/pvindex/integration_test.go
+git commit -m "test(pvindex): add integration tests against canonical views"
+```
+
+---
+
+### Task 14: Lint, Final Build, Spec & Plan Commit
+
+Wrap up: run linters, full build, and commit the design spec and plan together with the implementation.
+
+- [ ] **Step 1: Run lint**
+
+Run: `make lint`
+Expected: zero errors. Fix any reported issues with `golangci-lint run --fix` and re-run.
+
+- [ ] **Step 2: Full unit test run**
+
+Run: `make test`
+Expected: zero failures across the entire repo.
+
+- [ ] **Step 3: Full build**
+
+Run: `make build`
+Expected: clean build of the `pvdata` binary.
+
+- [ ] **Step 4: Commit the spec and plan**
+
+The design spec and implementation plan have been on disk since the brainstorming session. Commit them now alongside a final tag commit:
+
+```bash
+git add docs/superpowers/specs/2026-04-07-pvindex-tradable-universe-design.md docs/superpowers/plans/2026-04-07-pvindex-tradable-universe.md
+git commit -m "docs: add pvindex tradable universe design spec and implementation plan"
+```
+
+- [ ] **Step 5: Manual smoke test against real DB (optional, requires DB access)**
+
+If you want to verify the provider runs end-to-end through the normal subscription path (not just unit/integration tests):
+
+1. Create a `pvindex` subscription via the CLI: `pvdata subscription add` and select provider `pvindex`, dataset `US Tradable Universe`, with config `start_date_override = 2024-12-01` to limit the run.
+2. Run it on demand: `pvdata run <subscription-id>`.
+3. Inspect the resulting tables: `SELECT COUNT(*), MIN(snapshot_date), MAX(snapshot_date) FROM <pvindex_index_snapshot_table>;` and `SELECT COUNT(*) FROM <pvindex_index_changelog_table>;`.
+
+Expected:
+- 1 snapshot (the year boundary at 2025-01-01, plus the cold-start day 2024-12-02).
+- Several hundred to several thousand changelog rows from the daily computation.
+- No errors in `run_history` for the subscription.
+
+This step is optional but recommended for the human reviewer before merging.

--- a/docs/superpowers/specs/2026-04-07-pvindex-tradable-universe-design.md
+++ b/docs/superpowers/specs/2026-04-07-pvindex-tradable-universe-design.md
@@ -1,0 +1,349 @@
+# pvindex Tradable Universe Provider Design
+
+## Overview
+
+A new provider (`provider/pvindex/`) that produces a daily-recomputed investable universe of US-listed common stocks, published as an index named `us-tradable` using the existing `IndexSnapshot` and `IndexChange` schemas.
+
+Unlike every other provider in the codebase, `pvindex` does not fetch from an external source. It is a **derived** provider: it reads from the canonical published views (`eod`, `metrics`, `assets`) and computes membership locally by applying a deterministic filter chain. This makes it the first member of a new provider category — derived/computed providers — but it does not require any change to the `Provider` interface.
+
+The output matches the schema and conventions used by existing index providers (iShares, Nasdaq), so downstream consumers query it identically: `SELECT constituents FROM indices_snapshot WHERE index_ticker='us-tradable' AND snapshot_date=$1`.
+
+## Goals
+
+- Provide a single canonical "investable universe" that backtests and live strategies can use as a starting screen.
+- Adapt to market conditions over time — no fixed dollar thresholds that go stale.
+- Backfill historically as far back as the source data supports (~1999, bounded by `metrics` coverage).
+- Match the existing index provider pattern (annual snapshots + daily changelog) so consumers and tooling work without modification.
+- Capture distressed-recovery and large IPO names that strict filters historically exclude.
+
+## Non-Goals
+
+- Real-time intraday recomputation — this is end-of-day only.
+- Tracking exact daily cap-weights via snapshots — weights are emitted via changelog `weight-change` events between annual snapshots; consumers needing exact daily weights should recompute from `metrics` at query time.
+- Multiple universe variants in the initial release — only `us-tradable` ships. The provider is designed so additional universes can be added later without rework.
+
+## Data Sources
+
+The provider reads exclusively from canonical published views, never from subscription-specific tables. This insulates it from vendor changes and lets the published-view machinery handle multi-vendor multiplexing transparently.
+
+- `assets` — security master (ticker, name, asset_type, primary_exchange, cik, composite_figi, share_class_figi, active)
+- `eod` — daily OHLCV (close, volume, event_date, composite_figi)
+- `metrics` — daily valuation metrics, used for `market_cap` (event_date, composite_figi, market_cap)
+
+The provider writes to per-subscription tables produced for the `index-snapshot` and `index-changelog` data types, exactly like every other index provider. After the subscription is created and backfilled, an operator may register the snapshot/changelog tables as additional sources on the canonical `indices_snapshot` and `indices_changelog` published views, alongside other index sources (e.g., the existing Sharadar SPX entries). Since `index_ticker='us-tradable'` is unique, no row-level conflicts occur.
+
+## Universe Definition
+
+For each evaluation date `D`, the universe is computed as follows. The order matters — filters that are cheap or that establish denominators run first.
+
+### 1. Asset master filter
+
+Apply once per backfill chunk against `assets`:
+
+- `active = true`
+- `asset_type = 'CS'` — common stock only, by inclusion. (Excluding by enumerating `PS`/`ETF`/`ETN`/`CEF`/`MF`/`ADRC`/`SYNTH`/`INDEX` would be brittle as new asset types are added.)
+- `primary_exchange IN ('NASDAQ', 'NYSE', 'NYSE MKT', 'NYSE ARCA', 'BATS', 'AMEX', 'XNAS', 'XNYS', 'XASE', 'ARCX')` — see "Known limitation: exchange field inconsistency" below.
+- `name` does **not** end in any of: `LP`, `L.P.`, `L P`, `LLP`, `Limited Partnership` (case-insensitive, suffix match). LPs are stored as `CS` in the asset master and must be excluded explicitly. Suffix matching avoids false positives like "Marsh & McLennan Companies" while reliably catching "Enterprise Products LP".
+
+### 2. Load EOD and metric data for the chunk window
+
+Single bulk query per chunk; details in "Data Flow" below.
+
+### 3. Compute rolling-window stats per FIGI
+
+For each candidate, compute over the trailing window ending `D - 1 trading day`:
+
+- `day_count` — number of EOD rows present in the trailing window.
+- `median_dv` — median of `close * volume` over those rows.
+
+The trailing window is `min(day_count, 200)` trading days. For stocks with full history, this is the trailing 200. For early-entry IPOs (see step 5), it is the available 30–199 days. Median is robust to the IPO-pop outlier days, so even a 30-day window gives a usable signal. Computed once per FIGI per chunk and reused by downstream filters.
+
+### 4. Define the percentile baseline
+
+The "broad CS pool on `D`" used by the percentile filters in steps 5 and 7 is computed once per `D` and consists of:
+
+- All assets passing the structural filter from step 1, AND
+- having a `metrics.market_cap` row dated ≤ `D`, AND
+- after share-class deduplication (step 6 logic, applied to this set without the percentile filters yet).
+
+Note this baseline is **not contingent on EOD availability** — it uses market cap data only. This avoids a circular dependency between the data availability check and the percentile threshold it consults. The percentile is the canonical "size of all US-listed common stocks on `D`" that both the early-entry rule (top 20%) and the size filter (bottom 25%) reference.
+
+### 5. Data availability check
+
+A stock qualifies for the universe on `D` if it satisfies one of:
+
+- **Standard path**: `day_count >= 200` (200 contiguous trading days of EOD data ending `D - 1`), AND a `metrics.market_cap` row dated ≤ `D`.
+- **Early-entry path** (for recent IPOs): `30 <= day_count < 200`, AND a `metrics.market_cap` row dated ≤ `D`, AND market cap on `D` is in the **top 20% (80th percentile)** of the broad CS pool on `D` (per step 4 baseline).
+
+The early-entry path lets large recent IPOs (Meta, Snowflake, Uber, DoorDash, Airbnb, Palantir, Reddit) enter the universe roughly six weeks after listing instead of waiting ~10 months. The 80th-percentile threshold was empirically validated: every major IPO from 2004–2024 in our dataset clears it; smaller IPOs do not.
+
+The contiguity check is exact: `day_count == count(trading_days(window))`. No fuzzing — even one missing day disqualifies a stock for that day.
+
+### 6. Share-class deduplication
+
+Group survivors by `cik`. Within each group, keep the row with the highest median dollar volume (from step 3). For the ~7% of CS rows missing CIK, use `composite_figi` as the grouping key (yielding singletons that cannot collide).
+
+This step is necessary because multi-class companies (GOOG/GOOGL, BRK/A/BRK/B, BF/A/BF/B, FOX/FOXA) appear as separate rows in `assets` with the same CIK. We keep the most-traded class per company. Note: `share_class_figi` does **not** group multi-class companies in OpenFIGI's scheme — it groups same-class-across-countries. CIK is the correct grouping key.
+
+### 7. Market cap percentile filter
+
+Apply the 25th percentile of the broad CS pool baseline (from step 4) to the survivors of steps 1–6. Drop everything strictly below that threshold.
+
+Using a percentile rather than a fixed dollar threshold means the cutoff adapts to market conditions over time: the threshold in 1999 dollars naturally differs from 2026 dollars without manual recalibration.
+
+### 8. Liquidity filter
+
+Median dollar volume (from step 3) `≥ $2,500,000`.
+
+### 9. Price guard rail
+
+`prior_close ≥ $2.00`. The `$2` floor was chosen empirically — see "Price floor: $2" in the appendix. It excludes the broken sub-dollar cohort and the smallest distressed names while still admitting recognizable multi-billion-dollar companies that trade at low nominal prices (BlackBerry, Newell Brands, Coty, Transocean, etc.).
+
+### 10. Cap-weight assignment
+
+For each survivor `i`: `weight_i = market_cap_i / Σ market_cap_j`. Weights sum to 1.0 within float tolerance.
+
+## Output Format
+
+The provider emits two observation types using the existing `IndexSnapshot` and `IndexChange` schemas. No new data types or migrations are required.
+
+### Annual snapshots
+
+On the first trading day of each calendar year (and on the very first day of any backfill range), the provider emits a single `IndexSnapshot` observation containing the full constituent list with cap-weights as of that day. Snapshot frequency is `"yearly"` via the existing `ShouldTakeSnapshot` helper, matching the pvbt convention used by iShares and Nasdaq.
+
+```go
+data.IndexSnapshot{
+    IndexTicker:  "us-tradable",
+    SnapshotDate: D,
+    Constituents: []data.IndexConstituent{
+        {Ticker: "AAPL", CompositeFigi: "BBG000B9XRY4", Weight: 0.0451},
+        ...
+    },
+}
+```
+
+### Daily changelog
+
+For every trading day `D` (including snapshot days), the provider compares the freshly-computed universe against the prior-day reconstructed state and emits `IndexChange` observations:
+
+- **Adds**: stocks in the new universe that were not in the prior state. Action `"add"`. Weight = cap-weight on `D`.
+- **Removes**: stocks in the prior state that are not in the new universe. Action `"remove"`. Weight unset (0).
+- **Weight changes**: stocks present in both, whose new weight differs from the previously-recorded weight by `≥ 25% relative` (i.e., `|new - prev| ≥ 0.25 * prev`). Action `"weight-change"`. Weight = cap-weight on `D`.
+
+The 25% relative threshold replaces the existing absolute `WeightChangeThreshold = 0.01` for this provider. For a ~3,000-name universe where each weight is ~0.03%, the absolute threshold would essentially never fire; the relative threshold scales naturally to universe size.
+
+### Snapshot weight semantics
+
+The annual snapshot captures cap-weights as of the snapshot day. Throughout the year, `weight-change` events update the canonical state for any constituent whose weight has drifted ≥25% relative since its previously-recorded weight. A stable mega-cap typically emits one `weight-change` per year; a fast-mover may emit several. Storage scales with churn, not membership size.
+
+## Package Structure
+
+```
+provider/pvindex/
+  pvindex.go              # Provider registration, dataset definition, Fetch entry point
+  filter.go               # Filter chain (asset master, contiguity, share-class dedup, percentile, liquidity, price)
+  loader.go               # Chunked EOD/metric loading from canonical views
+  rolling.go              # In-memory rolling 200-day median computation
+  diff.go                 # Cap-weight calculation, snapshot vs prior-state diffing
+  pvindex_test.go         # Unit tests
+  pvindex_suite_test.go   # Ginkgo suite
+  integration_test.go     # Build tag `integration` — DB-backed end-to-end test
+  testdata/               # Synthetic EOD/metric fixtures for unit tests
+```
+
+The new provider is registered in `cmd/providers_register.go` via blank import:
+
+```go
+import _ "github.com/penny-vault/pvdata/provider/pvindex"
+```
+
+## Provider Interface
+
+Registers as `"pvindex"` implementing the existing `Provider` interface.
+
+- **`Name()`**: `"pvindex"`
+- **`Description()`**: `"Derived index provider that computes investable universes from canonical EOD, metric, and asset views"`
+- **`ConfigDescription()`**:
+  - `index_ticker` — optional, default `"us-tradable"`. Override only to publish a parallel-tuned universe (e.g., `us-tradable-strict`) without modifying source data.
+  - `start_date_override` — optional, default empty. Forces a later start date during testing or selective backfill.
+  - `chunk_size_days` — optional, default `63`. Tuning knob; not user-facing in normal operation.
+- **`Datasets()`**: one dataset, `"US Tradable Universe"`.
+
+```go
+"US Tradable Universe": provider.Dataset{
+    Name:        "US Tradable Universe",
+    Description: "Daily-recomputed investable universe of US common stocks: structural + liquidity + size + price filters with annual cap-weighted snapshots",
+    DataTypes:   []*data.DataType{data.DataTypes[data.IndexSnapshotKey], data.DataTypes[data.IndexChangelogKey]},
+    DateRange:   computeDateRange,
+    TTL:         0,
+    Fetch:       fetchTradableUniverse,
+}
+```
+
+`computeDateRange` queries the canonical views at fetch time:
+
+- **Start**: 200 trading days after `MIN(event_date) FROM metrics`. With `metrics` starting 1998-07-16, this gives roughly 1999-04-30.
+- **End**: `LEAST(MAX(event_date) FROM eod, MAX(event_date) FROM metrics)`. We cannot compute past the date where market cap data ends.
+
+## Data Flow
+
+### Backfill (cold start)
+
+```
+Determine date range from canonical views
+  -> chunk into 63-trading-day windows
+  -> for each chunk [d1..dn]:
+     -> single query: SELECT * FROM eod WHERE event_date BETWEEN (d1 - 200d) AND dn AND composite_figi IN candidates
+     -> single query: SELECT * FROM metrics WHERE event_date BETWEEN (d1 - 200d) AND dn AND composite_figi IN candidates
+     -> hold in memory: map[composite_figi][]eodRow, sorted by date
+     -> for each trading day d in [d1..dn]:
+        -> compute trailing-200d median dollar volume by rolling window (no DB I/O)
+        -> apply filter chain (Section "Universe Definition")
+        -> reconstruct prior state from in-memory cursor
+        -> diff -> add/remove/weight-change events
+        -> emit IndexChange observations
+        -> if d is the first trading day of a calendar year (or d == d1 of cold start), emit IndexSnapshot
+     -> reload prior state from DB at the start of the next chunk (single point of truth)
+```
+
+Memory bound per chunk: ~6,000 candidate stocks × 263 days × ~50 bytes per EOD row ≈ 80 MB. Comfortable.
+
+### Incremental run (scheduled)
+
+```
+high water mark = MAX(snapshot_date, last changelog event_date) for index_ticker='us-tradable'
+firstDay = high_water_mark + 1 trading day
+lastDay = end of computeDateRange()
+if firstDay > lastDay:
+    emit empty RunSummary, return
+otherwise: process [firstDay..lastDay] in chunks (same code path as backfill)
+```
+
+This naturally handles three cases identically: cold-start backfill, routine daily run (one new day), and gap recovery (provider was down for a week).
+
+## Helper Changes
+
+Two minimal additions to existing helpers in `provider/index_helpers.go`:
+
+### 1. `DiffSnapshotsWithThreshold`
+
+The existing `DiffSnapshots` is unchanged. A new variant accepts a threshold mode:
+
+```go
+type DiffOptions struct {
+    AbsoluteThreshold float64 // existing 0.01 default for absolute mode
+    RelativeThreshold float64 // 0 = disabled; for pvindex, 0.25 (25%)
+}
+
+func DiffSnapshotsWithThreshold(current, previous map[string]IndexMember, opts DiffOptions) (added, removed, weightChanged map[string]IndexMember)
+```
+
+Logic: a weight is considered changed when `|delta| >= max(opts.AbsoluteThreshold, prev.Weight * opts.RelativeThreshold)`. Existing iShares/Nasdaq callers continue to use the original `DiffSnapshots` (zero-touch).
+
+### 2. In-process state caching across the chunk
+
+The pvindex loader maintains `prevState map[string]IndexMember` in memory across the chunk's days, applying each day's emitted changes locally instead of round-tripping to the DB. The DB version remains the source of truth across chunk boundaries: each new chunk reloads from DB via `CurrentIndexMembers`.
+
+This is a usage pattern, not a helper change — `CurrentIndexMembers` is called once per chunk start.
+
+## Edge Cases and Known Limitations
+
+### Edge cases
+
+- **EOD data gaps within the 200-day window**: A stock with even one missing trading day inside the trailing 200 fails the contiguity check and is excluded for that day. By design.
+- **New IPOs**: Handled by the early-entry path (Section "Universe Definition" step 5). Stocks under 30 days old are always excluded.
+- **Stock with valid 200d EOD but no market cap on D**: Excluded silently. Logged at DEBUG level once per chunk; promoted to WARN if exclusion count exceeds 10% of candidates (signals a real metric data gap).
+- **CIK collisions across genuinely-different companies**: Rare. Share-class dedup keeps the row with highest median dollar volume per CIK; if two unrelated companies share a CIK, one is dropped. Acceptable trade-off; flagged here as a known limitation.
+- **Stock with no CIK**: Falls back to `composite_figi` as the grouping key, becoming a singleton. Cannot collide with other rows.
+- **Snapshot table conflicts on re-run**: `IndexSnapshot.SaveDB` already upserts on `(index_ticker, snapshot_date)`. Re-runs are idempotent.
+- **Changelog reconciliation on re-run**: `IndexChange.SaveDB` upserts on `(composite_figi, index_ticker, event_date)`. Multiple changes for the same FIGI on the same day collapse to one row (last write wins). The filter chain is deterministic, so re-running on the same date produces identical output.
+- **Empty universe day**: Mathematically possible. Emits a snapshot with empty constituents list; consumers should treat as "no data" rather than "universe is empty".
+- **Backfill dates before sufficient market cap data**: Excluded by `DateRange.Start`. The provider never attempts to compute the universe for dates outside the date range.
+
+### Known limitations
+
+- **Exchange field inconsistency**: The `assets.primary_exchange` column is mostly populated with display names (`NASDAQ`, `NYSE`, `NYSE MKT`, `NYSE ARCA`, `BATS`, `AMEX`) but the Go constants in `data/asset.go` use MIC codes (`XNAS`, `XNYS`, `XASE`, `ARCX`, `BATS`). The provider's exchange whitelist accepts both formats as a workaround. **The underlying inconsistency should be fixed by a separate cleanup task** that normalizes the field across source providers, after which the whitelist can drop the display-name aliases.
+- **ADRs are excluded by design**: Major foreign listings (BABA, JD, BIDU) are classified as `ADRC` and never enter the universe. Per the original spec ("exclude... ADRs"), this is intentional.
+- **Sharadar metric data ends 2026-01-08**: Until a newer metric source is published, `DateRange.End` is bounded by the metric data even though `eod` extends further. The provider correctly computes this bound at runtime.
+
+## Testing Strategy
+
+Three layers of tests, following the project's Ginkgo + Gomega convention.
+
+### Unit tests (`provider/pvindex/`)
+
+- LP suffix matcher: table-driven cases including positive matches ("Enterprise Products LP", "Brookfield Infrastructure L.P.") and negatives ("Marsh & McLennan Companies", "MetLife Inc").
+- Asset master filter: structural inclusion/exclusion against synthetic asset rows.
+- Rolling 200-day median: known-input fixtures with expected median.
+- Contiguity check: synthetic EOD slices with and without gaps.
+- Share-class dedup: multi-class company fixtures (GOOG/GOOGL with synthetic dollar volumes), CIK-fallback case.
+- Market cap percentile filter: known distribution, verify cutoff.
+- Cap-weight normalization: weights sum to 1.0 within float tolerance.
+- Early-entry path: stock with 50 days of data + top-quintile market cap passes; same stock with bottom-quintile cap is excluded.
+- `DiffSnapshotsWithThreshold`: table-driven cases for both absolute and relative threshold modes; verify backwards compat with `DiffSnapshots`.
+
+### Integration tests (`provider/pvindex/integration_test.go`, build tag `integration`)
+
+- Backfill a single test month (e.g., 2023-01-01 to 2023-01-31) against the real DB.
+- Assertions:
+  - Snapshot row count = 1 (year boundary at 2023-01-03).
+  - Changelog event count is non-zero.
+  - All emitted constituents have non-empty `composite_figi`.
+  - All snapshot weights sum to 1.0 within float tolerance.
+  - A known liquid CS (e.g., AAPL) is in the universe on 2023-01-31.
+  - A known LP (e.g., EPD) is NOT in the universe.
+  - A known ADRC (e.g., BABA) is NOT in the universe.
+- Re-run the same test month and assert idempotency: snapshot/changelog row counts unchanged, no duplicates.
+
+## Configuration and Operations
+
+Subscription configuration is minimal:
+
+- No source-data subscription IDs (reads from canonical views).
+- No vendor API keys.
+- Optional overrides only (`index_ticker`, `start_date_override`, `chunk_size_days`).
+
+Operationally, the subscription is:
+
+1. Created via the standard subscription UI/CLI, selecting provider `pvindex` and dataset `US Tradable Universe`.
+2. Backfilled by running it on-demand once. Initial backfill scans ~6,500 trading days from 1999-04-30 to today.
+3. Scheduled for daily incremental runs after market close.
+4. Optionally registered as an additional source on the canonical `indices_snapshot` and `indices_changelog` published views, so consumers can query `SELECT * FROM indices_snapshot WHERE index_ticker='us-tradable'` through the canonical interface.
+
+## Appendix: Empirical calibrations
+
+These thresholds were validated against the actual data in the database before being chosen.
+
+### Price floor: $2
+
+Three thresholds were measured against today's data (2026-01-08), four crisis dates (2009-03-09, 2020-03-23, 2022-10-12, 2023-03-13), and the cohort that passes ADV ≥ $2.5M:
+
+- **$5 floor**: excludes 192 names today (~7% of investable universe), including BlackBerry ($2.2B), Newell Brands ($1.7B), Coty ($2.6B), Transocean ($4.5B), Plug Power ($3.1B), and other multi-billion-dollar real companies. Rejected.
+- **$1 floor**: excludes only 12 names today, but includes Kosmos Energy ($433M, $0.92), Chegg ($104M, $0.93), and a small cohort of distressed-but-recoverable names. Loses some real distressed-value plays.
+- **$2 floor (chosen)**: catches the genuinely-broken sub-dollar cohort plus the AGL/CHGG/MVIS-class distressed names whose fundamentals are usually unsalvageable, while keeping the BlackBerry/Newell/Coty cohort that has strong businesses despite low nominal prices.
+
+### IPO early-entry market cap threshold: top 20% (80th percentile)
+
+Validated against ten major IPOs from 2004–2024:
+
+| Ticker | IPO date | IPO market cap | Percentile rank | Top 10%? | Top 20%? |
+|---|---|---|---|---|---|
+| GOOGL | 2004-08-19 | $27.2B | — | YES | YES |
+| META | 2012-05-18 | $81.7B | — | YES | YES |
+| LYFT | 2019-03-29 | $22.2B | — | YES | YES |
+| UBER | 2019-05-10 | $69.7B | — | YES | YES |
+| SNOW | 2020-09-16 | $70.4B | — | YES | YES |
+| PLTR | 2020-09-30 | $15.7B | 88.8% | no | YES |
+| DASH | 2020-12-09 | $60.2B | — | YES | YES |
+| ABNB | 2020-12-10 | $86.5B | — | YES | YES |
+| RDDT | 2024-03-21 | $8.0B | 83.2% | no | YES |
+
+Top decile (90th percentile) misses Palantir and Reddit. Top quintile (80th percentile) catches both while still being demanding enough that it cannot pass mid-cap or smaller IPOs.
+
+### Snapshot frequency: annual
+
+Matches the pvbt convention used by iShares and Nasdaq providers. Daily snapshots were considered and rejected as inconsistent with the project's existing index pattern. Weekly/monthly were considered for fresher cap-weights but rejected in favor of using `weight-change` changelog events with a relative threshold to track drift between annual snapshots.
+
+### Weight-change threshold: 25% relative
+
+The existing `WeightChangeThreshold = 0.01` (1% absolute) is calibrated for SPX-style indices where each constituent is several percent of the index. For a ~3,000-name universe where each weight averages ~0.03%, a 1% absolute threshold would essentially never fire. A 25% relative threshold scales naturally: a constituent's weight emits a `weight-change` when it has drifted by at least 25% of its previously-recorded value. Stable mega-caps emit ~1 event/year; fast-movers emit several. Storage scales with churn, not size.

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -97,6 +97,57 @@ func DiffSnapshots(current, previous map[string]IndexMember) (added, removed, we
 	return
 }
 
+// DiffOptions configures DiffSnapshotsWithThreshold weight-change detection.
+// A weight is considered changed when |delta| >= max(AbsoluteThreshold, prev.Weight * RelativeThreshold).
+// If RelativeThreshold is 0, only the absolute threshold applies.
+type DiffOptions struct {
+	AbsoluteThreshold float64 // absolute weight delta required (e.g., 0.01)
+	RelativeThreshold float64 // fraction of previous weight (e.g., 0.25 = 25%)
+}
+
+// DiffSnapshotsWithThreshold compares current holdings against previous holdings using
+// configurable thresholds for weight-change detection. Adds and removes are reported
+// regardless of threshold settings.
+func DiffSnapshotsWithThreshold(current, previous map[string]IndexMember, opts DiffOptions) (added, removed, weightChanged map[string]IndexMember) {
+	added = make(map[string]IndexMember)
+	removed = make(map[string]IndexMember)
+	weightChanged = make(map[string]IndexMember)
+
+	for ticker, member := range current {
+		prev, ok := previous[ticker]
+		if !ok {
+			added[ticker] = member
+			continue
+		}
+
+		delta := member.Weight - prev.Weight
+		if delta < 0 {
+			delta = -delta
+		}
+
+		threshold := opts.AbsoluteThreshold
+
+		relTh := prev.Weight * opts.RelativeThreshold
+		if relTh > threshold {
+			threshold = relTh
+		}
+
+		if delta >= threshold-1e-12 && delta > 0 {
+			// Note: we keep the legacy >= behavior of DiffSnapshots; the -1e-12 avoids
+			// strict floating-point edge cases when threshold == 0 + delta == 0.
+			weightChanged[ticker] = member
+		}
+	}
+
+	for ticker, member := range previous {
+		if _, ok := current[ticker]; !ok {
+			removed[ticker] = member
+		}
+	}
+
+	return
+}
+
 // LastSnapshotDate queries the database for the most recent snapshot date for the given index.
 func LastSnapshotDate(ctx context.Context, pool *pgxpool.Pool, table, indexTicker string) time.Time {
 	conn, err := pool.Acquire(ctx)

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -99,7 +99,9 @@ func DiffSnapshots(current, previous map[string]IndexMember) (added, removed, we
 
 // DiffOptions configures DiffSnapshotsWithThreshold weight-change detection.
 // A weight is considered changed when |delta| >= max(AbsoluteThreshold, prev.Weight * RelativeThreshold).
-// If RelativeThreshold is 0, only the absolute threshold applies.
+// If RelativeThreshold is 0, only the absolute threshold applies. If both thresholds are
+// zero (the struct zero value), every non-zero weight delta is reported as a change —
+// callers should set at least one threshold explicitly.
 type DiffOptions struct {
 	AbsoluteThreshold float64 // absolute weight delta required (e.g., 0.01)
 	RelativeThreshold float64 // fraction of previous weight (e.g., 0.25 = 25%)
@@ -127,14 +129,14 @@ func DiffSnapshotsWithThreshold(current, previous map[string]IndexMember, opts D
 
 		threshold := opts.AbsoluteThreshold
 
-		relTh := prev.Weight * opts.RelativeThreshold
-		if relTh > threshold {
-			threshold = relTh
+		relThreshold := prev.Weight * opts.RelativeThreshold
+		if relThreshold > threshold {
+			threshold = relThreshold
 		}
 
-		if delta >= threshold-1e-12 && delta > 0 {
-			// Note: we keep the legacy >= behavior of DiffSnapshots; the -1e-12 avoids
-			// strict floating-point edge cases when threshold == 0 + delta == 0.
+		// Skip unchanged weights; the 1e-9 epsilon tolerates floating-point
+		// representation noise at the threshold boundary, matching DiffSnapshots.
+		if delta > 0 && delta >= threshold-1e-9 {
 			weightChanged[ticker] = member
 		}
 	}

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -262,6 +262,18 @@ var _ = Describe("diffSnapshotsWithThreshold", func() {
 		Expect(removes).To(HaveKey("OLD1"))
 	})
 
+	It("detects weight change exactly at the absolute threshold", func() {
+		// delta = 0.01 exactly; threshold = 0.01. Matches legacy DiffSnapshots boundary behavior.
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.06},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+		}
+		_, _, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{AbsoluteThreshold: 0.01})
+		Expect(weightChanges).To(HaveKey("AAPL"))
+	})
+
 	It("treats prev.Weight=0 as falling back to absolute threshold", func() {
 		// prev weight is 0, so prev*rel = 0. max(abs, 0) = abs. delta must clear absolute.
 		current := map[string]IndexMember{

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -196,3 +196,81 @@ var _ = Describe("currentIndexMembers", func() {
 		Expect(result).To(BeEmpty())
 	})
 })
+
+var _ = Describe("diffSnapshotsWithThreshold", func() {
+	It("matches DiffSnapshots when only AbsoluteThreshold is set", func() {
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.06},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.04},
+		}
+		adds, removes, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{AbsoluteThreshold: 0.01})
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("MSFT"))
+	})
+
+	It("uses relative threshold when set", func() {
+		// AAPL prev=0.0003, current=0.00040. delta=0.0001, prev*0.25 = 0.000075
+		// 0.0001 >= 0.000075 -> CHANGED
+		// MSFT prev=0.0003, current=0.00031. delta=0.00001, prev*0.25 = 0.000075
+		// 0.00001 < 0.000075 -> NOT changed
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.00040},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.00031},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.00030},
+			"MSFT": {CompositeFigi: "BBG000BPH459", Weight: 0.00030},
+		}
+		adds, removes, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{RelativeThreshold: 0.25})
+		Expect(adds).To(BeEmpty())
+		Expect(removes).To(BeEmpty())
+		Expect(weightChanges).To(HaveLen(1))
+		Expect(weightChanges).To(HaveKey("AAPL"))
+		Expect(weightChanges).NotTo(HaveKey("MSFT"))
+	})
+
+	It("uses max(absolute, prev*relative) when both are set", func() {
+		// prev=0.10, current=0.108. delta=0.008.
+		// abs=0.01, prev*rel=0.10*0.25=0.025. max=0.025. 0.008 < 0.025 -> NOT changed.
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.108},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.10},
+		}
+		_, _, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{AbsoluteThreshold: 0.01, RelativeThreshold: 0.25})
+		Expect(weightChanges).To(BeEmpty())
+	})
+
+	It("detects adds and removes regardless of threshold mode", func() {
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"NEW1": {CompositeFigi: "BBG000NEW001", Weight: 0.01},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.05},
+			"OLD1": {CompositeFigi: "BBG000OLD001", Weight: 0.02},
+		}
+		adds, removes, _ := DiffSnapshotsWithThreshold(current, previous, DiffOptions{RelativeThreshold: 0.25})
+		Expect(adds).To(HaveKey("NEW1"))
+		Expect(removes).To(HaveKey("OLD1"))
+	})
+
+	It("treats prev.Weight=0 as falling back to absolute threshold", func() {
+		// prev weight is 0, so prev*rel = 0. max(abs, 0) = abs. delta must clear absolute.
+		current := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.005},
+		}
+		previous := map[string]IndexMember{
+			"AAPL": {CompositeFigi: "BBG000B9XRY4", Weight: 0.0},
+		}
+		_, _, weightChanges := DiffSnapshotsWithThreshold(current, previous, DiffOptions{AbsoluteThreshold: 0.01, RelativeThreshold: 0.25})
+		Expect(weightChanges).To(BeEmpty())
+	})
+})

--- a/provider/pvindex/chunk.go
+++ b/provider/pvindex/chunk.go
@@ -359,7 +359,7 @@ func loadTrailingWindow(ctx context.Context, pool *pgxpool.Pool, asOf time.Time,
 
 	rows, err := conn.Query(ctx,
 		`SELECT dt FROM (
-		   SELECT dt FROM trading_days($1::date - INTERVAL '400 days', $1::date - INTERVAL '1 day') AS t(dt)
+		   SELECT dt FROM trading_days(($1::date - INTERVAL '400 days')::date, ($1::date - INTERVAL '1 day')::date) AS t(dt)
 		   ORDER BY dt DESC
 		   LIMIT $2
 		 ) sub

--- a/provider/pvindex/chunk.go
+++ b/provider/pvindex/chunk.go
@@ -1,0 +1,197 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"time"
+
+	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/provider"
+)
+
+const (
+	// minDayCountStandard is the standard contiguity threshold (200 trading days).
+	minDayCountStandard = 200
+	// minDayCountEarlyEntry is the minimum data required for the IPO early-entry path.
+	minDayCountEarlyEntry = 30
+	// liquidityThresholdUSD is the minimum 200-day median dollar volume.
+	liquidityThresholdUSD = 2_500_000.0
+	// priceFloorUSD is the minimum prior-day close.
+	priceFloorUSD = 2.0
+	// sizePercentile is the 25th percentile cutoff for market cap.
+	sizePercentile = 0.25
+	// earlyEntryPercentile is the top quintile threshold (80th percentile).
+	earlyEntryPercentile = 0.80
+)
+
+// perDayInput is the data needed to compute the universe for a single date.
+// Loaded once per chunk and reused across days.
+type perDayInput struct {
+	Date            time.Time
+	WindowStart     time.Time // inclusive lower bound for the 200-day rolling window
+	WindowEnd       time.Time // inclusive upper bound (= D - 1 trading day)
+	TradingDayCount int       // expected count of trading days in [WindowStart, WindowEnd]
+	Assets          []*data.Asset
+	EodByFigi       map[string][]eodRow
+	MarketCapByFigi map[string]int64
+	BroadMarketCaps []int64 // all market caps in the broad CS pool on D, used for percentile thresholds
+}
+
+// computeUniverseForDate runs the full filter chain for a single trading day and
+// returns the resulting universe as map[ticker]IndexMember with cap-weights assigned.
+func computeUniverseForDate(in perDayInput) map[string]provider.IndexMember {
+	// Step 1 (asset master) is assumed to have already been applied to in.Assets.
+
+	// Step 3: rolling stats per FIGI.
+	statsByFigi := make(map[string]stats, len(in.Assets))
+
+	for _, a := range in.Assets {
+		rows := in.EodByFigi[a.CompositeFigi]
+		statsByFigi[a.CompositeFigi] = rollingStats(rows, in.WindowStart, in.WindowEnd)
+	}
+
+	// Step 4: percentile baseline (broad CS pool).
+	sizeCutoff := percentileInt64(in.BroadMarketCaps, sizePercentile)
+	earlyEntryCutoff := percentileInt64(in.BroadMarketCaps, earlyEntryPercentile)
+
+	// Step 5: data availability.
+	type candidate struct {
+		asset      *data.Asset
+		priorClose float64
+		marketCap  int64
+		medianDV   float64
+	}
+
+	candidates := make([]candidate, 0, len(in.Assets))
+
+	for _, a := range in.Assets {
+		st := statsByFigi[a.CompositeFigi]
+
+		mcap, hasMcap := in.MarketCapByFigi[a.CompositeFigi]
+		if !hasMcap || mcap <= 0 {
+			continue
+		}
+
+		standardEligible := st.dayCount >= minDayCountStandard
+		earlyEligible := st.dayCount >= minDayCountEarlyEntry && st.dayCount < minDayCountStandard && mcap >= earlyEntryCutoff
+
+		if !standardEligible && !earlyEligible {
+			continue
+		}
+
+		// Contiguity check for standard path: dayCount must equal expected trading day count.
+		// For early-entry, contiguity is implicit (all available rows count toward dayCount).
+		if standardEligible && st.dayCount != in.TradingDayCount {
+			continue
+		}
+
+		// Prior close = most recent in-window EOD close.
+		priorClose := mostRecentClose(in.EodByFigi[a.CompositeFigi], in.WindowEnd)
+
+		candidates = append(candidates, candidate{
+			asset:      a,
+			priorClose: priorClose,
+			marketCap:  mcap,
+			medianDV:   st.medianDV,
+		})
+	}
+
+	// Step 6: share-class deduplication.
+	dvByFigi := make(map[string]float64, len(candidates))
+	assetsForDedup := make([]*data.Asset, 0, len(candidates))
+	candByFigi := make(map[string]candidate, len(candidates))
+
+	for _, c := range candidates {
+		dvByFigi[c.asset.CompositeFigi] = c.medianDV
+		assetsForDedup = append(assetsForDedup, c.asset)
+		candByFigi[c.asset.CompositeFigi] = c
+	}
+
+	deduped := dedupShareClasses(assetsForDedup, dvByFigi)
+
+	// Step 7: market cap percentile filter.
+	survivors := make([]candidate, 0, len(deduped))
+
+	for _, a := range deduped {
+		c := candByFigi[a.CompositeFigi]
+		if c.marketCap < sizeCutoff {
+			continue
+		}
+
+		survivors = append(survivors, c)
+	}
+
+	// Step 8: liquidity filter.
+	liquidSurvivors := make([]candidate, 0, len(survivors))
+
+	for _, c := range survivors {
+		if c.medianDV < liquidityThresholdUSD {
+			continue
+		}
+
+		liquidSurvivors = append(liquidSurvivors, c)
+	}
+
+	// Step 9: price guard rail.
+	priceSurvivors := make([]candidate, 0, len(liquidSurvivors))
+
+	for _, c := range liquidSurvivors {
+		if c.priorClose < priceFloorUSD {
+			continue
+		}
+
+		priceSurvivors = append(priceSurvivors, c)
+	}
+
+	// Step 10: cap weights.
+	caps := make(map[string]int64, len(priceSurvivors))
+	for _, c := range priceSurvivors {
+		caps[c.asset.CompositeFigi] = c.marketCap
+	}
+
+	weights := assignCapWeights(caps)
+
+	universe := make(map[string]provider.IndexMember, len(priceSurvivors))
+	for _, c := range priceSurvivors {
+		universe[c.asset.Ticker] = provider.IndexMember{
+			CompositeFigi: c.asset.CompositeFigi,
+			Weight:        weights[c.asset.CompositeFigi],
+		}
+	}
+
+	return universe
+}
+
+// mostRecentClose returns the close price of the most recent EOD row at or before the
+// given date, or 0 if no such row exists.
+func mostRecentClose(rows []eodRow, asOf time.Time) float64 {
+	var (
+		bestDate  time.Time
+		bestClose float64
+	)
+
+	for _, r := range rows {
+		if r.Date.After(asOf) {
+			continue
+		}
+
+		if r.Date.After(bestDate) {
+			bestDate = r.Date
+			bestClose = r.Close
+		}
+	}
+
+	return bestClose
+}

--- a/provider/pvindex/chunk.go
+++ b/provider/pvindex/chunk.go
@@ -15,10 +15,15 @@
 package pvindex
 
 import (
+	"context"
+	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/library"
 	"github.com/penny-vault/pvdata/provider"
+	"github.com/rs/zerolog"
 )
 
 const (
@@ -194,4 +199,188 @@ func mostRecentClose(rows []eodRow, asOf time.Time) float64 {
 	}
 
 	return bestClose
+}
+
+// processChunk executes the universe computation for one chunk of trading days.
+// It loads source data once, iterates days, computes the universe, diffs against the
+// prior state, and emits observations to `out`. The prior state is loaded from the DB
+// at chunk start and maintained in memory across the chunk's days.
+func processChunk(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	sub *library.Subscription,
+	indexTicker string,
+	tradingDays []time.Time,
+	candidates []*data.Asset,
+	out chan<- *data.Observation,
+) error {
+	if len(tradingDays) == 0 {
+		return nil
+	}
+
+	logger := zerolog.Ctx(ctx)
+
+	chunkStart := tradingDays[0]
+	chunkEnd := tradingDays[len(tradingDays)-1]
+
+	// 200 trading days of EOD prefix before the chunk start (~400 calendar days
+	// covers 200 trading days comfortably).
+	loadStart := chunkStart.AddDate(0, 0, -400)
+
+	figis := make([]string, len(candidates))
+	for i, a := range candidates {
+		figis[i] = a.CompositeFigi
+	}
+
+	logger.Info().
+		Time("chunk_start", chunkStart).
+		Time("chunk_end", chunkEnd).
+		Int("trading_days", len(tradingDays)).
+		Int("candidate_assets", len(candidates)).
+		Msg("loading chunk data")
+
+	eodByFigi, err := loadEodChunk(ctx, pool, figis, loadStart, chunkEnd)
+	if err != nil {
+		return fmt.Errorf("load eod chunk: %w", err)
+	}
+
+	// Reconstruct prior state from DB at chunk start.
+	prevState := provider.CurrentIndexMembers(
+		ctx,
+		pool,
+		sub.DataTablesMap[data.IndexSnapshotKey],
+		sub.DataTablesMap[data.IndexChangelogKey],
+		indexTicker,
+		chunkStart.AddDate(0, 0, -1),
+	)
+
+	for _, d := range tradingDays {
+		// Determine the trailing 200-trading-day window ending d-1.
+		windowDays, err := loadTrailingWindow(ctx, pool, d, minDayCountStandard)
+		if err != nil {
+			return fmt.Errorf("load trailing window for %s: %w", d.Format("2006-01-02"), err)
+		}
+
+		if len(windowDays) < minDayCountEarlyEntry {
+			logger.Warn().Time("date", d).Msg("insufficient trading days for window; skipping")
+			continue
+		}
+
+		windowStart := windowDays[0]
+		windowEnd := windowDays[len(windowDays)-1]
+
+		mcapByFigi, err := loadMarketCapAsOf(ctx, pool, figis, d)
+		if err != nil {
+			return fmt.Errorf("load market cap for %s: %w", d.Format("2006-01-02"), err)
+		}
+
+		broadMcaps, err := loadBroadMarketCaps(ctx, pool, d)
+		if err != nil {
+			return fmt.Errorf("load broad mcaps for %s: %w", d.Format("2006-01-02"), err)
+		}
+
+		input := perDayInput{
+			Date:            d,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: len(windowDays),
+			Assets:          candidates,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		newState := computeUniverseForDate(input)
+
+		adds, removes, weightChanges := provider.DiffSnapshotsWithThreshold(
+			newState,
+			prevState,
+			provider.DiffOptions{RelativeThreshold: 0.25},
+		)
+
+		obsTemplate := &data.Observation{
+			ObservationDate:  d,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		provider.EmitChangelog(adds, removes, indexTicker, d, obsTemplate, out)
+		provider.EmitWeightChanges(weightChanges, indexTicker, d, obsTemplate, out)
+
+		// Emit annual snapshot if a year has elapsed since the last in-DB snapshot,
+		// or if no snapshot has ever been taken (cold start).
+		lastSnapshot := provider.LastSnapshotDate(ctx, pool, sub.DataTablesMap[data.IndexSnapshotKey], indexTicker)
+		if provider.ShouldTakeSnapshot(lastSnapshot, d, "yearly") {
+			constituents := make([]data.IndexConstituent, 0, len(newState))
+			for tk, m := range newState {
+				constituents = append(constituents, data.IndexConstituent{
+					Ticker:        tk,
+					CompositeFigi: m.CompositeFigi,
+					Weight:        m.Weight,
+				})
+			}
+
+			out <- &data.Observation{
+				IndexSnapshot: &data.IndexSnapshot{
+					IndexTicker:  indexTicker,
+					SnapshotDate: d,
+					Constituents: constituents,
+				},
+				ObservationDate:  d,
+				SubscriptionID:   sub.ID,
+				SubscriptionName: sub.Name,
+			}
+		}
+
+		// Apply emitted changes to prevState in memory for the next day's diff.
+		for tk := range removes {
+			delete(prevState, tk)
+		}
+
+		for tk, m := range adds {
+			prevState[tk] = m
+		}
+
+		for tk, m := range weightChanges {
+			prevState[tk] = m
+		}
+	}
+
+	return nil
+}
+
+// loadTrailingWindow returns the trailing N trading days ending at (asOf - 1 trading day).
+func loadTrailingWindow(ctx context.Context, pool *pgxpool.Pool, asOf time.Time, n int) ([]time.Time, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadTrailingWindow: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`SELECT dt FROM (
+		   SELECT dt FROM trading_days($1::date - INTERVAL '400 days', $1::date - INTERVAL '1 day') AS t(dt)
+		   ORDER BY dt DESC
+		   LIMIT $2
+		 ) sub
+		 ORDER BY dt`,
+		asOf, n,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query trailing window: %w", err)
+	}
+	defer rows.Close()
+
+	var out []time.Time
+
+	for rows.Next() {
+		var dt time.Time
+		if err := rows.Scan(&dt); err != nil {
+			return nil, fmt.Errorf("scan trailing window day: %w", err)
+		}
+
+		out = append(out, dt)
+	}
+
+	return out, nil
 }

--- a/provider/pvindex/chunk_test.go
+++ b/provider/pvindex/chunk_test.go
@@ -1,0 +1,284 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/data"
+)
+
+var _ = Describe("computeUniverseForDate", func() {
+	// Helper: build a contiguous EOD slice for one FIGI from startDate going N days forward.
+	// All trading days are simulated as consecutive calendar days for simplicity in tests.
+	mkEodSeries := func(startDate string, n int, close, volume float64) []eodRow {
+		t, _ := time.Parse("2006-01-02", startDate)
+		out := make([]eodRow, n)
+		for i := 0; i < n; i++ {
+			out[i] = eodRow{Date: t.AddDate(0, 0, i), Close: close, Volume: volume}
+		}
+		return out
+	}
+
+	mkCSAsset := func(ticker, cik, figi, name string) *data.Asset {
+		return &data.Asset{
+			Ticker:          ticker,
+			Name:            name,
+			CompositeFigi:   figi,
+			CIK:             cik,
+			AssetType:       data.CommonStock,
+			PrimaryExchange: "NASDAQ",
+			Active:          true,
+		}
+	}
+
+	It("includes a stock that passes all filters", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		// Window: [2024-06-14, 2024-12-30] = exactly 200 calendar days.
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("AAPL", "0000320193", "BBG000B9XRY4", "Apple Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000B9XRY4": mkEodSeries("2024-06-14", 200, 100.0, 100_000), // dv = 10M
+		}
+		mcapByFigi := map[string]int64{
+			"BBG000B9XRY4": 3_000_000_000_000, // $3T
+		}
+		broadMcaps := []int64{1_000_000, 3_000_000_000_000}
+		tradingDayCount := 200
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: tradingDayCount,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(HaveKey("AAPL"))
+		Expect(universe["AAPL"].Weight).To(BeNumerically("~", 1.0, 1e-9))
+	})
+
+	It("excludes a stock with insufficient EOD history (under 30 days)", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("NEW", "0001111111", "BBG000NEW001", "New Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000NEW001": mkEodSeries(evalDate.AddDate(0, 0, -20).Format("2006-01-02"), 20, 50.0, 100_000),
+		}
+		mcapByFigi := map[string]int64{"BBG000NEW001": 50_000_000_000}
+		broadMcaps := []int64{50_000_000_000, 1_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("includes a stock via early-entry path (50 days, top quintile market cap)", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("BIGIPO", "0002222222", "BBG000BIGIPO", "BigIPO Inc.")}
+		// 50 contiguous days ending day-1
+		eodByFigi := map[string][]eodRow{
+			"BBG000BIGIPO": mkEodSeries(evalDate.AddDate(0, 0, -50).Format("2006-01-02"), 50, 200.0, 100_000), // dv = 20M
+		}
+		mcapByFigi := map[string]int64{"BBG000BIGIPO": 80_000_000_000}
+		// Broad market cap pool: BIGIPO at $80B is in top 20% of [1B, 5B, 10B, 80B] (80th percentile).
+		broadMcaps := []int64{1_000_000_000, 5_000_000_000, 10_000_000_000, 80_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(HaveKey("BIGIPO"))
+	})
+
+	It("excludes a stock via early-entry path when market cap is below top quintile", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("SMALLIPO", "0003333333", "BBG000SMALLIPO", "SmallIPO Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000SMALLIPO": mkEodSeries(evalDate.AddDate(0, 0, -50).Format("2006-01-02"), 50, 10.0, 100_000),
+		}
+		mcapByFigi := map[string]int64{"BBG000SMALLIPO": 500_000_000} // $500M
+		// Broad market cap pool: SMALLIPO at $500M is bottom of [500M, 5B, 10B, 80B], not top 20%.
+		broadMcaps := []int64{500_000_000, 5_000_000_000, 10_000_000_000, 80_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock with low ADV", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("ILLIQ", "0004444444", "BBG000ILLIQ01", "Illiquid Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000ILLIQ01": mkEodSeries("2024-06-14", 200, 10.0, 1_000), // dv = 10K
+		}
+		mcapByFigi := map[string]int64{"BBG000ILLIQ01": 100_000_000_000}
+		broadMcaps := []int64{100_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock with prior_close below $2", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("CHEAP", "0005555555", "BBG000CHEAP01", "Cheap Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000CHEAP01": mkEodSeries("2024-06-14", 200, 1.5, 10_000_000), // dv = 15M, but price < $2
+		}
+		mcapByFigi := map[string]int64{"BBG000CHEAP01": 100_000_000_000}
+		broadMcaps := []int64{100_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock below the 25th percentile market cap cutoff", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		assets := []*data.Asset{mkCSAsset("TINY", "0006666666", "BBG000TINY001", "Tiny Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000TINY001": mkEodSeries("2024-06-14", 200, 10.0, 1_000_000), // dv = 10M, passes ADV
+		}
+		mcapByFigi := map[string]int64{"BBG000TINY001": 50_000_000} // $50M
+		// Broad pool: 25th percentile of [50M, 1B, 5B, 10B, 80B] = ceil(5*0.25)=2 -> sorted[1] = 1B.
+		// TINY at $50M is below the 1B cutoff -> excluded.
+		broadMcaps := []int64{50_000_000, 1_000_000_000, 5_000_000_000, 10_000_000_000, 80_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+
+	It("excludes a stock with insufficient EOD rows after a gap", func() {
+		evalDate, _ := time.Parse("2006-01-02", "2024-12-31")
+		windowStart := evalDate.AddDate(0, 0, -200)
+		windowEnd := evalDate.AddDate(0, 0, -1)
+
+		// Build 200 consecutive calendar days starting 2024-06-15, then drop the middle row.
+		// After removal, only ~198 rows fall inside the window, so the stock fails the standard-path
+		// dayCount threshold (< 200). BroadMarketCaps is set so the stock is also below the
+		// 80th-percentile early-entry threshold, so neither path admits it.
+		series := mkEodSeries("2024-06-15", 200, 100.0, 100_000)
+		series = append(series[:100], series[101:]...)
+
+		assets := []*data.Asset{mkCSAsset("GAPPY", "0007777777", "BBG000GAPPY01", "Gappy Inc.")}
+		eodByFigi := map[string][]eodRow{
+			"BBG000GAPPY01": series,
+		}
+		mcapByFigi := map[string]int64{"BBG000GAPPY01": 100_000_000_000} // $100B
+		// 80th percentile of [100B, 500B, 1T, 2T, 5T] = ceil(5*0.8)=4 -> sorted[3] = 2T.
+		// GAPPY's 100B is well below the 2T early-entry cutoff.
+		broadMcaps := []int64{100_000_000_000, 500_000_000_000, 1_000_000_000_000, 2_000_000_000_000, 5_000_000_000_000}
+
+		input := perDayInput{
+			Date:            evalDate,
+			WindowStart:     windowStart,
+			WindowEnd:       windowEnd,
+			TradingDayCount: 200,
+			Assets:          assets,
+			EodByFigi:       eodByFigi,
+			MarketCapByFigi: mcapByFigi,
+			BroadMarketCaps: broadMcaps,
+		}
+
+		universe := computeUniverseForDate(input)
+		Expect(universe).To(BeEmpty())
+	})
+})

--- a/provider/pvindex/date_range.go
+++ b/provider/pvindex/date_range.go
@@ -47,7 +47,7 @@ func computeDateRange(ctx context.Context, pool *pgxpool.Pool) (time.Time, time.
 	// Find the 200th trading day after minMetric.
 	var startDate time.Time
 	if err := conn.QueryRow(ctx,
-		`SELECT dt FROM trading_days($1::date, $1::date + INTERVAL '400 days') AS t(dt)
+		`SELECT dt FROM trading_days($1::date, ($1::date + INTERVAL '400 days')::date) AS t(dt)
 		 ORDER BY dt LIMIT 1 OFFSET 199`,
 		minMetric,
 	).Scan(&startDate); err != nil {

--- a/provider/pvindex/date_range.go
+++ b/provider/pvindex/date_range.go
@@ -1,0 +1,106 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// computeDateRange returns the [start, end] date range for the universe computation:
+// start = 200 trading days after MIN(metrics.event_date)
+// end = LEAST(MAX(eod.event_date), MAX(metrics.event_date))
+func computeDateRange(ctx context.Context, pool *pgxpool.Pool) (time.Time, time.Time, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("acquire conn for computeDateRange: %w", err)
+	}
+	defer conn.Release()
+
+	var (
+		minMetric, maxMetric, maxEod time.Time
+	)
+
+	if err := conn.QueryRow(ctx, `SELECT MIN(event_date), MAX(event_date) FROM metrics`).Scan(&minMetric, &maxMetric); err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("query metric date range: %w", err)
+	}
+
+	if err := conn.QueryRow(ctx, `SELECT MAX(event_date) FROM eod`).Scan(&maxEod); err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("query eod max date: %w", err)
+	}
+
+	// Find the 200th trading day after minMetric.
+	var startDate time.Time
+	if err := conn.QueryRow(ctx,
+		`SELECT dt FROM trading_days($1::date, $1::date + INTERVAL '400 days') AS t(dt)
+		 ORDER BY dt LIMIT 1 OFFSET 199`,
+		minMetric,
+	).Scan(&startDate); err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("compute start date: %w", err)
+	}
+
+	endDate := maxMetric
+	if maxEod.Before(endDate) {
+		endDate = maxEod
+	}
+
+	return startDate, endDate, nil
+}
+
+// chunkTradingDays loads trading days in [start, end] from the database and splits them
+// into fixed-size chunks. Each chunk is a slice of trading days.
+func chunkTradingDays(ctx context.Context, pool *pgxpool.Pool, start, end time.Time, chunkSize int) ([][]time.Time, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for chunkTradingDays: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, `SELECT dt FROM trading_days($1::date, $2::date) AS t(dt) ORDER BY dt`, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query trading days: %w", err)
+	}
+	defer rows.Close()
+
+	var allDays []time.Time
+
+	for rows.Next() {
+		var dt time.Time
+		if err := rows.Scan(&dt); err != nil {
+			return nil, fmt.Errorf("scan trading day: %w", err)
+		}
+
+		allDays = append(allDays, dt)
+	}
+
+	if len(allDays) == 0 {
+		return nil, nil
+	}
+
+	chunks := make([][]time.Time, 0, (len(allDays)/chunkSize)+1)
+	for i := 0; i < len(allDays); i += chunkSize {
+		end := i + chunkSize
+		if end > len(allDays) {
+			end = len(allDays)
+		}
+
+		chunks = append(chunks, allDays[i:end])
+	}
+
+	return chunks, nil
+}

--- a/provider/pvindex/filter.go
+++ b/provider/pvindex/filter.go
@@ -16,6 +16,8 @@ package pvindex
 
 import (
 	"strings"
+
+	"github.com/penny-vault/pvdata/data"
 )
 
 // lpSuffixes is the list of legal-form suffixes that identify a limited partnership.
@@ -44,4 +46,50 @@ func isLPName(name string) bool {
 	}
 
 	return false
+}
+
+// allowedExchanges is the whitelist of US-listed common stock exchanges.
+// Both display-name and MIC code formats are accepted, because the assets table
+// currently contains a mix of both. See "Known limitation: exchange field inconsistency"
+// in the design spec.
+var allowedExchanges = map[data.Exchange]struct{}{
+	"NASDAQ":    {},
+	"XNAS":      {},
+	"NYSE":      {},
+	"XNYS":      {},
+	"NYSE MKT":  {},
+	"XASE":      {},
+	"AMEX":      {},
+	"NYSE ARCA": {},
+	"ARCX":      {},
+	"BATS":      {},
+}
+
+// filterAssetMaster returns the subset of assets passing the structural filter:
+// active = true, asset_type = CS, primary_exchange in whitelist, name does not match
+// an LP suffix.
+func filterAssetMaster(assets []*data.Asset) []*data.Asset {
+	out := make([]*data.Asset, 0, len(assets))
+
+	for _, a := range assets {
+		if !a.Active {
+			continue
+		}
+
+		if a.AssetType != data.CommonStock {
+			continue
+		}
+
+		if _, ok := allowedExchanges[a.PrimaryExchange]; !ok {
+			continue
+		}
+
+		if isLPName(a.Name) {
+			continue
+		}
+
+		out = append(out, a)
+	}
+
+	return out
 }

--- a/provider/pvindex/filter.go
+++ b/provider/pvindex/filter.go
@@ -182,6 +182,7 @@ func percentileInt64(values []int64, p float64) int64 {
 	if rank < 1 {
 		rank = 1
 	}
+
 	if rank > len(sorted) {
 		rank = len(sorted)
 	}

--- a/provider/pvindex/filter.go
+++ b/provider/pvindex/filter.go
@@ -93,3 +93,41 @@ func filterAssetMaster(assets []*data.Asset) []*data.Asset {
 
 	return out
 }
+
+// dedupShareClasses groups assets by CIK (or composite_figi as fallback for null CIK)
+// and keeps the row with the highest median dollar volume per group. Ties are broken
+// alphabetically by ticker for deterministic output.
+func dedupShareClasses(assets []*data.Asset, dvByFigi map[string]float64) []*data.Asset {
+	type bestRow struct {
+		asset *data.Asset
+		dv    float64
+	}
+
+	groups := make(map[string]bestRow, len(assets))
+
+	for _, a := range assets {
+		key := a.CIK
+		if key == "" {
+			key = a.CompositeFigi
+		}
+
+		dv := dvByFigi[a.CompositeFigi]
+
+		current, exists := groups[key]
+		if !exists {
+			groups[key] = bestRow{asset: a, dv: dv}
+			continue
+		}
+
+		if dv > current.dv || (dv == current.dv && a.Ticker < current.asset.Ticker) {
+			groups[key] = bestRow{asset: a, dv: dv}
+		}
+	}
+
+	out := make([]*data.Asset, 0, len(groups))
+	for _, b := range groups {
+		out = append(out, b.asset)
+	}
+
+	return out
+}

--- a/provider/pvindex/filter.go
+++ b/provider/pvindex/filter.go
@@ -131,3 +131,30 @@ func dedupShareClasses(assets []*data.Asset, dvByFigi map[string]float64) []*dat
 
 	return out
 }
+
+// assignCapWeights computes market-cap-weighted weights from a map of composite_figi
+// to market_cap. Weights are normalized to sum to 1.0. Returns an empty map if the
+// input is empty or the total market cap is zero.
+func assignCapWeights(caps map[string]int64) map[string]float64 {
+	if len(caps) == 0 {
+		return map[string]float64{}
+	}
+
+	var total int64
+	for _, c := range caps {
+		total += c
+	}
+
+	if total <= 0 {
+		return map[string]float64{}
+	}
+
+	weights := make(map[string]float64, len(caps))
+
+	totalF := float64(total)
+	for figi, c := range caps {
+		weights[figi] = float64(c) / totalF
+	}
+
+	return weights
+}

--- a/provider/pvindex/filter.go
+++ b/provider/pvindex/filter.go
@@ -15,6 +15,8 @@
 package pvindex
 
 import (
+	"math"
+	"sort"
 	"strings"
 
 	"github.com/penny-vault/pvdata/data"
@@ -157,4 +159,32 @@ func assignCapWeights(caps map[string]int64) map[string]float64 {
 	}
 
 	return weights
+}
+
+// percentileInt64 returns the value at the given percentile (0..1) of the input slice.
+// Uses the "nearest rank" method: for n values, the rank index = ceil(n*p), clamped
+// to [1, n]. The returned value is sorted[rank-1]. Does not modify the input slice.
+// Returns 0 for empty input.
+func percentileInt64(values []int64, p float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+
+	if len(values) == 1 {
+		return values[0]
+	}
+
+	sorted := make([]int64, len(values))
+	copy(sorted, values)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	rank := int(math.Ceil(float64(len(sorted)) * p))
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > len(sorted) {
+		rank = len(sorted)
+	}
+
+	return sorted[rank-1]
 }

--- a/provider/pvindex/filter.go
+++ b/provider/pvindex/filter.go
@@ -1,0 +1,47 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"strings"
+)
+
+// lpSuffixes is the list of legal-form suffixes that identify a limited partnership.
+// Matched as case-insensitive whole-word suffixes against the trimmed asset name.
+var lpSuffixes = []string{
+	" LP",
+	" L.P.",
+	" L P",
+	" LLP",
+	" LIMITED PARTNERSHIP",
+}
+
+// isLPName returns true if the asset name ends in a recognized LP suffix.
+// Suffix matching is case-insensitive and whitespace-tolerant.
+func isLPName(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return false
+	}
+
+	upper := strings.ToUpper(trimmed)
+	for _, suffix := range lpSuffixes {
+		if strings.HasSuffix(upper, suffix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/provider/pvindex/filter_test.go
+++ b/provider/pvindex/filter_test.go
@@ -17,6 +17,8 @@ package pvindex
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/data"
 )
 
 var _ = Describe("isLPName", func() {
@@ -40,4 +42,80 @@ var _ = Describe("isLPName", func() {
 		Entry("Compass Plc (negative - similar shape)", "Compass Group plc", false),
 		Entry("Empty name (negative)", "", false),
 	)
+})
+
+var _ = Describe("filterAssetMaster", func() {
+	mkAsset := func(ticker, name, exch string, atype data.AssetType, active bool) *data.Asset {
+		return &data.Asset{
+			Ticker:          ticker,
+			Name:            name,
+			PrimaryExchange: data.Exchange(exch),
+			AssetType:       atype,
+			Active:          active,
+		}
+	}
+
+	It("keeps active US common stocks on whitelisted exchanges", func() {
+		input := []*data.Asset{
+			mkAsset("AAPL", "Apple Inc.", "NASDAQ", data.CommonStock, true),
+			mkAsset("BAC", "Bank of America Corporation", "NYSE", data.CommonStock, true),
+			mkAsset("XOM", "Exxon Mobil Corporation", "XNYS", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(HaveLen(3))
+	})
+
+	It("excludes inactive assets", func() {
+		input := []*data.Asset{
+			mkAsset("DEAD", "Dead Co", "NYSE", data.CommonStock, false),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
+
+	It("excludes non-CS asset types", func() {
+		input := []*data.Asset{
+			mkAsset("SPY", "SPDR S&P 500 ETF", "NYSE ARCA", data.ETF, true),
+			mkAsset("PCQ", "PIMCO California Muni", "NYSE", data.CEF, true),
+			mkAsset("BABA", "Alibaba ADR", "NYSE", data.ADRC, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
+
+	It("excludes OTC and unknown exchanges", func() {
+		input := []*data.Asset{
+			mkAsset("FOO", "Foo Inc", "OTC", data.CommonStock, true),
+			mkAsset("BAR", "Bar Inc", "NMFQS", data.CommonStock, true),
+			mkAsset("BAZ", "Baz Inc", "UNK", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
+
+	It("accepts both display-name and MIC code formats for whitelisted exchanges", func() {
+		input := []*data.Asset{
+			mkAsset("A", "Alpha Inc", "NASDAQ", data.CommonStock, true),
+			mkAsset("B", "Beta Inc", "XNAS", data.CommonStock, true),
+			mkAsset("C", "Gamma Inc", "NYSE", data.CommonStock, true),
+			mkAsset("D", "Delta Inc", "XNYS", data.CommonStock, true),
+			mkAsset("E", "Epsilon Inc", "NYSE MKT", data.CommonStock, true),
+			mkAsset("F", "Zeta Inc", "XASE", data.CommonStock, true),
+			mkAsset("G", "Eta Inc", "AMEX", data.CommonStock, true),
+			mkAsset("H", "Theta Inc", "NYSE ARCA", data.CommonStock, true),
+			mkAsset("I", "Iota Inc", "ARCX", data.CommonStock, true),
+			mkAsset("J", "Kappa Inc", "BATS", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(HaveLen(10))
+	})
+
+	It("excludes LPs", func() {
+		input := []*data.Asset{
+			mkAsset("EPD", "Enterprise Products Partners LP", "NYSE", data.CommonStock, true),
+			mkAsset("ET", "Energy Transfer LP", "NYSE", data.CommonStock, true),
+		}
+		out := filterAssetMaster(input)
+		Expect(out).To(BeEmpty())
+	})
 })

--- a/provider/pvindex/filter_test.go
+++ b/provider/pvindex/filter_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isLPName", func() {
+	DescribeTable("LP suffix detection",
+		func(name string, expected bool) {
+			Expect(isLPName(name)).To(Equal(expected))
+		},
+		Entry("Enterprise Products LP", "Enterprise Products Partners LP", true),
+		Entry("Energy Transfer LP", "Energy Transfer LP", true),
+		Entry("MPLX LP", "MPLX LP", true),
+		Entry("Brookfield Infrastructure L.P.", "Brookfield Infrastructure L.P.", true),
+		Entry("L.P. with trailing whitespace", "Some Partnership L.P.   ", true),
+		Entry("LLP suffix", "Big Law LLP", true),
+		Entry("Limited Partnership full word", "Foo Limited Partnership", true),
+		Entry("L P with space", "ABC Investments L P", true),
+		Entry("lower case lp", "enterprise products lp", true),
+		Entry("Marsh & McLennan Companies (negative - not LP)", "Marsh & McLennan Companies", false),
+		Entry("Apple Inc (negative)", "Apple Inc.", false),
+		Entry("MetLife Inc (negative)", "MetLife Inc", false),
+		Entry("LP in middle of name (negative)", "LP Holdings Corporation", false),
+		Entry("Compass Plc (negative - similar shape)", "Compass Group plc", false),
+		Entry("Empty name (negative)", "", false),
+	)
+})

--- a/provider/pvindex/filter_test.go
+++ b/provider/pvindex/filter_test.go
@@ -119,3 +119,63 @@ var _ = Describe("filterAssetMaster", func() {
 		Expect(out).To(BeEmpty())
 	})
 })
+
+var _ = Describe("dedupShareClasses", func() {
+	mkAssetWithCIK := func(ticker, cik, figi string) *data.Asset {
+		return &data.Asset{
+			Ticker:        ticker,
+			CompositeFigi: figi,
+			CIK:           cik,
+		}
+	}
+
+	It("keeps the highest-DV share class within a CIK group", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("GOOGL", "0001652044", "BBG009S39JX6"),
+			mkAssetWithCIK("GOOG", "0001652044", "BBG009S3NB30"),
+		}
+		dvByFigi := map[string]float64{
+			"BBG009S39JX6": 1_500_000_000, // GOOGL
+			"BBG009S3NB30": 2_500_000_000, // GOOG (higher)
+		}
+		out := dedupShareClasses(assets, dvByFigi)
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Ticker).To(Equal("GOOG"))
+	})
+
+	It("treats null CIK rows as singleton groups", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("XYZ", "", "BBGXYZ00001"),
+			mkAssetWithCIK("ABC", "", "BBGABC00001"),
+		}
+		dvByFigi := map[string]float64{
+			"BBGXYZ00001": 100,
+			"BBGABC00001": 200,
+		}
+		out := dedupShareClasses(assets, dvByFigi)
+		Expect(out).To(HaveLen(2))
+	})
+
+	It("breaks ties by ticker for determinism", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("AAA", "0001234567", "BBGAAA00001"),
+			mkAssetWithCIK("BBB", "0001234567", "BBGBBB00001"),
+		}
+		dvByFigi := map[string]float64{
+			"BBGAAA00001": 1000,
+			"BBGBBB00001": 1000,
+		}
+		out := dedupShareClasses(assets, dvByFigi)
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Ticker).To(Equal("AAA"))
+	})
+
+	It("handles assets with zero dollar volume", func() {
+		assets := []*data.Asset{
+			mkAssetWithCIK("ZERO", "0001111111", "BBGZERO0001"),
+		}
+		out := dedupShareClasses(assets, map[string]float64{})
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Ticker).To(Equal("ZERO"))
+	})
+})

--- a/provider/pvindex/filter_test.go
+++ b/provider/pvindex/filter_test.go
@@ -216,3 +216,33 @@ var _ = Describe("assignCapWeights", func() {
 		Expect(assignCapWeights(caps)).To(BeEmpty())
 	})
 })
+
+var _ = Describe("percentileInt64", func() {
+	It("computes 25th percentile of a known distribution", func() {
+		vals := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+		// 25th percentile of 10 values: rank = ceil(10 * 0.25) = ceil(2.5) = 3 -> sorted[2] = 30
+		Expect(percentileInt64(vals, 0.25)).To(Equal(int64(30)))
+	})
+
+	It("computes 80th percentile of a known distribution", func() {
+		vals := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+		// 80th percentile of 10 values: rank = ceil(10 * 0.80) = ceil(8.0) = 8 -> sorted[7] = 80
+		Expect(percentileInt64(vals, 0.80)).To(Equal(int64(80)))
+	})
+
+	It("returns zero for empty input", func() {
+		Expect(percentileInt64(nil, 0.5)).To(Equal(int64(0)))
+		Expect(percentileInt64([]int64{}, 0.5)).To(Equal(int64(0)))
+	})
+
+	It("returns the only element for single-element input", func() {
+		Expect(percentileInt64([]int64{42}, 0.25)).To(Equal(int64(42)))
+		Expect(percentileInt64([]int64{42}, 0.80)).To(Equal(int64(42)))
+	})
+
+	It("does not modify the input slice", func() {
+		vals := []int64{50, 10, 30, 20, 40}
+		_ = percentileInt64(vals, 0.5)
+		Expect(vals).To(Equal([]int64{50, 10, 30, 20, 40}))
+	})
+})

--- a/provider/pvindex/filter_test.go
+++ b/provider/pvindex/filter_test.go
@@ -179,3 +179,40 @@ var _ = Describe("dedupShareClasses", func() {
 		Expect(out[0].Ticker).To(Equal("ZERO"))
 	})
 })
+
+var _ = Describe("assignCapWeights", func() {
+	It("normalizes weights to sum to 1.0", func() {
+		caps := map[string]int64{
+			"BBG000A": 1_000_000_000,
+			"BBG000B": 2_000_000_000,
+			"BBG000C": 7_000_000_000,
+		}
+		weights := assignCapWeights(caps)
+		Expect(weights).To(HaveLen(3))
+		Expect(weights["BBG000A"]).To(BeNumerically("~", 0.10, 1e-9))
+		Expect(weights["BBG000B"]).To(BeNumerically("~", 0.20, 1e-9))
+		Expect(weights["BBG000C"]).To(BeNumerically("~", 0.70, 1e-9))
+	})
+
+	It("returns weights summing to 1.0 within float tolerance", func() {
+		caps := map[string]int64{
+			"A": 333, "B": 333, "C": 333, "D": 1,
+		}
+		weights := assignCapWeights(caps)
+		var sum float64
+		for _, w := range weights {
+			sum += w
+		}
+		Expect(sum).To(BeNumerically("~", 1.0, 1e-9))
+	})
+
+	It("returns empty map for empty input", func() {
+		Expect(assignCapWeights(nil)).To(BeEmpty())
+		Expect(assignCapWeights(map[string]int64{})).To(BeEmpty())
+	})
+
+	It("returns empty map when total cap is zero", func() {
+		caps := map[string]int64{"A": 0, "B": 0}
+		Expect(assignCapWeights(caps)).To(BeEmpty())
+	})
+})

--- a/provider/pvindex/loader.go
+++ b/provider/pvindex/loader.go
@@ -1,0 +1,196 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/penny-vault/pvdata/data"
+	"github.com/rs/zerolog/log"
+)
+
+// loadCandidateAssets reads all rows from the `assets` view and returns those passing
+// the structural filter (active, CS, exchange whitelist, not LP).
+func loadCandidateAssets(ctx context.Context, pool *pgxpool.Pool) ([]*data.Asset, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadCandidateAssets: %w", err)
+	}
+	defer conn.Release()
+
+	all, err := data.ActiveAssets(ctx, conn, "assets")
+	if err != nil {
+		return nil, fmt.Errorf("load active assets: %w", err)
+	}
+
+	filtered := filterAssetMaster(all)
+
+	log.Debug().
+		Int("total_active", len(all)).
+		Int("after_structural_filter", len(filtered)).
+		Msg("loaded candidate assets")
+
+	return filtered, nil
+}
+
+// loadEodChunk reads EOD rows for the given FIGIs over [start, end] inclusive from
+// the `eod` published view. Returns a map keyed by composite_figi.
+func loadEodChunk(ctx context.Context, pool *pgxpool.Pool, figis []string, start, end time.Time) (map[string][]eodRow, error) {
+	if len(figis) == 0 {
+		return map[string][]eodRow{}, nil
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadEodChunk: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`SELECT composite_figi, event_date, close, volume
+		 FROM eod
+		 WHERE event_date BETWEEN $1 AND $2
+		   AND composite_figi = ANY($3)
+		 ORDER BY composite_figi, event_date`,
+		start, end, figis,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query eod chunk: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string][]eodRow)
+
+	for rows.Next() {
+		var (
+			figi   string
+			date   time.Time
+			closeP float64
+			volume float64
+		)
+
+		if err := rows.Scan(&figi, &date, &closeP, &volume); err != nil {
+			return nil, fmt.Errorf("scan eod row: %w", err)
+		}
+
+		out[figi] = append(out[figi], eodRow{Date: date, Close: closeP, Volume: volume})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate eod rows: %w", err)
+	}
+
+	return out, nil
+}
+
+// loadMarketCapAsOf reads the most recent market_cap on or before `asOf` for each FIGI
+// in the input. Used to populate per-day market cap lookups within a chunk.
+func loadMarketCapAsOf(ctx context.Context, pool *pgxpool.Pool, figis []string, asOf time.Time) (map[string]int64, error) {
+	if len(figis) == 0 {
+		return map[string]int64{}, nil
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadMarketCapAsOf: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`SELECT DISTINCT ON (composite_figi) composite_figi, market_cap
+		 FROM metrics
+		 WHERE composite_figi = ANY($1)
+		   AND event_date <= $2
+		   AND market_cap > 0
+		 ORDER BY composite_figi, event_date DESC`,
+		figis, asOf,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query market_cap: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]int64)
+
+	for rows.Next() {
+		var (
+			figi string
+			mcap int64
+		)
+
+		if err := rows.Scan(&figi, &mcap); err != nil {
+			return nil, fmt.Errorf("scan metric row: %w", err)
+		}
+
+		out[figi] = mcap
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate metric rows: %w", err)
+	}
+
+	return out, nil
+}
+
+// loadBroadMarketCaps returns the market caps of all CS rows on the broad pool baseline:
+// active CS on whitelisted exchanges with a metric row on or before `asOf`. Used as the
+// percentile baseline for the size and early-entry filters.
+func loadBroadMarketCaps(ctx context.Context, pool *pgxpool.Pool, asOf time.Time) ([]int64, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for loadBroadMarketCaps: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx,
+		`WITH latest AS (
+		   SELECT DISTINCT ON (m.composite_figi) m.composite_figi, m.market_cap
+		   FROM metrics m
+		   JOIN assets a USING (composite_figi)
+		   WHERE a.active = true
+		     AND a.asset_type = 'CS'
+		     AND a.primary_exchange IN ('NASDAQ','NYSE','NYSE MKT','NYSE ARCA','BATS','AMEX','XNAS','XNYS','XASE','ARCX')
+		     AND m.event_date <= $1
+		     AND m.market_cap > 0
+		   ORDER BY m.composite_figi, m.event_date DESC
+		 )
+		 SELECT market_cap FROM latest`,
+		asOf,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query broad market caps: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]int64, 0, 5000)
+
+	for rows.Next() {
+		var mcap int64
+		if err := rows.Scan(&mcap); err != nil {
+			return nil, fmt.Errorf("scan broad mcap row: %w", err)
+		}
+
+		out = append(out, mcap)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate broad mcap rows: %w", err)
+	}
+
+	return out, nil
+}

--- a/provider/pvindex/pvindex.go
+++ b/provider/pvindex/pvindex.go
@@ -16,11 +16,18 @@ package pvindex
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/penny-vault/pvdata/data"
 	"github.com/penny-vault/pvdata/library"
 	"github.com/penny-vault/pvdata/provider"
+	"github.com/rs/zerolog"
+)
+
+const (
+	defaultIndexTicker = "us-tradable"
+	defaultChunkSize   = 63
 )
 
 // Pvindex is a derived provider that computes investable universes by reading from
@@ -67,13 +74,84 @@ func (p *Pvindex) Datasets() map[string]provider.Dataset {
 	}
 }
 
-// fetchTradableUniverse is the dataset Fetch entry point. Real implementation lands in Task 12.
 func fetchTradableUniverse(ctx context.Context, sub *library.Subscription, out chan<- *data.Observation, exit chan<- data.RunSummary) {
-	exit <- data.RunSummary{
+	logger := zerolog.Ctx(ctx)
+	pool := sub.Library.Pool
+
+	runSummary := data.RunSummary{
 		StartTime:        time.Now(),
-		EndTime:          time.Now(),
 		SubscriptionID:   sub.ID,
 		SubscriptionName: sub.Name,
 		Status:           data.RunSuccess,
 	}
+
+	defer func() {
+		runSummary.EndTime = time.Now()
+		exit <- runSummary
+	}()
+
+	indexTicker := defaultIndexTicker
+	if v := sub.Config["index_ticker"]; v != "" {
+		indexTicker = v
+	}
+
+	chunkSize := defaultChunkSize
+	if v := sub.Config["chunk_size_days"]; v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			chunkSize = n
+		}
+	}
+
+	startDate, endDate, err := computeDateRange(ctx, pool)
+	if err != nil {
+		logger.Error().Err(err).Msg("compute date range failed")
+		runSummary.Status = data.RunFailed
+		return
+	}
+
+	// Honor start_date_override.
+	if v := sub.Config["start_date_override"]; v != "" {
+		if t, err := time.Parse("2006-01-02", v); err == nil && t.After(startDate) {
+			startDate = t
+		}
+	}
+
+	// Incremental: skip dates already covered.
+	highWater := provider.LastSnapshotDate(ctx, pool, sub.DataTablesMap[data.IndexSnapshotKey], indexTicker)
+	if !highWater.IsZero() && highWater.After(startDate) {
+		startDate = highWater.AddDate(0, 0, 1)
+	}
+
+	if startDate.After(endDate) {
+		logger.Info().Msg("no new dates to process")
+		return
+	}
+
+	candidates, err := loadCandidateAssets(ctx, pool)
+	if err != nil {
+		logger.Error().Err(err).Msg("load candidate assets failed")
+		runSummary.Status = data.RunFailed
+		return
+	}
+
+	chunks, err := chunkTradingDays(ctx, pool, startDate, endDate, chunkSize)
+	if err != nil {
+		logger.Error().Err(err).Msg("chunk trading days failed")
+		runSummary.Status = data.RunFailed
+		return
+	}
+
+	totalObs := 0
+	for _, chunk := range chunks {
+		if err := processChunk(ctx, pool, sub, indexTicker, chunk, candidates, out); err != nil {
+			logger.Error().Err(err).Time("chunk_start", chunk[0]).Msg("process chunk failed")
+			runSummary.Status = data.RunFailed
+
+			return
+		}
+
+		totalObs += len(chunk)
+	}
+
+	runSummary.NumObservations = totalObs
 }

--- a/provider/pvindex/pvindex.go
+++ b/provider/pvindex/pvindex.go
@@ -96,6 +96,7 @@ func fetchTradableUniverse(ctx context.Context, sub *library.Subscription, out c
 	}
 
 	chunkSize := defaultChunkSize
+
 	if v := sub.Config["chunk_size_days"]; v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			chunkSize = n
@@ -105,7 +106,9 @@ func fetchTradableUniverse(ctx context.Context, sub *library.Subscription, out c
 	startDate, endDate, err := computeDateRange(ctx, pool)
 	if err != nil {
 		logger.Error().Err(err).Msg("compute date range failed")
+
 		runSummary.Status = data.RunFailed
+
 		return
 	}
 
@@ -130,21 +133,27 @@ func fetchTradableUniverse(ctx context.Context, sub *library.Subscription, out c
 	candidates, err := loadCandidateAssets(ctx, pool)
 	if err != nil {
 		logger.Error().Err(err).Msg("load candidate assets failed")
+
 		runSummary.Status = data.RunFailed
+
 		return
 	}
 
 	chunks, err := chunkTradingDays(ctx, pool, startDate, endDate, chunkSize)
 	if err != nil {
 		logger.Error().Err(err).Msg("chunk trading days failed")
+
 		runSummary.Status = data.RunFailed
+
 		return
 	}
 
 	totalObs := 0
+
 	for _, chunk := range chunks {
 		if err := processChunk(ctx, pool, sub, indexTicker, chunk, candidates, out); err != nil {
 			logger.Error().Err(err).Time("chunk_start", chunk[0]).Msg("process chunk failed")
+
 			runSummary.Status = data.RunFailed
 
 			return

--- a/provider/pvindex/pvindex.go
+++ b/provider/pvindex/pvindex.go
@@ -1,0 +1,79 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"context"
+	"time"
+
+	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/library"
+	"github.com/penny-vault/pvdata/provider"
+)
+
+// Pvindex is a derived provider that computes investable universes by reading from
+// the canonical published views (eod, metrics, assets) rather than fetching from an
+// external source.
+type Pvindex struct{}
+
+func init() {
+	provider.Register("pvindex", &Pvindex{})
+}
+
+func (p *Pvindex) Name() string {
+	return "pvindex"
+}
+
+func (p *Pvindex) Description() string {
+	return "Derived index provider that computes investable universes from canonical EOD, metric, and asset views."
+}
+
+func (p *Pvindex) ConfigDescription() map[string]string {
+	return map[string]string{
+		"index_ticker":        "Optional. Override the index ticker (default: us-tradable).",
+		"start_date_override": "Optional. Force a later start date in YYYY-MM-DD format. Used for testing or selective backfill.",
+		"chunk_size_days":     "Optional. Number of trading days per processing chunk (default: 63).",
+	}
+}
+
+func (p *Pvindex) Datasets() map[string]provider.Dataset {
+	return map[string]provider.Dataset{
+		"US Tradable Universe": {
+			Name:        "US Tradable Universe",
+			Description: "Daily-recomputed investable universe of US common stocks: structural + liquidity + size + price filters with annual cap-weighted snapshots.",
+			DataTypes: []*data.DataType{
+				data.DataTypes[data.IndexSnapshotKey],
+				data.DataTypes[data.IndexChangelogKey],
+			},
+			DateRange: func() (time.Time, time.Time) {
+				// Stub: real implementation lands in Task 11.
+				return time.Date(1999, 4, 30, 0, 0, 0, 0, time.UTC), time.Now().UTC()
+			},
+			TTL:   0,
+			Fetch: fetchTradableUniverse,
+		},
+	}
+}
+
+// fetchTradableUniverse is the dataset Fetch entry point. Real implementation lands in Task 12.
+func fetchTradableUniverse(ctx context.Context, sub *library.Subscription, out chan<- *data.Observation, exit chan<- data.RunSummary) {
+	exit <- data.RunSummary{
+		StartTime:        time.Now(),
+		EndTime:          time.Now(),
+		SubscriptionID:   sub.ID,
+		SubscriptionName: sub.Name,
+		Status:           data.RunSuccess,
+	}
+}

--- a/provider/pvindex/pvindex_suite_test.go
+++ b/provider/pvindex/pvindex_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPvindex(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pvindex Suite")
+}

--- a/provider/pvindex/pvindex_test.go
+++ b/provider/pvindex/pvindex_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/penny-vault/pvdata/data"
 	"github.com/penny-vault/pvdata/provider"
 )
 
@@ -43,5 +44,7 @@ var _ = Describe("pvindex Provider", func() {
 		p := provider.Map["pvindex"]
 		ds := p.Datasets()["US Tradable Universe"]
 		Expect(ds.DataTypes).To(HaveLen(2))
+		typeNames := []string{ds.DataTypes[0].Name, ds.DataTypes[1].Name}
+		Expect(typeNames).To(ConsistOf(data.IndexSnapshotKey, data.IndexChangelogKey))
 	})
 })

--- a/provider/pvindex/pvindex_test.go
+++ b/provider/pvindex/pvindex_test.go
@@ -1,0 +1,47 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/provider"
+)
+
+var _ = Describe("pvindex Provider", func() {
+	It("registers itself in the provider map", func() {
+		p, ok := provider.Map["pvindex"]
+		Expect(ok).To(BeTrue())
+		Expect(p.Name()).To(Equal("pvindex"))
+	})
+
+	It("returns a non-empty description", func() {
+		p := provider.Map["pvindex"]
+		Expect(p.Description()).NotTo(BeEmpty())
+	})
+
+	It("declares the US Tradable Universe dataset", func() {
+		p := provider.Map["pvindex"]
+		datasets := p.Datasets()
+		Expect(datasets).To(HaveKey("US Tradable Universe"))
+	})
+
+	It("US Tradable Universe dataset emits IndexSnapshot and IndexChangelog data types", func() {
+		p := provider.Map["pvindex"]
+		ds := p.Datasets()["US Tradable Universe"]
+		Expect(ds.DataTypes).To(HaveLen(2))
+	})
+})

--- a/provider/pvindex/rolling.go
+++ b/provider/pvindex/rolling.go
@@ -1,0 +1,72 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"sort"
+	"time"
+)
+
+// eodRow is the in-memory representation of one EOD row used by the rolling-window
+// computation. We do not reuse data.Eod because it carries OHLC fields we don't need
+// and we want a tightly-packed struct for the chunk loader's memory budget.
+type eodRow struct {
+	Date   time.Time
+	Close  float64
+	Volume float64
+}
+
+// stats holds the rolling-window statistics for a single FIGI.
+type stats struct {
+	dayCount int
+	medianDV float64
+}
+
+// rollingStats computes (count, median dollar volume) over the rows whose Date
+// falls within [windowStart, windowEnd] inclusive. Rows are assumed to be sorted by
+// date but the implementation does not require it. Returns zero values if no rows
+// fall in the window.
+func rollingStats(rows []eodRow, windowStart, windowEnd time.Time) stats {
+	if len(rows) == 0 {
+		return stats{}
+	}
+
+	dvs := make([]float64, 0, len(rows))
+
+	for _, r := range rows {
+		if r.Date.Before(windowStart) || r.Date.After(windowEnd) {
+			continue
+		}
+
+		dvs = append(dvs, r.Close*r.Volume)
+	}
+
+	if len(dvs) == 0 {
+		return stats{}
+	}
+
+	sort.Float64s(dvs)
+
+	var median float64
+
+	mid := len(dvs) / 2
+	if len(dvs)%2 == 1 {
+		median = dvs[mid]
+	} else {
+		median = (dvs[mid-1] + dvs[mid]) / 2
+	}
+
+	return stats{dayCount: len(dvs), medianDV: median}
+}

--- a/provider/pvindex/rolling_test.go
+++ b/provider/pvindex/rolling_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvindex
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("rollingStats", func() {
+	mkRow := func(date string, close, vol float64) eodRow {
+		t, _ := time.Parse("2006-01-02", date)
+		return eodRow{Date: t, Close: close, Volume: vol}
+	}
+
+	It("returns count and median over a window with all rows in range", func() {
+		rows := []eodRow{
+			mkRow("2024-01-02", 10, 100), // dv=1000
+			mkRow("2024-01-03", 20, 100), // dv=2000
+			mkRow("2024-01-04", 30, 100), // dv=3000
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-04")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(3))
+		Expect(stats.medianDV).To(Equal(2000.0))
+	})
+
+	It("ignores rows outside the window", func() {
+		rows := []eodRow{
+			mkRow("2023-12-30", 10, 100),
+			mkRow("2024-01-02", 20, 100), // dv=2000
+			mkRow("2024-01-03", 30, 100), // dv=3000
+			mkRow("2024-01-05", 40, 100),
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-02")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-04")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(2))
+		Expect(stats.medianDV).To(Equal(2500.0))
+	})
+
+	It("returns zero stats for empty input", func() {
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-31")
+		stats := rollingStats(nil, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(0))
+		Expect(stats.medianDV).To(Equal(0.0))
+	})
+
+	It("computes median correctly for odd-count window", func() {
+		rows := []eodRow{
+			mkRow("2024-01-01", 10, 100), // dv=1000
+			mkRow("2024-01-02", 20, 100), // dv=2000
+			mkRow("2024-01-03", 30, 100), // dv=3000
+			mkRow("2024-01-04", 40, 100), // dv=4000
+			mkRow("2024-01-05", 50, 100), // dv=5000
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-05")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(5))
+		Expect(stats.medianDV).To(Equal(3000.0))
+	})
+
+	It("computes median correctly for even-count window", func() {
+		rows := []eodRow{
+			mkRow("2024-01-01", 10, 100), // dv=1000
+			mkRow("2024-01-02", 20, 100), // dv=2000
+			mkRow("2024-01-03", 30, 100), // dv=3000
+			mkRow("2024-01-04", 40, 100), // dv=4000
+		}
+		windowStart, _ := time.Parse("2006-01-02", "2024-01-01")
+		windowEnd, _ := time.Parse("2006-01-02", "2024-01-04")
+		stats := rollingStats(rows, windowStart, windowEnd)
+		Expect(stats.dayCount).To(Equal(4))
+		Expect(stats.medianDV).To(Equal(2500.0))
+	})
+})

--- a/web/observation_summary_test.go
+++ b/web/observation_summary_test.go
@@ -33,7 +33,7 @@ var _ = Describe("summarizeObservation", func() {
 	It("summarizes an IndexSnapshot", func() {
 		obs := &data.Observation{
 			IndexSnapshot: &data.IndexSnapshot{
-				IndexTicker:    "sp-500",
+				IndexTicker:  "sp-500",
 				SnapshotDate: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
 				Constituents: []data.IndexConstituent{
 					{Ticker: "AAPL", CompositeFigi: "BBG000B9XRY4", Weight: 0.0712},
@@ -50,10 +50,10 @@ var _ = Describe("summarizeObservation", func() {
 		obs := &data.Observation{
 			IndexChange: &data.IndexChange{
 				IndexTicker: "sp-500",
-				Ticker:    "NVDA",
-				Action:    "add",
-				Weight:    0.0523,
-				EventDate: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+				Ticker:      "NVDA",
+				Action:      "add",
+				Weight:      0.0523,
+				EventDate:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
 			},
 		}
 		typ, summary := summarizeObservation(obs)


### PR DESCRIPTION
## Summary

Adds a new `provider/pvindex/` package that produces a daily-recomputed investable universe of US-listed common stocks (`us-tradable`) by reading from the canonical published views (`eod`, `metrics`, `assets`) and emitting `IndexSnapshot` and `IndexChange` observations.

This is the first **derived** provider in the codebase — it doesn't fetch from an external source. Instead, it applies a deterministic filter chain locally and reuses the existing `index-snapshot` / `index-changelog` schemas, so downstream consumers can query it the same way as iShares or Nasdaq indices.

**Spec:** `docs/superpowers/specs/2026-04-07-pvindex-tradable-universe-design.md`
**Plan:** `docs/superpowers/plans/2026-04-07-pvindex-tradable-universe.md`

## Filter chain

For each evaluation date `D`:

1. **Asset master** — `active=true`, `asset_type='CS'`, exchange in {NASDAQ, NYSE, NYSE MKT, NYSE ARCA, BATS, AMEX, plus MIC-code aliases}, name does NOT end in LP/L.P./L P/LLP/Limited Partnership.
2. **Rolling 200d stats** — count + median dollar volume per FIGI.
3. **Percentile baseline** — 25th and 80th percentile of broad CS market caps on D.
4. **Data availability** — standard path needs 200 contiguous trading days; early-entry path admits big IPOs (30-199 days + top-quintile market cap), so e.g. Snowflake/Reddit enter ~6 weeks after listing instead of waiting 10 months.
5. **Share-class dedup** — group by CIK (composite_figi fallback), keep highest median DV.
6. **25th percentile size filter** — drop bottom quartile by market cap.
7. **Liquidity filter** — 200d median dollar volume ≥ \$2.5M.
8. **Price guard rail** — prior close ≥ \$2.
9. **Cap-weight assignment** — sums to 1.0.

## Output

- **Annual snapshots** with full cap-weights (matches pvbt convention).
- **Daily changelog** with adds/removes/weight-changes.
- **Weight-change events** use a 25% relative threshold (new `DiffSnapshotsWithThreshold` helper) since the existing 1% absolute threshold never fires for a ~3,000-name universe with ~0.03% per-name weights.

## Notable bug fixes

- `provider/index_helpers.go`: epsilon mismatch between new `DiffSnapshotsWithThreshold` and legacy `DiffSnapshots` (1e-12 → 1e-9, matching legacy).
- `provider/pvindex/date_range.go` and `chunk.go`: \`trading_days(\$1::date + INTERVAL '400 days', ...)\` was failing at runtime because \`date + INTERVAL\` returns timestamp, not date. Added explicit \`::date\` casts.
- `checks/audit_runner_test.go`, `web/observation_summary_test.go`: pre-existing gofmt whitespace issues in main, fixed so \`make lint\` passes.

## Scoping notes

- **No DB-backed integration tests.** Per project preference, all tests are unit tests using synthetic in-memory fixtures (51 specs, all passing). The DB loaders (\`loadCandidateAssets\`, \`loadEodChunk\`, \`loadMarketCapAsOf\`, \`loadBroadMarketCaps\`, \`computeDateRange\`, \`chunkTradingDays\`, \`loadTrailingWindow\`) should be exercised by a manual smoke test before merging.
- **Exchange field has mixed format** in the assets table (display names like \`NASDAQ\` plus MIC codes like \`XNAS\`). The whitelist accepts both as a workaround; flagged in the design spec as a known limitation needing a separate cleanup task.

## Test plan

- [x] \`make lint\` — clean (0 issues)
- [x] \`make test\` — 13 suites pass, **51/51 pvindex specs**, no regressions
- [x] \`make build\` — clean
- [ ] **Manual smoke test:** create a \`pvindex\` subscription with \`start_date_override = 2024-12-01\` and run it on-demand. Verify the snapshot table gets populated and \`run_history\` shows success.
- [ ] **Optional:** register the resulting tables as additional sources on the canonical \`indices_snapshot\` and \`indices_changelog\` published views so consumers can query \`SELECT * FROM indices_snapshot WHERE index_ticker='us-tradable'\`.