### PR TITLE
fix(sec): eliminate spurious 10-Q periods and de-cumulate YTD cash flow

### DIFF
--- a/cmd/compare_fundamentals.go
+++ b/cmd/compare_fundamentals.go
@@ -29,6 +29,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/mattn/go-isatty"
 	"github.com/penny-vault/pvdata/data"
 	"github.com/penny-vault/pvdata/library"
 	"github.com/rs/zerolog/log"
@@ -1006,9 +1007,19 @@ func runCompareFundamentals(cmd *cobra.Command, args []string) {
 		doneCh <- err
 	}()
 
-	program := tea.NewProgram(newCFModel(progressCh, doneCh))
-	if _, runErr := program.Run(); runErr != nil {
-		log.Error().Err(runErr).Msg("TUI error")
+	if !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		// No TTY available -- drain progress channel and wait for completion
+		for range progressCh {
+		}
+
+		if compErr := <-doneCh; compErr != nil {
+			log.Fatal().Err(compErr).Msg("comparison failed")
+		}
+	} else {
+		program := tea.NewProgram(newCFModel(progressCh, doneCh))
+		if _, runErr := program.Run(); runErr != nil {
+			log.Error().Err(runErr).Msg("TUI error")
+		}
 	}
 
 	if cerr := writer.Close(); cerr != nil {

--- a/provider/index_helpers.go
+++ b/provider/index_helpers.go
@@ -111,7 +111,6 @@ func DiffSnapshots(current, previous map[string]IndexMember) (added, removed, we
 	return
 }
 
-
 // LastSnapshotDate queries the database for the most recent snapshot date for the given index.
 func LastSnapshotDate(ctx context.Context, pool *pgxpool.Pool, table, indexTicker string) time.Time {
 	conn, err := pool.Acquire(ctx)

--- a/provider/index_helpers_test.go
+++ b/provider/index_helpers_test.go
@@ -233,4 +233,3 @@ var _ = Describe("currentIndexMembers", func() {
 		Expect(result).To(BeEmpty())
 	})
 })
-

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -79,10 +79,24 @@ func IdentifyPeriods(cf *CompanyFacts) []Period {
 
 	// First pass: group raw facts by exact (end, form) pair so we collect
 	// AR/MR filed dates per raw period end.
+	//
+	// Only duration concepts (those with a non-zero Start date) drive period
+	// identification. Instant concepts (balance sheet items like Assets that
+	// have no Start date) supplement existing periods during field resolution
+	// but must not create new periods on their own. Without this filter,
+	// comparative balance sheet data included in 10-Q filings (which reports
+	// instant values as of the prior fiscal year-end) would create spurious
+	// 10-Q periods at fiscal year-end dates. Those fake periods resolve only
+	// balance sheet fields, leaving revenues and shares at zero, which trips
+	// inline data quality checks.
 	rawPeriods := make(map[periodKey]*Period)
 
 	for _, facts := range cf.Facts {
 		for _, f := range facts {
+			if f.Start.IsZero() {
+				continue
+			}
+
 			key := periodKey{end: f.End, form: f.Form}
 
 			p, exists := rawPeriods[key]
@@ -265,6 +279,75 @@ func ResolveFieldsForFiling(cf *CompanyFacts, periodEnd time.Time, formType stri
 	}
 
 	return ResolveAllFields(filtered, periodEnd, formType)
+}
+
+// DecumulateYTD converts YTD cumulative values in a 10-Q resolved field map to
+// single-quarter values by subtracting the prior quarter's (also YTD) values.
+//
+// SEC 10-Q filings report cash flow items as year-to-date cumulative values
+// only -- no single-quarter fact exists. Income statement items typically have
+// both a single-quarter and a YTD fact; ResolveDirect's shorter-duration
+// preference already picks the quarterly fact for those. This function handles
+// the remaining YTD-only fields.
+//
+// current and prior are the original resolved field maps (prior may contain YTD
+// values). cf is the unfiltered CompanyFacts used to determine which fields are
+// YTD via needsDecumulation. The returned map is a copy; current and prior are
+// not modified.
+//
+// After de-cumulating direct fields, derived flow fields are recomputed from the
+// de-cumulated components. Metric-type derived fields (ratios) are then
+// recomputed from the updated flow/point-in-time values.
+func DecumulateYTD(cf *CompanyFacts, current, prior map[string]float64, periodEnd time.Time, formType string) map[string]float64 {
+	result := make(map[string]float64, len(current))
+	for k, v := range current {
+		result[k] = v
+	}
+
+	// Pass 1: de-cumulate direct and fallback-resolved flow fields.
+	for _, m := range FieldMappings {
+		if m.StatementType != StmtFlow {
+			continue
+		}
+
+		if !needsDecumulation(cf, m, periodEnd, formType) {
+			continue
+		}
+
+		currVal, hasCurr := current[m.FieldName]
+		priorVal, hasPrior := prior[m.FieldName]
+
+		if hasCurr && hasPrior {
+			result[m.FieldName] = currVal - priorVal
+		}
+	}
+
+	// Pass 2: recompute derived flow fields from (now de-cumulated) components.
+	// This handles cases like FreeCashFlow = NetCashFlowFromOperations -
+	// CapitalExpenditure where both operands are cash flow YTD values.
+	for _, m := range FieldMappings {
+		if m.Type != MappingDerived || m.StatementType != StmtFlow {
+			continue
+		}
+
+		if val, ok := computeDerived(m, result); ok {
+			result[m.FieldName] = val
+		}
+	}
+
+	// Pass 3: recompute metric-type derived fields (ratios like EBITDAMargin)
+	// since their flow operands may have changed.
+	for _, m := range FieldMappings {
+		if m.Type != MappingDerived || m.StatementType != StmtMetric {
+			continue
+		}
+
+		if val, ok := computeDerived(m, result); ok {
+			result[m.FieldName] = val
+		}
+	}
+
+	return result
 }
 
 // ComputeTTM computes trailing twelve month values from the 4 most recent quarterly

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -118,6 +118,96 @@ var _ = Describe("Dimensions", func() {
 				Expect(p.MRFiledDate).To(Equal(time.Date(2018, 11, 15, 0, 0, 0, 0, time.UTC)))
 			})
 
+			It("excludes spurious 10-Q periods created by comparative balance sheet data", func() {
+				// Simulate Apple's Q1 10-Q (covering Oct-Dec 2024) which includes
+				// comparative balance sheet data (instant concepts like Assets)
+				// as of the prior fiscal year-end (2024-09-28). IdentifyPeriods
+				// should NOT create a 10-Q period at 2024-09-28 -- that date
+				// belongs to the 10-K only.
+				comparativeCF := &CompanyFacts{
+					CIK:        320193,
+					EntityName: "Apple Inc",
+					Facts: map[string][]Fact{
+						"Revenues": {
+							// Real Q1 10-Q revenue (duration concept)
+							{
+								Val:   100000,
+								Start: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC),
+								Form:  "10-Q",
+								FY:    2025,
+								FP:    "Q1",
+								Filed: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+							},
+							// Annual revenue (duration concept)
+							{
+								Val:   400000,
+								Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+								Form:  "10-K",
+								FY:    2024,
+								FP:    "FY",
+								Filed: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC),
+							},
+						},
+						"Assets": {
+							// Q1 10-Q balance sheet (instant concept, current quarter)
+							{
+								Val:   500000,
+								End:   time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC),
+								Form:  "10-Q",
+								FY:    2025,
+								FP:    "Q1",
+								Filed: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+							},
+							// Q1 10-Q comparative balance sheet (instant concept
+							// at PRIOR fiscal year-end) -- this is the problematic
+							// fact that was creating a spurious 10-Q period.
+							{
+								Val:   480000,
+								End:   time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+								Form:  "10-Q",
+								FY:    2025,
+								FP:    "Q1",
+								Filed: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+							},
+							// Annual balance sheet (instant concept)
+							{
+								Val:   480000,
+								End:   time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+								Form:  "10-K",
+								FY:    2024,
+								FP:    "FY",
+								Filed: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC),
+							},
+						},
+					},
+				}
+
+				periods := IdentifyPeriods(comparativeCF)
+
+				// Should have exactly 2 periods: one 10-Q for Q1 2025 and one
+				// 10-K for FY2024. The comparative balance sheet data at the
+				// fiscal year-end should NOT create a third (spurious) 10-Q period.
+				Expect(periods).To(HaveLen(2))
+
+				formTypes := map[string]bool{}
+				for _, p := range periods {
+					formTypes[p.FormType] = true
+				}
+
+				Expect(formTypes).To(HaveKey("10-Q"))
+				Expect(formTypes).To(HaveKey("10-K"))
+
+				// The 10-Q period should be for Q1 (Dec 2024), not the fiscal year-end (Sep 2024).
+				for _, p := range periods {
+					if p.FormType == "10-Q" {
+						Expect(p.PeriodEnd).To(Equal(time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC)),
+							"10-Q period should be at Q1 end, not at fiscal year-end")
+					}
+				}
+			})
+
 			It("keeps distinct calendar quarters as separate periods", func() {
 				// Q2 2018 (2018-06-30) and Q3 2018 (2018-09-30) normalize to
 				// different calendar quarter ends and must remain separate.
@@ -298,6 +388,129 @@ var _ = Describe("Dimensions", func() {
 			Expect(obs["MRQ"]).To(Equal(0))
 			Expect(obs["ART"]).To(Equal(0))
 			Expect(obs["MRT"]).To(Equal(0))
+		})
+	})
+
+	Describe("YTD cash flow de-cumulation", func() {
+		It("de-cumulates YTD cash flow values to single-quarter values", func() {
+			// Build 3 consecutive quarters with:
+			// - Income statement items: both quarterly and YTD facts (should pick quarterly)
+			// - Cash flow items: ONLY YTD facts (should be de-cumulated)
+			cf := &CompanyFacts{
+				CIK:        1,
+				EntityName: "YTD Co",
+				Facts:      make(map[string][]Fact),
+			}
+
+			q1End := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+			q2End := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+			q3End := time.Date(2024, 9, 30, 0, 0, 0, 0, time.UTC)
+			fyStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			q1Filed := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+			q2Filed := time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)
+			q3Filed := time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)
+
+			// Revenues: quarterly facts (90 days each)
+			// Q1=100, Q2=120, Q3=110
+			cf.Facts["Revenues"] = []Fact{
+				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 100, Form: "10-Q", FP: "Q1"},
+				// Q2 has both quarterly and YTD
+				{Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 120, Form: "10-Q", FP: "Q2"},
+				{Start: fyStart, End: q2End, Filed: q2Filed, Val: 220, Form: "10-Q", FP: "Q2"}, // YTD
+				// Q3 has both quarterly and YTD
+				{Start: q2End.AddDate(0, 0, 1), End: q3End, Filed: q3Filed, Val: 110, Form: "10-Q", FP: "Q3"},
+				{Start: fyStart, End: q3End, Filed: q3Filed, Val: 330, Form: "10-Q", FP: "Q3"}, // YTD
+			}
+
+			// NetIncomeLoss: quarterly facts
+			cf.Facts["NetIncomeLoss"] = []Fact{
+				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 20, Form: "10-Q", FP: "Q1"},
+				{Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 25, Form: "10-Q", FP: "Q2"},
+				{Start: fyStart, End: q2End, Filed: q2Filed, Val: 45, Form: "10-Q", FP: "Q2"}, // YTD
+				{Start: q2End.AddDate(0, 0, 1), End: q3End, Filed: q3Filed, Val: 22, Form: "10-Q", FP: "Q3"},
+				{Start: fyStart, End: q3End, Filed: q3Filed, Val: 67, Form: "10-Q", FP: "Q3"}, // YTD
+			}
+
+			// Cash flow (operations): YTD ONLY (no quarterly facts)
+			// Q1=50, cumulative Q2=110 (Q2 alone=60), cumulative Q3=180 (Q3 alone=70)
+			cf.Facts["NetCashProvidedByUsedInOperatingActivities"] = []Fact{
+				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 50, Form: "10-Q", FP: "Q1"},
+				{Start: fyStart, End: q2End, Filed: q2Filed, Val: 110, Form: "10-Q", FP: "Q2"},  // YTD
+				{Start: fyStart, End: q3End, Filed: q3Filed, Val: 180, Form: "10-Q", FP: "Q3"},  // YTD
+			}
+
+			// CapEx: YTD ONLY
+			// Q1=10, cumulative Q2=22 (Q2 alone=12), cumulative Q3=35 (Q3 alone=13)
+			cf.Facts["PaymentsToAcquirePropertyPlantAndEquipment"] = []Fact{
+				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 10, Form: "10-Q", FP: "Q1"},
+				{Start: fyStart, End: q2End, Filed: q2Filed, Val: 22, Form: "10-Q", FP: "Q2"},
+				{Start: fyStart, End: q3End, Filed: q3Filed, Val: 35, Form: "10-Q", FP: "Q3"},
+			}
+
+			// Balance sheet (instant, for period identification support)
+			cf.Facts["Assets"] = []Fact{
+				{End: q1End, Filed: q1Filed, Val: 1000, Form: "10-Q", FP: "Q1"},
+				{End: q2End, Filed: q2Filed, Val: 1050, Form: "10-Q", FP: "Q2"},
+				{End: q3End, Filed: q3Filed, Val: 1100, Form: "10-Q", FP: "Q3"},
+			}
+
+			asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+			out := make(chan *data.Observation, 256)
+			sub := &library.Subscription{Name: "test"}
+
+			done := make(chan struct{})
+			results := make(map[string]map[string]*data.Fundamental)
+
+			go func() {
+				for obs := range out {
+					dim := obs.Fundamental.Dimension
+					dateKey := obs.ObservationDate.Format("2006-01-02")
+					key := dim + ":" + dateKey
+					if results[key] == nil {
+						results[key] = make(map[string]*data.Fundamental)
+					}
+					results[key][dim] = obs.Fundamental
+				}
+				close(done)
+			}()
+
+			numObs := 0
+			emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+			close(out)
+			<-done
+
+			// Q1 (2024-03-31): no de-cumulation needed
+			q1ARQ := results["ARQ:2024-03-31"]["ARQ"]
+			Expect(q1ARQ).NotTo(BeNil())
+			Expect(q1ARQ.Revenues).To(Equal(int64(100)))
+			Expect(q1ARQ.NetCashFlowFromOperations).To(Equal(int64(50)))
+			Expect(q1ARQ.CapitalExpenditure).To(Equal(int64(10)))
+
+			// Q2 (2024-06-30): should be de-cumulated
+			q2ARQ := results["ARQ:2024-06-30"]["ARQ"]
+			Expect(q2ARQ).NotTo(BeNil())
+			Expect(q2ARQ.Revenues).To(Equal(int64(120)),
+				"revenues should be quarterly (shorter-duration preference), not YTD")
+			Expect(q2ARQ.NetCashFlowFromOperations).To(Equal(int64(60)),
+				"cash flow should be de-cumulated: 110 (YTD) - 50 (Q1) = 60")
+			Expect(q2ARQ.CapitalExpenditure).To(Equal(int64(12)),
+				"cap-ex should be de-cumulated: 22 (YTD) - 10 (Q1) = 12")
+
+			// Q3 (2024-09-30): should be de-cumulated using Q2's ORIGINAL YTD
+			q3ARQ := results["ARQ:2024-09-30"]["ARQ"]
+			Expect(q3ARQ).NotTo(BeNil())
+			Expect(q3ARQ.Revenues).To(Equal(int64(110)),
+				"revenues should be quarterly")
+			Expect(q3ARQ.NetCashFlowFromOperations).To(Equal(int64(70)),
+				"cash flow should be de-cumulated: 180 (YTD) - 110 (Q2 YTD) = 70")
+			Expect(q3ARQ.CapitalExpenditure).To(Equal(int64(13)),
+				"cap-ex should be de-cumulated: 35 (YTD) - 22 (Q2 YTD) = 13")
+
+			// FreeCashFlow is derived: NetCashFlowFromOperations - CapitalExpenditure
+			Expect(q2ARQ.FreeCashFlow).To(Equal(int64(48)),
+				"free cash flow should be re-derived from de-cumulated components: 60 - 12 = 48")
+			Expect(q3ARQ.FreeCashFlow).To(Equal(int64(57)),
+				"free cash flow should be re-derived: 70 - 13 = 57")
 		})
 	})
 

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -77,22 +77,31 @@ func ResolveDirect(cf *CompanyFacts, m FieldMapping, periodEnd time.Time, formTy
 				continue
 			}
 
-			// For duration concepts, verify the period length is reasonable
-			// (roughly a quarter for 10-Q, roughly a year for 10-K)
+			// For duration concepts, verify the period length is reasonable.
 			if !f.Start.IsZero() {
 				days := f.End.Sub(f.Start).Hours() / 24
 				if formType == "10-K" && days < 300 {
 					continue // Skip quarterly data in an annual filing
 				}
-
-				if formType == "10-Q" && days > 200 {
-					continue // Skip annual data in a quarterly filing
-				}
 			}
 
-			// Prefer the fact with the latest filing date (most recent data)
+			// Prefer the fact with the latest filing date (most recent data).
+			// When filing dates are equal, prefer the shorter duration. SEC
+			// 10-Q filings report both single-quarter (~90 days) and YTD
+			// cumulative (Q2: ~180, Q3: ~270 days) facts for income statement
+			// items. Cash flow items only have YTD facts. By preferring the
+			// shortest duration among same-filing-date facts, we pick the
+			// single-quarter value when available and fall through to the
+			// YTD value when it's the only option.
 			if best == nil || f.Filed.After(best.Filed) {
 				best = f
+			} else if f.Filed.Equal(best.Filed) && !f.Start.IsZero() && !best.Start.IsZero() {
+				fDays := f.End.Sub(f.Start).Hours() / 24
+				bestDays := best.End.Sub(best.Start).Hours() / 24
+
+				if fDays < bestDays {
+					best = f
+				}
 			}
 		}
 
@@ -102,6 +111,75 @@ func ResolveDirect(cf *CompanyFacts, m FieldMapping, periodEnd time.Time, formTy
 	}
 
 	return 0, false
+}
+
+// ytdThresholdDays is the maximum duration (in days) of a single-quarter fact.
+// Facts longer than this in a 10-Q filing are treated as YTD cumulative values
+// that need de-cumulation. A standard quarter is ~90 days; 120 provides margin
+// for unusual fiscal calendars while cleanly excluding 2-quarter YTD (~180 days).
+const ytdThresholdDays = 120
+
+// needsDecumulation reports whether a flow field's best-matching fact for the
+// given 10-Q period is a YTD cumulative value. It mirrors ResolveDirect's tag
+// priority: the first tag with matching facts determines the answer.
+//
+// Returns true when the matching tag has duration facts for the period end but
+// none of them are single-quarter (all > ytdThresholdDays). This indicates the
+// SEC filing only reported YTD cumulative values for this concept, as is
+// standard for cash flow statement items.
+func needsDecumulation(cf *CompanyFacts, m FieldMapping, periodEnd time.Time, formType string) bool {
+	if formType != "10-Q" {
+		return false
+	}
+
+	if m.StatementType != StmtFlow {
+		return false
+	}
+
+	normalPeriodEnd := NormalizeEventDate(periodEnd, formType)
+
+	tags := m.XBRLTags
+	if m.Type == MappingDerived {
+		tags = m.FallbackTags
+	}
+
+	for _, tag := range tags {
+		facts, ok := cf.Facts[tag]
+		if !ok {
+			continue
+		}
+
+		var hasMatch bool
+
+		for i := range facts {
+			f := &facts[i]
+
+			if f.Form != formType {
+				continue
+			}
+
+			if !NormalizeEventDate(f.End, formType).Equal(normalPeriodEnd) {
+				continue
+			}
+
+			if f.Start.IsZero() {
+				continue // instant concept, not applicable
+			}
+
+			hasMatch = true
+
+			days := f.End.Sub(f.Start).Hours() / 24
+			if days <= ytdThresholdDays {
+				return false // found a quarterly fact, no de-cumulation needed
+			}
+		}
+
+		if hasMatch {
+			return true // this tag has only YTD facts
+		}
+	}
+
+	return false
 }
 
 // ResolveAllFields resolves all configured field mappings for a given period.

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -380,9 +380,13 @@ var FieldMappings = []FieldMapping{
 	},
 	{
 		FieldName: "WeightedAverageSharesDiluted", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		// WeightedAverageNumberOfSharesOutstandingBasic is the final fallback
+		// because in loss periods the diluted count is antidilutive and many
+		// filers omit the diluted tag entirely; in those cases basic ≡ diluted.
 		XBRLTags: []string{
 			"WeightedAverageNumberOfDilutedSharesOutstanding",
 			"WeightedAverageNumberOfShareOutstandingBasicAndDiluted",
+			"WeightedAverageNumberOfSharesOutstandingBasic",
 		},
 	},
 
@@ -465,7 +469,10 @@ var FieldMappings = []FieldMapping{
 		FieldName: "NetCashFlowInvest", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
 		XBRLTags: []string{
 			"PaymentsToAcquireInvestments",
+			"PaymentsToAcquireAvailableForSaleSecuritiesDebt",
 			"ProceedsFromSaleAndMaturityOfMarketableSecurities",
+			"ProceedsFromMaturitiesPrepaymentsAndCallsOfAvailableForSaleSecurities",
+			"ProceedsFromSaleOfAvailableForSaleSecuritiesDebt",
 		},
 	},
 	{

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -118,6 +118,52 @@ var _ = Describe("Mapping Engine", func() {
 			}, periodEnd, "10-K")
 			Expect(ok).To(BeFalse())
 		})
+
+		It("prefers single-quarter facts over YTD cumulative facts in 10-Q", func() {
+			// Simulate Apple's Q2 10-Q where both a 90-day single-quarter
+			// fact and a 181-day YTD cumulative fact exist for the same
+			// period end and filing date. ResolveDirect must pick the
+			// single-quarter value.
+			q2End := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			ytdCF := &CompanyFacts{
+				CIK:        320193,
+				EntityName: "Apple Inc",
+				Facts: map[string][]Fact{
+					"RevenueFromContractWithCustomerExcludingAssessedTax": {
+						// YTD 6-month cumulative (Q1+Q2)
+						{
+							Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+							End:   q2End,
+							Filed: filed,
+							Val:   210_328_000_000,
+							Form:  "10-Q",
+							FP:    "Q2",
+						},
+						// Single quarter (Q2 only)
+						{
+							Start: time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC),
+							End:   q2End,
+							Filed: filed,
+							Val:   90_753_000_000,
+							Form:  "10-Q",
+							FP:    "Q2",
+						},
+					},
+				},
+			}
+
+			val, ok := ResolveDirect(ytdCF, FieldMapping{
+				FieldName: "Revenues",
+				Type:      MappingDirect,
+				XBRLTags:  []string{"RevenueFromContractWithCustomerExcludingAssessedTax"},
+			}, q2End, "10-Q")
+
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(90_753_000_000.0),
+				"should pick single-quarter revenue, not YTD cumulative")
+		})
 	})
 
 	Describe("ResolveAllFields", func() {
@@ -131,6 +177,39 @@ var _ = Describe("Mapping Engine", func() {
 
 			_, hasAssets := resolved["TotalAssets"]
 			Expect(hasAssets).To(BeTrue())
+		})
+
+		It("falls back to basic weighted-average shares when diluted tags are absent", func() {
+			// Simulates a loss-quarter filer (e.g. Nordstrom during COVID,
+			// Vaxart as a pre-revenue biotech) that reports only the basic
+			// weighted-average share count because the diluted figure is
+			// antidilutive. The fallback must still produce a positive value
+			// so PositiveShares does not reject the observation.
+			periodStart := time.Date(2020, 2, 2, 0, 0, 0, 0, time.UTC)
+			periodEnd := time.Date(2020, 5, 2, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2020, 6, 10, 0, 0, 0, 0, time.UTC)
+
+			lossCF := &CompanyFacts{
+				CIK:        12345,
+				EntityName: "Loss Co",
+				Facts: map[string][]Fact{
+					"WeightedAverageNumberOfSharesOutstandingBasic": {
+						{
+							Start: periodStart,
+							End:   periodEnd,
+							Filed: filed,
+							Val:   157_000_000,
+							Form:  "10-Q",
+						},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(lossCF, periodEnd, "10-Q")
+
+			val, ok := resolved["WeightedAverageSharesDiluted"]
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(float64(157_000_000)))
 		})
 	})
 })

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -488,14 +488,16 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 	// the true latest-period coverage for the company.
 	var latestPeriodEnd time.Time
 
-	// Collect quarterly periods for TTM computation, keyed by normalized event date.
-	// All quarters are kept (even those filtered out below) so TTM windows can
-	// still find their constituent quarters; the since check is reapplied per
-	// window when emitting TTM observations.
+	// Collect quarterly periods for de-cumulation and TTM computation. All
+	// quarters are kept (even those filtered by since) so TTM windows and
+	// de-cumulation chains remain complete; the since check is reapplied when
+	// emitting.
 	type quarterData struct {
 		period   Period
-		arFields map[string]float64
-		mrFields map[string]float64
+		arFields map[string]float64 // original resolved values (may be YTD for cash flow)
+		mrFields map[string]float64 // original resolved values (may be YTD for cash flow)
+		arEmit   map[string]float64 // de-cumulated values for emission and TTM
+		mrEmit   map[string]float64 // de-cumulated values for emission and TTM
 	}
 
 	var quarters []quarterData
@@ -531,41 +533,13 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			latestPeriodCoverage = len(arFields)
 		}
 
-		// Skip emitting per-period observations for periods filed before since.
-		// MRFiledDate is used so that restatements filed after since are re-emitted.
-		if !since.IsZero() && p.MRFiledDate.Before(since) {
-			continue
-		}
-
-		if p.FormType == "10-Q" {
-			// ARQ
-			fundamental := BuildFundamental(arFields, asset.Ticker, asset.CompositeFigi, "ARQ",
-				p.ARFiledDate, calendarDate, p.PeriodEnd, p.ARFiledDate)
-			out <- &data.Observation{
-				Fundamental:      fundamental,
-				ObservationDate:  calendarDate,
-				SubscriptionID:   sub.ID,
-				SubscriptionName: sub.Name,
-			}
-
-			*numObservations++
-
-			// MRQ
-			fundamental = BuildFundamental(mrFields, asset.Ticker, asset.CompositeFigi, "MRQ",
-				p.PeriodEnd, calendarDate, p.PeriodEnd, p.MRFiledDate)
-			out <- &data.Observation{
-				Fundamental:      fundamental,
-				ObservationDate:  calendarDate,
-				SubscriptionID:   sub.ID,
-				SubscriptionName: sub.Name,
-			}
-
-			*numObservations++
-
-			periodsEmitted++
-		}
-
+		// Emit annual observations immediately (10-K data is always full-year,
+		// no de-cumulation needed).
 		if p.FormType == "10-K" {
+			if !since.IsZero() && p.MRFiledDate.Before(since) {
+				continue
+			}
+
 			// ARY
 			fundamental := BuildFundamental(arFields, asset.Ticker, asset.CompositeFigi, "ARY",
 				p.ARFiledDate, calendarDate, p.PeriodEnd, p.ARFiledDate)
@@ -594,7 +568,77 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		}
 	}
 
-	// Compute TTM for each quarter that has 4 preceding quarters
+	// De-cumulate YTD cash flow values for quarterly periods. SEC 10-Q filings
+	// report cash flow items as year-to-date cumulative values only. For Q1 the
+	// YTD equals the quarterly value; for Q2/Q3 we subtract the prior quarter's
+	// YTD to isolate the single-quarter amount.
+	//
+	// Consecutive quarters within the same fiscal year are identified by a gap
+	// of <= 120 days between period ends. A larger gap (e.g. Q3 -> Q1 across a
+	// 10-K boundary) means the current quarter is a new fiscal year's Q1 and
+	// its YTD value is already the quarterly value.
+	const maxQuarterGapDays = 120
+
+	for i := range quarters {
+		q := &quarters[i]
+
+		if i > 0 {
+			prev := &quarters[i-1]
+			gapDays := q.period.PeriodEnd.Sub(prev.period.PeriodEnd).Hours() / 24
+
+			if gapDays <= maxQuarterGapDays {
+				// Consecutive quarter in same fiscal year: de-cumulate using
+				// the prior quarter's ORIGINAL (pre-de-cumulation) YTD values.
+				q.arEmit = DecumulateYTD(cf, q.arFields, prev.arFields, q.period.PeriodEnd, q.period.FormType)
+				q.mrEmit = DecumulateYTD(cf, q.mrFields, prev.mrFields, q.period.PeriodEnd, q.period.FormType)
+
+				continue
+			}
+		}
+
+		// Q1 or no prior quarter: no de-cumulation needed.
+		q.arEmit = q.arFields
+		q.mrEmit = q.mrFields
+	}
+
+	// Emit quarterly observations using de-cumulated values.
+	for i := range quarters {
+		q := &quarters[i]
+		calendarDate := NormalizeEventDate(q.period.PeriodEnd, q.period.FormType)
+
+		if !since.IsZero() && q.period.MRFiledDate.Before(since) {
+			continue
+		}
+
+		// ARQ
+		fundamental := BuildFundamental(q.arEmit, asset.Ticker, asset.CompositeFigi, "ARQ",
+			q.period.ARFiledDate, calendarDate, q.period.PeriodEnd, q.period.ARFiledDate)
+		out <- &data.Observation{
+			Fundamental:      fundamental,
+			ObservationDate:  calendarDate,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		*numObservations++
+
+		// MRQ
+		fundamental = BuildFundamental(q.mrEmit, asset.Ticker, asset.CompositeFigi, "MRQ",
+			q.period.PeriodEnd, calendarDate, q.period.PeriodEnd, q.period.MRFiledDate)
+		out <- &data.Observation{
+			Fundamental:      fundamental,
+			ObservationDate:  calendarDate,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		*numObservations++
+
+		periodsEmitted++
+	}
+
+	// Compute TTM for each quarter that has 4 preceding quarters.
+	// Uses de-cumulated (single-quarter) values so the TTM sum is correct.
 	for i := 3; i < len(quarters); i++ {
 		q := quarters[i]
 		calendarDate := NormalizeEventDate(q.period.PeriodEnd, q.period.FormType)
@@ -653,10 +697,10 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			}
 		}
 
-		// ART
+		// ART — uses de-cumulated quarterly values
 		arQSlice := make([]map[string]float64, 4)
 		for j := 0; j < 4; j++ {
-			arQSlice[j] = quarters[i-3+j].arFields
+			arQSlice[j] = quarters[i-3+j].arEmit
 		}
 
 		if ttm := ComputeTTM(arQSlice); ttm != nil {
@@ -672,10 +716,10 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			*numObservations++
 		}
 
-		// MRT
+		// MRT — uses de-cumulated quarterly values
 		mrQSlice := make([]map[string]float64, 4)
 		for j := 0; j < 4; j++ {
-			mrQSlice[j] = quarters[i-3+j].mrFields
+			mrQSlice[j] = quarters[i-3+j].mrEmit
 		}
 
 		if ttm := ComputeTTM(mrQSlice); ttm != nil {


### PR DESCRIPTION
## Summary

Closes #37

- **Spurious 10-Q periods**: `IdentifyPeriods` now skips instant (balance sheet) facts when building periods. Comparative balance sheet data in 10-Q filings was creating fake 10-Q periods at fiscal year-end dates, producing observations with zero revenues that tripped inline data quality checks.
- **YTD de-cumulation**: SEC 10-Q filings report cash flow items as year-to-date cumulative values only. `ResolveDirect` now prefers shorter-duration facts (picking single-quarter over YTD for income statement items), and a new `DecumulateYTD` pass subtracts the prior quarter's YTD values for cash-flow-only fields. Derived fields (FreeCashFlow, EBITDA, etc.) are recomputed from the de-cumulated components.
- **TTY detection for compare-fundamentals**: Skips the TUI when no TTY is available, matching the existing pattern in the `run` command.
- **NetCashFlowInvest tag coverage**: Added fallback XBRL tags (`PaymentsToAcquireAvailableForSaleSecuritiesDebt`, `ProceedsFromMaturitiesPrepaymentsAndCallsOfAvailableForSaleSecurities`, `ProceedsFromSaleOfAvailableForSaleSecuritiesDebt`) for broader coverage.

AAPL comparison diffs vs Sharadar dropped from 1349 to 1193 (remaining diffs tracked in #38-#44).

## Test plan

- [x] `ginkgo run -race ./...` -- all 14 suites pass (67 SEC specs including 3 new ones)
- [x] `pvdata run "SEC Fundamentals" --ticker AAPL --lookback 1y` -- 0 process errors, no blocked observations, 84% field coverage
- [x] `pvdata compare-fundamentals --ticker AAPL --since 2024-01-01` -- ARQ/MRQ revenue and cash flow diffs eliminated