### PR TITLE
fix(sec): widen XBRL tag scope for investments, receivables, deferred_revenue, debt_current

### DIFF
--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -525,9 +525,23 @@ var _ = Describe("Dimensions", func() {
 
 			srcStr := string(src)
 
+			// Intermediate fields used only as operands for derived fields;
+			// they are intentionally not mapped to Fundamental struct fields.
+			intermediate := map[string]bool{
+				"TradeReceivables":            true,
+				"NonTradeReceivables":         true,
+				"ShortTermDebt":               true,
+				"LongTermDebtCurrentMaturities": true,
+				"CommercialPaperDebt":         true,
+			}
+
 			var missing []string
 
 			for _, m := range FieldMappings {
+				if intermediate[m.FieldName] {
+					continue
+				}
+
 				pattern := fmt.Sprintf(`fields[%q]`, m.FieldName)
 				if !strings.Contains(srcStr, pattern) {
 					missing = append(missing, m.FieldName)

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -216,6 +216,28 @@ func ResolveAllFields(cf *CompanyFacts, periodEnd time.Time, formType string) ma
 
 // computeDerived evaluates a derived field's formula using already-resolved values.
 func computeDerived(m FieldMapping, resolved map[string]float64) (float64, bool) {
+	// When OptionalOperands is set, OpAdd sums whatever operands are present
+	// and resolves if at least one exists. This handles fields like
+	// Investments = InvestmentsCurrent + InvestmentsNonCurrent where a
+	// company may report only one component.
+	if m.OptionalOperands && m.Op == OpAdd {
+		sum := 0.0
+		found := false
+
+		for _, op := range m.Operands {
+			if v, ok := resolved[op]; ok {
+				sum += v
+				found = true
+			}
+		}
+
+		if found {
+			return sum, true
+		}
+
+		return 0, false
+	}
+
 	// All operands must be present
 	vals := make([]float64, len(m.Operands))
 	for i, op := range m.Operands {

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -57,6 +57,10 @@ type FieldMapping struct {
 
 	// For derived mappings that also have a direct XBRL fallback
 	FallbackTags []string
+
+	// OptionalOperands makes OpAdd treat missing operands as 0 and resolve
+	// when at least one operand is present, instead of requiring all.
+	OptionalOperands bool
 }
 
 // FieldMappings defines the complete mapping from XBRL to data.Fundamental fields.
@@ -93,15 +97,6 @@ var FieldMappings = []FieldMapping{
 		XBRLTags: []string{"InventoryNet", "InventoryFinishedGoodsAndWorkInProcess"},
 	},
 	{
-		FieldName: "Investments", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		XBRLTags: []string{
-			"Investments",
-			"ShortTermInvestments",
-			"LongTermInvestments",
-			"MarketableSecuritiesCurrent",
-		},
-	},
-	{
 		FieldName: "InvestmentsCurrent", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
 		XBRLTags: []string{
 			"ShortTermInvestments",
@@ -117,13 +112,40 @@ var FieldMappings = []FieldMapping{
 			"AvailableForSaleSecuritiesDebtSecuritiesNoncurrent",
 		},
 	},
+	// Investments = InvestmentsCurrent + InvestmentsNonCurrent. Sharadar
+	// defines this as "total amount of marketable and non-marketable
+	// securities, loans receivable and other invested assets." Companies
+	// like Apple tag current/noncurrent separately rather than a single
+	// "Investments" concept; the sum captures both.
 	{
-		FieldName: "Receivables", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		FieldName: "Investments", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+		FallbackTags:     []string{"Investments"},
+		Op:               OpAdd,
+		Operands:         []string{"InvestmentsCurrent", "InvestmentsNonCurrent"},
+		OptionalOperands: true,
+	},
+	{
+		FieldName: "TradeReceivables", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
 		XBRLTags: []string{
 			"AccountsReceivableNetCurrent",
 			"AccountsReceivableNet",
-			"ReceivablesNetCurrent",
 		},
+	},
+	{
+		FieldName: "NonTradeReceivables", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		XBRLTags: []string{
+			"NontradeReceivablesCurrent",
+		},
+	},
+	// Receivables = TradeReceivables + NonTradeReceivables. Sharadar
+	// defines this as "trade and non-trade receivables." Apple tags these
+	// separately (AccountsReceivableNetCurrent + NontradeReceivablesCurrent).
+	{
+		FieldName: "Receivables", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+		FallbackTags:     []string{"ReceivablesNetCurrent"},
+		Op:               OpAdd,
+		Operands:         []string{"TradeReceivables", "NonTradeReceivables"},
+		OptionalOperands: true,
 	},
 	{
 		FieldName: "Payables", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
@@ -165,13 +187,28 @@ var FieldMappings = []FieldMapping{
 		},
 	},
 	{
-		FieldName: "DebtCurrent", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		XBRLTags: []string{
-			"ShortTermBorrowings",
-			"LongTermDebtCurrent",
-			"DebtCurrent",
-			"CommercialPaper",
-		},
+		FieldName: "ShortTermDebt", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		XBRLTags: []string{"ShortTermBorrowings"},
+	},
+	{
+		FieldName: "LongTermDebtCurrentMaturities", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		XBRLTags: []string{"LongTermDebtCurrent"},
+	},
+	{
+		FieldName: "CommercialPaperDebt", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		XBRLTags: []string{"CommercialPaper"},
+	},
+	// DebtCurrent = ShortTermDebt + LongTermDebtCurrentMaturities +
+	// CommercialPaperDebt. Sharadar includes all forms of current debt
+	// (bonds, commercial paper, notes payable, credit facilities). Apple
+	// tags LongTermDebtCurrent and CommercialPaper separately; the sum
+	// captures both.
+	{
+		FieldName: "DebtCurrent", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+		FallbackTags:     []string{"DebtCurrent"},
+		Op:               OpAdd,
+		Operands:         []string{"ShortTermDebt", "LongTermDebtCurrentMaturities", "CommercialPaperDebt"},
+		OptionalOperands: true,
 	},
 	{
 		FieldName: "DebtNonCurrent", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
@@ -188,10 +225,14 @@ var FieldMappings = []FieldMapping{
 	},
 	{
 		FieldName: "DeferredRevenue", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		// Current-specific tags first to match Sharadar, which reports
+		// the current portion. Apple tags ContractWithCustomerLiabilityCurrent
+		// (8.0B) vs the total ContractWithCustomerLiability (12.6B).
 		XBRLTags: []string{
+			"DeferredRevenueCurrent",
+			"ContractWithCustomerLiabilityCurrent",
 			"DeferredRevenue",
 			"ContractWithCustomerLiability",
-			"DeferredRevenueCurrent",
 		},
 	},
 	{

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -166,6 +166,52 @@ var _ = Describe("Mapping Engine", func() {
 		})
 	})
 
+	Describe("computeDerived with OptionalOperands", func() {
+		It("sums present operands and ignores missing ones", func() {
+			resolved := map[string]float64{
+				"A": 100,
+				"C": 300,
+			}
+			m := FieldMapping{
+				FieldName:        "Sum",
+				Type:             MappingDerived,
+				Op:               OpAdd,
+				Operands:         []string{"A", "B", "C"},
+				OptionalOperands: true,
+			}
+			val, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(400.0))
+		})
+
+		It("returns false when no operands are present", func() {
+			resolved := map[string]float64{}
+			m := FieldMapping{
+				FieldName:        "Sum",
+				Type:             MappingDerived,
+				Op:               OpAdd,
+				Operands:         []string{"A", "B"},
+				OptionalOperands: true,
+			}
+			_, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeFalse())
+		})
+
+		It("does not apply to non-optional OpAdd", func() {
+			resolved := map[string]float64{
+				"A": 100,
+			}
+			m := FieldMapping{
+				FieldName: "Sum",
+				Type:      MappingDerived,
+				Op:        OpAdd,
+				Operands:  []string{"A", "B"},
+			}
+			_, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
 	Describe("ResolveAllFields", func() {
 		It("resolves both direct and derived fields", func() {
 			periodEnd := time.Date(2018, 9, 29, 0, 0, 0, 0, time.UTC)
@@ -177,6 +223,124 @@ var _ = Describe("Mapping Engine", func() {
 
 			_, hasAssets := resolved["TotalAssets"]
 			Expect(hasAssets).To(BeTrue())
+		})
+
+		// Verify the four fields that were misaligned with Sharadar due to
+		// narrow XBRL tag scope. Uses synthetic data modeled on AAPL Q2 2024
+		// (period ending 2024-03-30, filed 2024-05-03).
+		It("resolves Investments as sum of current + noncurrent", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			investCF := &CompanyFacts{
+				CIK: 320193, EntityName: "Apple Inc",
+				Facts: map[string][]Fact{
+					"MarketableSecuritiesCurrent": {
+						{End: periodEnd, Filed: filed, Val: 34_455_000_000, Form: "10-Q"},
+					},
+					"MarketableSecuritiesNoncurrent": {
+						{End: periodEnd, Filed: filed, Val: 95_187_000_000, Form: "10-Q"},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(investCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("Investments"))
+			Expect(resolved["Investments"]).To(Equal(129_642_000_000.0),
+				"Investments should sum current + noncurrent marketable securities")
+		})
+
+		It("resolves Investments from single component when only one exists", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			investCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"ShortTermInvestments": {
+						{End: periodEnd, Filed: filed, Val: 50_000_000, Form: "10-Q"},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(investCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("Investments"))
+			Expect(resolved["Investments"]).To(Equal(50_000_000.0),
+				"Investments should resolve from single component via OptionalOperands")
+		})
+
+		It("resolves Receivables as sum of trade + non-trade", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			recvCF := &CompanyFacts{
+				CIK: 320193, EntityName: "Apple Inc",
+				Facts: map[string][]Fact{
+					"AccountsReceivableNetCurrent": {
+						{End: periodEnd, Filed: filed, Val: 21_837_000_000, Form: "10-Q"},
+					},
+					"NontradeReceivablesCurrent": {
+						{End: periodEnd, Filed: filed, Val: 19_313_000_000, Form: "10-Q"},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(recvCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("Receivables"))
+			Expect(resolved["Receivables"]).To(Equal(41_150_000_000.0),
+				"Receivables should sum trade + non-trade receivables")
+		})
+
+		It("resolves DeferredRevenue as current portion", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			defRevCF := &CompanyFacts{
+				CIK: 320193, EntityName: "Apple Inc",
+				Facts: map[string][]Fact{
+					"ContractWithCustomerLiabilityCurrent": {
+						{End: periodEnd, Filed: filed, Val: 8_012_000_000, Form: "10-Q"},
+					},
+					"ContractWithCustomerLiability": {
+						{End: periodEnd, Filed: filed, Val: 12_600_000_000, Form: "10-Q"},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(defRevCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("DeferredRevenue"))
+			Expect(resolved["DeferredRevenue"]).To(Equal(8_012_000_000.0),
+				"DeferredRevenue should pick current-specific tag over total")
+		})
+
+		It("resolves DebtCurrent as sum of components", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			debtCF := &CompanyFacts{
+				CIK: 320193, EntityName: "Apple Inc",
+				Facts: map[string][]Fact{
+					"LongTermDebtCurrent": {
+						{End: periodEnd, Filed: filed, Val: 10_762_000_000, Form: "10-Q"},
+					},
+					"CommercialPaper": {
+						{End: periodEnd, Filed: filed, Val: 1_997_000_000, Form: "10-Q"},
+					},
+					"LongTermDebtNoncurrent": {
+						{End: periodEnd, Filed: filed, Val: 91_831_000_000, Form: "10-Q"},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(debtCF, periodEnd, "10-Q")
+
+			Expect(resolved).To(HaveKey("DebtCurrent"))
+			Expect(resolved["DebtCurrent"]).To(Equal(12_759_000_000.0),
+				"DebtCurrent should sum current maturities + commercial paper")
+
+			Expect(resolved).To(HaveKey("TotalDebt"))
+			Expect(resolved["TotalDebt"]).To(Equal(104_590_000_000.0),
+				"TotalDebt should cascade from corrected DebtCurrent + DebtNonCurrent")
 		})
 
 		It("falls back to basic weighted-average shares when diluted tags are absent", func() {


### PR DESCRIPTION
## Summary

Fixes #40 -- Several balance sheet fields resolved to narrower XBRL tags than Sharadar, producing significantly different values (up to ~168 diffs in the AAPL comparison).

- **Investments**: converted from direct to derived (`InvestmentsCurrent + InvestmentsNonCurrent`), capturing both current and noncurrent marketable securities (AAPL: 34.5B -> 129.6B)
- **Receivables**: converted from direct to derived (`TradeReceivables + NonTradeReceivables`), capturing both trade and non-trade receivables (AAPL: 21.8B -> 41.2B)
- **DeferredRevenue**: reordered tags to prioritize current-specific concepts (`DeferredRevenueCurrent`, `ContractWithCustomerLiabilityCurrent`) over totals (AAPL: 12.6B -> 8.0B)
- **DebtCurrent**: converted from direct to derived (`ShortTermDebt + LongTermDebtCurrentMaturities + CommercialPaperDebt`), summing all current debt components (AAPL: 10.8B -> 12.8B)
- **TotalDebt**: cascades from corrected DebtCurrent (AAPL: 102.6B -> 104.6B)

Added `OptionalOperands` support to the derivation engine so `OpAdd` can sum whichever components are present (resolves if >= 1 exists). This handles companies that report only a subset of debt/investment components.

## Test plan

- [x] 8 new tests added (3 for OptionalOperands behavior, 5 for field-level fixes using synthetic AAPL data)
- [x] All 75 SEC tests passing (up from 67 baseline)
- [x] Full project builds clean
- [x] Lint clean
- [ ] Run `compare-fundamentals` against AAPL to verify diffs eliminated