### PR TITLE
fix(sec): synthesize Q4 from 10-K for correct TTM computation

### DIFF
--- a/cmd/compare_fundamentals.go
+++ b/cmd/compare_fundamentals.go
@@ -249,15 +249,16 @@ func discoverFundamentalsSubscriptions(subs []*library.Subscription) (secTable, 
 }
 
 type rawCompareFlags struct {
-	tickers    []string
-	since      string
-	until      string
-	dimensions []string
-	fields     []string
-	relTol     float64
-	absTol     float64
-	format     string
-	output     string
+	tickers        []string
+	since          string
+	until          string
+	dimensions     []string
+	fields         []string
+	relTol         float64
+	absTol         float64
+	format         string
+	output         string
+	excludeForeign bool
 }
 
 type compareOptions struct {
@@ -938,15 +939,16 @@ func runCompareFundamentals(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
 	raw := rawCompareFlags{
-		tickers:    viper.GetStringSlice("compare-fundamentals.ticker"),
-		since:      viper.GetString("compare-fundamentals.since"),
-		until:      viper.GetString("compare-fundamentals.until"),
-		dimensions: viper.GetStringSlice("compare-fundamentals.dimension"),
-		fields:     viper.GetStringSlice("compare-fundamentals.fields"),
-		relTol:     viper.GetFloat64("compare-fundamentals.rel-tol"),
-		absTol:     viper.GetFloat64("compare-fundamentals.abs-tol"),
-		format:     viper.GetString("compare-fundamentals.format"),
-		output:     viper.GetString("compare-fundamentals.output"),
+		tickers:        viper.GetStringSlice("compare-fundamentals.ticker"),
+		since:          viper.GetString("compare-fundamentals.since"),
+		until:          viper.GetString("compare-fundamentals.until"),
+		dimensions:     viper.GetStringSlice("compare-fundamentals.dimension"),
+		fields:         viper.GetStringSlice("compare-fundamentals.fields"),
+		relTol:         viper.GetFloat64("compare-fundamentals.rel-tol"),
+		absTol:         viper.GetFloat64("compare-fundamentals.abs-tol"),
+		format:         viper.GetString("compare-fundamentals.format"),
+		output:         viper.GetString("compare-fundamentals.output"),
+		excludeForeign: viper.GetBool("compare-fundamentals.exclude-foreign"),
 	}
 
 	opts, err := resolveCompareOptions(raw)
@@ -969,6 +971,61 @@ func runCompareFundamentals(cmd *cobra.Command, args []string) {
 	secTable, sharadarTable, err := discoverFundamentalsSubscriptions(subs)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not discover fundamentals subscriptions")
+	}
+
+	if raw.excludeForeign {
+		conn, connErr := myLibrary.Pool.Acquire(ctx)
+		if connErr != nil {
+			log.Fatal().Err(connErr).Msg("could not acquire db connection for domestic ticker query")
+		}
+
+		domesticSQL := fmt.Sprintf("SELECT DISTINCT ticker FROM %s WHERE dimension = 'ARQ'", secTable)
+
+		arqRows, arqErr := conn.Query(ctx, domesticSQL)
+		conn.Release()
+
+		if arqErr != nil {
+			log.Fatal().Err(arqErr).Msg("could not query domestic tickers from sec table")
+		}
+
+		var domesticTickers []string
+
+		for arqRows.Next() {
+			var t string
+			if scanErr := arqRows.Scan(&t); scanErr != nil {
+				arqRows.Close()
+				log.Fatal().Err(scanErr).Msg("could not scan domestic ticker")
+			}
+
+			domesticTickers = append(domesticTickers, t)
+		}
+
+		arqRows.Close()
+
+		if arqErr = arqRows.Err(); arqErr != nil {
+			log.Fatal().Err(arqErr).Msg("error reading domestic ticker rows")
+		}
+
+		log.Info().Int("count", len(domesticTickers)).Msg("domestic tickers found (have ARQ data in sec table)")
+
+		if len(opts.tickers) > 0 {
+			// Intersect user-provided filter with domestic set.
+			domesticSet := make(map[string]struct{}, len(domesticTickers))
+			for _, t := range domesticTickers {
+				domesticSet[t] = struct{}{}
+			}
+
+			filtered := opts.tickers[:0]
+			for _, t := range opts.tickers {
+				if _, ok := domesticSet[t]; ok {
+					filtered = append(filtered, t)
+				}
+			}
+
+			opts.tickers = filtered
+		} else {
+			opts.tickers = domesticTickers
+		}
 	}
 
 	var (
@@ -1137,8 +1194,9 @@ func init() {
 	compareFundamentalsCmd.Flags().Float64("abs-tol", 0, "Absolute tolerance floor: values differ only when |a-b| > abs-tol")
 	compareFundamentalsCmd.Flags().String("format", "text", "Output format: text or csv")
 	compareFundamentalsCmd.Flags().String("output", "", "Write output to this file instead of stdout")
+	compareFundamentalsCmd.Flags().Bool("exclude-foreign", true, "Exclude tickers with no ARQ data in the SEC table (foreign filers)")
 
-	for _, name := range []string{"ticker", "since", "until", "dimension", "fields", "rel-tol", "abs-tol", "format", "output"} {
+	for _, name := range []string{"ticker", "since", "until", "dimension", "fields", "rel-tol", "abs-tol", "format", "output", "exclude-foreign"} {
 		if err := viper.BindPFlag("compare-fundamentals."+name, compareFundamentalsCmd.Flags().Lookup(name)); err != nil {
 			log.Panic().Err(err).Str("flag", name).Msg("BindPFlag failed for compare-fundamentals")
 		}

--- a/docs/superpowers/plans/2026-04-11-fix-ttm-q4.md
+++ b/docs/superpowers/plans/2026-04-11-fix-ttm-q4.md
@@ -1,0 +1,584 @@
+# Fix SEC TTM by Synthesizing Q4 from 10-K Annual Data
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the SEC provider's trailing-twelve-month (TTM) computation so it includes Q4 data derived from 10-K annual filings, and emit the missing Q4 ARQ/MRQ observations.
+
+**Architecture:** After collecting 10-Q periods and de-cumulating YTD values, a new `synthesizeQ4` function iterates over 10-K periods, finds the 3 preceding de-cumulated 10-Q quarters in the same fiscal year, and computes Q4 = annual - sum(Q1+Q2+Q3). The synthetic Q4 entries are inserted into the sorted quarters slice so the existing `ComputeTTM` and emission logic work unchanged. A separate small change filters foreign issuers from the compare-fundamentals command.
+
+**Tech Stack:** Go 1.25, Ginkgo v2 + Gomega (tests)
+
+---
+
+### Task 1: Add `SynthesizeQ4` function with tests
+
+**Files:**
+- Create: `provider/sec/synthesize_q4.go`
+- Create: `provider/sec/synthesize_q4_test.go`
+
+The function takes the 10-K annual resolved fields (AR and MR), the sorted de-cumulated quarters slice, and the 10-K period metadata. It returns a `quarterData`-compatible struct with Q4 single-quarter values, or nil if fewer than 3 preceding quarters exist.
+
+- [ ] **Step 1: Write the failing test**
+
+In `provider/sec/synthesize_q4_test.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+
+package sec
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SynthesizeQ4", func() {
+	// Simulate a company with FY ending Sep 2024.
+	// Q1=Oct-Dec 2023, Q2=Jan-Mar 2024, Q3=Apr-Jun 2024, Q4=Jul-Sep 2024 (from 10-K).
+	// All values are de-cumulated single-quarter amounts.
+	var (
+		annualAR map[string]float64
+		annualMR map[string]float64
+		annualPeriod Period
+		quarters []synthesizeInput
+	)
+
+	BeforeEach(func() {
+		annualAR = map[string]float64{
+			"Revenues":              400000,
+			"NetIncomeCommonStock":  100000,
+			"TotalAssets":           500000, // point-in-time
+			"GrossMargin":          0.45,   // metric
+		}
+		annualMR = map[string]float64{
+			"Revenues":              400000,
+			"NetIncomeCommonStock":  100000,
+			"TotalAssets":           500000,
+			"GrossMargin":          0.45,
+		}
+		annualPeriod = Period{
+			PeriodEnd:   time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+			FormType:    "10-K",
+			ARFiledDate: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC),
+			MRFiledDate: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC),
+		}
+		quarters = []synthesizeInput{
+			{
+				periodEnd: time.Date(2023, 12, 30, 0, 0, 0, 0, time.UTC),
+				arEmit:    map[string]float64{"Revenues": 110000, "NetIncomeCommonStock": 30000, "TotalAssets": 470000, "GrossMargin": 0.42},
+				mrEmit:    map[string]float64{"Revenues": 110000, "NetIncomeCommonStock": 30000, "TotalAssets": 470000, "GrossMargin": 0.42},
+			},
+			{
+				periodEnd: time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC),
+				arEmit:    map[string]float64{"Revenues": 95000, "NetIncomeCommonStock": 25000, "TotalAssets": 480000, "GrossMargin": 0.40},
+				mrEmit:    map[string]float64{"Revenues": 95000, "NetIncomeCommonStock": 25000, "TotalAssets": 480000, "GrossMargin": 0.40},
+			},
+			{
+				periodEnd: time.Date(2024, 6, 29, 0, 0, 0, 0, time.UTC),
+				arEmit:    map[string]float64{"Revenues": 90000, "NetIncomeCommonStock": 22000, "TotalAssets": 490000, "GrossMargin": 0.43},
+				mrEmit:    map[string]float64{"Revenues": 90000, "NetIncomeCommonStock": 22000, "TotalAssets": 490000, "GrossMargin": 0.43},
+			},
+		}
+	})
+
+	It("computes Q4 flow fields as annual minus sum of 3 quarters", func() {
+		arQ4, mrQ4 := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters)
+		Expect(arQ4).NotTo(BeNil())
+
+		// Revenues: 400000 - (110000+95000+90000) = 105000
+		Expect(arQ4["Revenues"]).To(BeNumerically("==", 105000))
+		// NetIncome: 100000 - (30000+25000+22000) = 23000
+		Expect(arQ4["NetIncomeCommonStock"]).To(BeNumerically("==", 23000))
+
+		Expect(mrQ4).NotTo(BeNil())
+		Expect(mrQ4["Revenues"]).To(BeNumerically("==", 105000))
+	})
+
+	It("uses 10-K value directly for point-in-time fields", func() {
+		arQ4, _ := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters)
+		Expect(arQ4).NotTo(BeNil())
+		Expect(arQ4["TotalAssets"]).To(BeNumerically("==", 500000))
+	})
+
+	It("returns nil when fewer than 3 quarters precede the 10-K", func() {
+		arQ4, mrQ4 := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters[:2])
+		Expect(arQ4).To(BeNil())
+		Expect(mrQ4).To(BeNil())
+	})
+
+	It("returns nil when quarters are too far from the 10-K period end", func() {
+		// Move quarters back 2 years so they don't belong to this fiscal year
+		oldQuarters := []synthesizeInput{
+			{
+				periodEnd: time.Date(2021, 12, 30, 0, 0, 0, 0, time.UTC),
+				arEmit:    map[string]float64{"Revenues": 80000},
+				mrEmit:    map[string]float64{"Revenues": 80000},
+			},
+			{
+				periodEnd: time.Date(2022, 3, 30, 0, 0, 0, 0, time.UTC),
+				arEmit:    map[string]float64{"Revenues": 85000},
+				mrEmit:    map[string]float64{"Revenues": 85000},
+			},
+			{
+				periodEnd: time.Date(2022, 6, 29, 0, 0, 0, 0, time.UTC),
+				arEmit:    map[string]float64{"Revenues": 90000},
+				mrEmit:    map[string]float64{"Revenues": 90000},
+			},
+		}
+		arQ4, mrQ4 := SynthesizeQ4(annualAR, annualMR, annualPeriod, oldQuarters)
+		Expect(arQ4).To(BeNil())
+		Expect(mrQ4).To(BeNil())
+	})
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "SynthesizeQ4" ./provider/sec/`
+Expected: FAIL -- `SynthesizeQ4` and `synthesizeInput` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `provider/sec/synthesize_q4.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+
+package sec
+
+import (
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// synthesizeInput holds the de-cumulated quarterly data needed by SynthesizeQ4.
+type synthesizeInput struct {
+	periodEnd time.Time
+	arEmit    map[string]float64
+	mrEmit    map[string]float64
+}
+
+// SynthesizeQ4 derives Q4 single-quarter field maps from 10-K annual values
+// and the 3 preceding de-cumulated 10-Q quarters.
+//
+// For flow fields (income statement, cash flow): Q4 = annual - (Q1+Q2+Q3).
+// For point-in-time fields (balance sheet): Q4 = annual value directly.
+// Metric fields are recomputed from the Q4 flow/point-in-time values.
+//
+// Returns (arQ4, mrQ4) field maps, or (nil, nil) if the 3 preceding quarters
+// cannot be identified (fewer than 3, or too far from the 10-K period end).
+func SynthesizeQ4(annualAR, annualMR map[string]float64, annualPeriod Period, quarters []synthesizeInput) (map[string]float64, map[string]float64) {
+	const maxFYSpanDays = 400
+
+	// Find the 3 quarters preceding the 10-K period end within the fiscal year.
+	// Walk backwards from the end of the quarters slice.
+	var fyQuarters []synthesizeInput
+	for i := len(quarters) - 1; i >= 0 && len(fyQuarters) < 3; i-- {
+		q := quarters[i]
+		// Quarter must precede the 10-K period end.
+		if !q.periodEnd.Before(annualPeriod.PeriodEnd) {
+			continue
+		}
+		// Quarter must be within ~13 months of the 10-K period end.
+		gapDays := annualPeriod.PeriodEnd.Sub(q.periodEnd).Hours() / 24
+		if gapDays > maxFYSpanDays {
+			break
+		}
+		fyQuarters = append(fyQuarters, q)
+	}
+
+	if len(fyQuarters) != 3 {
+		if len(quarters) > 0 {
+			log.Debug().
+				Time("annual_period_end", annualPeriod.PeriodEnd).
+				Int("found_quarters", len(fyQuarters)).
+				Msg("skipping Q4 synthesis: need exactly 3 preceding quarters")
+		}
+		return nil, nil
+	}
+
+	arQ4 := subtractQuarters(annualAR, fyQuarters, true)
+	mrQ4 := subtractQuarters(annualMR, fyQuarters, false)
+
+	return arQ4, mrQ4
+}
+
+// subtractQuarters computes Q4 = annual - sum(quarters) for flow fields,
+// copies annual values for point-in-time fields, and recomputes metrics.
+func subtractQuarters(annual map[string]float64, fyQuarters []synthesizeInput, useAR bool) map[string]float64 {
+	result := make(map[string]float64, len(annual))
+
+	for _, m := range FieldMappings {
+		annualVal, hasAnnual := annual[m.FieldName]
+		if !hasAnnual {
+			continue
+		}
+
+		switch m.StatementType {
+		case StmtFlow:
+			sum := 0.0
+			found := 0
+			for _, q := range fyQuarters {
+				emit := q.arEmit
+				if !useAR {
+					emit = q.mrEmit
+				}
+				if v, ok := emit[m.FieldName]; ok {
+					sum += v
+					found++
+				}
+			}
+			if found == 3 {
+				result[m.FieldName] = annualVal - sum
+			}
+
+		case StmtPointInTime:
+			result[m.FieldName] = annualVal
+		}
+	}
+
+	// Recompute derived metrics from Q4 values.
+	for _, m := range FieldMappings {
+		if m.Type == MappingDerived && m.StatementType == StmtMetric {
+			if val, ok := computeDerived(m, result); ok {
+				result[m.FieldName] = val
+			}
+		}
+	}
+
+	return result
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "SynthesizeQ4" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/sec/synthesize_q4.go provider/sec/synthesize_q4_test.go
+git commit -m "feat(sec): add SynthesizeQ4 to derive Q4 from 10-K annual data"
+```
+
+---
+
+### Task 2: Wire Q4 synthesis into `emitFundamentals`
+
+**Files:**
+- Modify: `provider/sec/sec.go:483-774` (`emitFundamentals` function)
+
+After de-cumulation (line 602) and before emitting quarterly observations (line 604), iterate over 10-K periods and insert synthetic Q4 entries into the `quarters` slice.
+
+- [ ] **Step 1: Write the failing test**
+
+In `provider/sec/synthesize_q4_test.go`, add a new `Describe` block that tests the full pipeline via `emitFundamentals`:
+
+```go
+var _ = Describe("emitFundamentals Q4 synthesis", func() {
+	It("emits Q4 ARQ/MRQ and correct ART/MRT for a company with 3 10-Qs and 1 10-K", func() {
+		// Build a CompanyFacts with:
+		// - 10-K for FY ending Sep 2024, annual Revenues=400000, NetIncomeCommonStock=100000
+		// - 3 10-Qs: Q1 (Dec 2023), Q2 (Mar 2024), Q3 (Jun 2024)
+		//   with single-quarter Revenues of 110000, 95000, 90000
+		//   and NetIncomeCommonStock of 30000, 25000, 22000
+		// - 1 10-Q for next year Q1 (Dec 2024) to trigger TTM
+		//   with Revenues=115000, NetIncomeCommonStock=32000
+		cf := &CompanyFacts{
+			CIK:        999,
+			EntityName: "TestCo",
+			Facts: map[string][]Fact{
+				"Revenues": {
+					// Q1 FY2024 (Oct-Dec 2023) single quarter
+					{Val: 110000, Start: time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC), End: time.Date(2023, 12, 30, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
+					// Q2 FY2024 (Jan-Mar 2024) cumulative YTD
+					{Val: 205000, Start: time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)},
+					// Q2 FY2024 single quarter
+					{Val: 95000, Start: time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)},
+					// Q3 FY2024 (Apr-Jun 2024) cumulative YTD
+					{Val: 295000, Start: time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 6, 29, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)},
+					// Q3 FY2024 single quarter
+					{Val: 90000, Start: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 6, 29, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)},
+					// Annual FY2024 (10-K)
+					{Val: 400000, Start: time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC), Form: "10-K", Filed: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)},
+					// Q1 FY2025 (Oct-Dec 2024) single quarter
+					{Val: 115000, Start: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC)},
+				},
+				"NetIncomeCommonStock": {
+					{Val: 30000, Start: time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC), End: time.Date(2023, 12, 30, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
+					{Val: 25000, Start: time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)},
+					{Val: 22000, Start: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 6, 29, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)},
+					{Val: 100000, Start: time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC), Form: "10-K", Filed: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)},
+					{Val: 32000, Start: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+		}
+
+		asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST01", CIK: 999}
+		sub := &library.Subscription{Name: "test"}
+		out := make(chan *data.Observation, 100)
+		numObs := 0
+
+		emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+		close(out)
+
+		observations := make(map[string]*data.Fundamental)
+		for obs := range out {
+			if obs.Fundamental != nil {
+				key := obs.Fundamental.Dimension + "_" + obs.Fundamental.DateKey.Format("2006-01-02")
+				observations[key] = obs.Fundamental
+			}
+		}
+
+		// Q4 ARQ should exist at date_key 2024-09-30 (NormalizeEventDate of 2024-09-28 for 10-Q)
+		q4ARQ, ok := observations["ARQ_2024-09-30"]
+		Expect(ok).To(BeTrue(), "Q4 ARQ should be emitted")
+		// Q4 revenues = 400000 - (110000+95000+90000) = 105000
+		Expect(q4ARQ.Revenues).To(Equal(int64(105000)))
+		// Q4 net_income = 100000 - (30000+25000+22000) = 23000
+		Expect(q4ARQ.NetIncomeCommonStock).To(Equal(int64(23000)))
+
+		// ART at date_key 2024-12-31 should be TTM = Q1FY25 + Q4 + Q3 + Q2
+		// Revenues: 115000 + 105000 + 90000 + 95000 = 405000
+		art, ok := observations["ART_2024-12-31"]
+		Expect(ok).To(BeTrue(), "ART should be emitted")
+		Expect(art.Revenues).To(Equal(int64(405000)))
+		// NetIncome: 32000 + 23000 + 22000 + 25000 = 102000
+		Expect(art.NetIncomeCommonStock).To(Equal(int64(102000)))
+	})
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "emitFundamentals Q4 synthesis" ./provider/sec/`
+Expected: FAIL -- Q4 ARQ not emitted, ART revenues incorrect (sums wrong 4 quarters).
+
+- [ ] **Step 3: Wire Q4 synthesis into emitFundamentals**
+
+In `provider/sec/sec.go`, make three changes to `emitFundamentals`:
+
+**Change 1:** Collect 10-K periods alongside quarters. After line 502 (`var quarters []quarterData`), add:
+
+```go
+	// Collect 10-K annual data for Q4 synthesis.
+	type annualData struct {
+		period   Period
+		arFields map[string]float64
+		mrFields map[string]float64
+	}
+
+	var annuals []annualData
+```
+
+**Change 2:** Inside the `for _, p := range periods` loop, after the `if p.FormType == "10-Q"` block (line 526), add collection of annual data. Change the 10-K emission block (lines 538-568) to also collect the annual fields:
+
+Replace lines 538-568 (the `if p.FormType == "10-K"` block) with:
+
+```go
+		if p.FormType == "10-K" {
+			// Collect annual data for Q4 synthesis (always, regardless of since).
+			annuals = append(annuals, annualData{period: p, arFields: arFields, mrFields: mrFields})
+
+			if !since.IsZero() && p.MRFiledDate.Before(since) {
+				continue
+			}
+
+			// ARY
+			fundamental := BuildFundamental(arFields, asset.Ticker, asset.CompositeFigi, "ARY",
+				p.ARFiledDate, calendarDate, p.PeriodEnd, p.ARFiledDate)
+			out <- &data.Observation{
+				Fundamental:      fundamental,
+				ObservationDate:  calendarDate,
+				SubscriptionID:   sub.ID,
+				SubscriptionName: sub.Name,
+			}
+
+			*numObservations++
+
+			// MRY
+			fundamental = BuildFundamental(mrFields, asset.Ticker, asset.CompositeFigi, "MRY",
+				p.PeriodEnd, calendarDate, p.PeriodEnd, p.MRFiledDate)
+			out <- &data.Observation{
+				Fundamental:      fundamental,
+				ObservationDate:  calendarDate,
+				SubscriptionID:   sub.ID,
+				SubscriptionName: sub.Name,
+			}
+
+			*numObservations++
+
+			periodsEmitted++
+		}
+```
+
+**Change 3:** After de-cumulation (after line 602, the end of the de-cumulation loop), add Q4 synthesis and insertion:
+
+```go
+	// Synthesize Q4 entries from 10-K annual data. For each 10-K, derive
+	// Q4 = annual - sum(Q1+Q2+Q3) using the de-cumulated quarterly values,
+	// then insert the synthetic Q4 into the quarters slice.
+	for _, annual := range annuals {
+		// Build synthesizeInput from the de-cumulated quarters.
+		inputs := make([]synthesizeInput, len(quarters))
+		for i, q := range quarters {
+			inputs[i] = synthesizeInput{
+				periodEnd: q.period.PeriodEnd,
+				arEmit:    q.arEmit,
+				mrEmit:    q.mrEmit,
+			}
+		}
+
+		arQ4, mrQ4 := SynthesizeQ4(annual.arFields, annual.mrFields, annual.period, inputs)
+		if arQ4 == nil {
+			continue
+		}
+
+		q4Period := Period{
+			PeriodEnd:   annual.period.PeriodEnd,
+			FormType:    "10-Q", // treat as quarter for TTM and emission
+			ARFiledDate: annual.period.ARFiledDate,
+			MRFiledDate: annual.period.MRFiledDate,
+		}
+
+		q4 := quarterData{
+			period:   q4Period,
+			arFields: arQ4, // synthetic Q4 is already single-quarter
+			mrFields: mrQ4,
+			arEmit:   arQ4,
+			mrEmit:   mrQ4,
+		}
+
+		// Insert into sorted position in quarters slice.
+		insertIdx := sort.Search(len(quarters), func(i int) bool {
+			return quarters[i].period.PeriodEnd.After(q4Period.PeriodEnd)
+		})
+
+		quarters = append(quarters, quarterData{})
+		copy(quarters[insertIdx+1:], quarters[insertIdx:])
+		quarters[insertIdx] = q4
+	}
+```
+
+Add `"sort"` to the import block in `sec.go` if not already present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "emitFundamentals Q4 synthesis" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Run all SEC tests to check for regressions**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: All existing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add provider/sec/sec.go
+git commit -m "feat(sec): wire Q4 synthesis into emitFundamentals for correct TTM (#42)"
+```
+
+---
+
+### Task 3: Filter foreign issuers from compare-fundamentals
+
+**Files:**
+- Modify: `cmd/compare_fundamentals.go`
+
+Foreign issuers (filing 20-F/6-K instead of 10-K/10-Q) don't have quarterly data in the SEC provider. They create noise in comparisons. Filter them by excluding tickers that have zero ARQ records in the SEC table.
+
+- [ ] **Step 1: Add `--exclude-foreign` flag (default true)**
+
+In `cmd/compare_fundamentals.go`, add to the `rawCompareFlags` struct and `init()`:
+
+In the `rawCompareFlags` struct (find it near the top of the file), add:
+
+```go
+	excludeForeign bool
+```
+
+In `init()`, after the existing flags (around line 1139), add:
+
+```go
+	compareFundamentalsCmd.Flags().Bool("exclude-foreign", true, "Exclude tickers with no ARQ data in the SEC table (foreign filers)")
+```
+
+And add to the viper bind list (the `for _, name := range []string{...}` loop):
+
+```go
+	for _, name := range []string{"ticker", "since", "until", "dimension", "fields", "rel-tol", "abs-tol", "format", "output", "exclude-foreign"} {
+```
+
+- [ ] **Step 2: Filter in `runCompareFundamentals`**
+
+Find where the comparison query runs (in `runCompareFundamentals`). After the SEC and Sharadar table names are resolved but before the main comparison loop, add a query to find tickers with at least one ARQ row in the SEC table, then filter the comparison to only those tickers.
+
+Locate where `buildDateKeyQuery` is called. Before that call, add:
+
+```go
+	// Exclude foreign issuers: tickers with no ARQ data in the SEC table.
+	if raw.excludeForeign {
+		foreignQuery := fmt.Sprintf(
+			`SELECT DISTINCT ticker FROM %s WHERE dimension = 'ARQ' AND ticker IS NOT NULL`,
+			secTable,
+		)
+		foreignRows, err := conn.Query(ctx, foreignQuery)
+		if err != nil {
+			log.Fatal().Err(err).Msg("query domestic tickers")
+		}
+
+		domesticTickers := make(map[string]bool)
+		for foreignRows.Next() {
+			var t string
+			if err := foreignRows.Scan(&t); err != nil {
+				foreignRows.Close()
+				log.Fatal().Err(err).Msg("scan domestic ticker")
+			}
+			domesticTickers[t] = true
+		}
+		foreignRows.Close()
+
+		if len(opts.tickers) > 0 {
+			// Intersect user-specified tickers with domestic set.
+			var filtered []string
+			for _, t := range opts.tickers {
+				if domesticTickers[t] {
+					filtered = append(filtered, t)
+				}
+			}
+			opts.tickers = filtered
+		} else {
+			// Use domestic tickers as the ticker filter.
+			for t := range domesticTickers {
+				opts.tickers = append(opts.tickers, t)
+			}
+		}
+
+		log.Info().Int("domestic_tickers", len(opts.tickers)).Msg("filtered to domestic filers")
+	}
+```
+
+Wire `raw.excludeForeign` by reading the viper config in `runCompareFundamentals`:
+
+```go
+	raw.excludeForeign = viper.GetBool("compare-fundamentals.exclude-foreign")
+```
+
+- [ ] **Step 3: Run lint**
+
+Run: `golangci-lint run --fix ./cmd/...`
+Expected: No errors (or auto-fixed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/compare_fundamentals.go
+git commit -m "feat: exclude foreign issuers from compare-fundamentals by default"
+```

--- a/docs/superpowers/specs/2026-04-11-fix-ttm-q4-design.md
+++ b/docs/superpowers/specs/2026-04-11-fix-ttm-q4-design.md
@@ -1,0 +1,56 @@
+# SEC: Fix TTM by synthesizing Q4 from 10-K annual data
+
+**Issue:** #42
+
+## Problem
+
+The SEC provider's TTM computation sums 4 consecutive 10-Q periods, but no company files a 10-Q for its fiscal year-end quarter (Q4). Q4 data only exists in the 10-K annual filing. This means the `quarters` slice in `emitFundamentals()` has only 3 quarters per fiscal year, and `ComputeTTM` sums 4 consecutive 10-Q periods that skip Q4 entirely.
+
+For AAPL (FY ends September), ART at date_key 2024-12-31:
+- SEC computes: Q1FY25 + Q3FY24 + Q2FY24 + Q1FY24 = 115.3B net income
+- Correct: Q1FY25 + Q4FY24 + Q3FY24 + Q2FY24 = 96.2B net income
+
+Verified that Q4 = annual - sum(Q1+Q2+Q3) is exact (not approximate) for US 10-K/10-Q filers: 98.2% exact match across 4125 companies in Sharadar data, with the remaining ~2% being foreign filers (20-F/6-K) outside the SEC provider's universe.
+
+## Fix
+
+In `emitFundamentals()`, after collecting 10-Q periods into the `quarters` slice and de-cumulating YTD values, synthesize a Q4 entry for each 10-K period.
+
+### Identifying the fiscal year's 10-Q quarters
+
+Walk backwards through the sorted `quarters` slice from the 10-K's period end. Take consecutive quarters whose period end is within ~365 days of the 10-K period end and within ~120 days of each other (same gap logic as existing de-cumulation). Expect exactly 3 quarters. If fewer are found, skip Q4 synthesis for that fiscal year and log a warning.
+
+### Computing synthetic Q4 fields
+
+- **Flow fields** (income statement, cash flow): Q4 = 10-K annual value - sum(Q1+Q2+Q3 de-cumulated values)
+- **Point-in-time fields** (balance sheet): Q4 = 10-K value directly
+- **Metric fields** (ratios): recompute from Q4 flow/point-in-time values using existing `computeDerived()`
+
+### Synthetic Q4 period metadata
+
+- `PeriodEnd`: the 10-K's period end (e.g., 2024-09-28 for AAPL FY2024)
+- `FormType`: "10-Q" (so existing TTM and emission code treats it as a quarter)
+- `ARFiledDate` / `MRFiledDate`: copied from the 10-K period
+
+### What the synthetic Q4 produces
+
+- ARQ and MRQ observations for the fiscal year-end quarter (currently missing)
+- Correct TTM: `ComputeTTM` now sees all 4 quarters per fiscal year
+
+## Scope boundary
+
+The `compare_fundamentals` command should also exclude foreign issuers (those without 10-Q filings) to avoid noise from companies the SEC provider cannot process. This is a small separate change included in the same PR.
+
+## Files modified
+
+- `provider/sec/sec.go` -- `emitFundamentals()`: synthesize Q4 entries, insert into quarters slice
+- `provider/sec/sec_test.go` or `provider/sec/dimensions_test.go` -- new test cases
+- `cmd/compare_fundamentals.go` -- filter out foreign issuers
+
+## Testing
+
+Unit tests with synthetic `CompanyFacts` data:
+
+1. Company with 3 10-Q periods + 1 10-K: verify Q4 ARQ/MRQ emitted with correct single-quarter values, and ART/MRT have correct TTM (sum of all 4 quarters)
+2. Company with only 2 10-Q quarters before a 10-K: no synthetic Q4 emitted, warning logged
+3. Company whose FY aligns with calendar year (Q4 = Oct-Dec): still works correctly

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -502,6 +502,14 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 	var quarters []quarterData
 
+	type annualData struct {
+		period   Period
+		arFields map[string]float64
+		mrFields map[string]float64
+	}
+
+	var annuals []annualData
+
 	for _, p := range periods {
 		calendarDate := NormalizeEventDate(p.PeriodEnd, p.FormType)
 
@@ -536,6 +544,8 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// Emit annual observations immediately (10-K data is always full-year,
 		// no de-cumulation needed).
 		if p.FormType == "10-K" {
+			annuals = append(annuals, annualData{period: p, arFields: arFields, mrFields: mrFields})
+
 			if !since.IsZero() && p.MRFiledDate.Before(since) {
 				continue
 			}
@@ -599,6 +609,63 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// Q1 or no prior quarter: no de-cumulation needed.
 		q.arEmit = q.arFields
 		q.mrEmit = q.mrFields
+	}
+
+	// Synthesize Q4 entries from 10-K annual data and preceding quarters.
+	// Each synthesized Q4 is inserted into the sorted quarters slice so it
+	// participates in TTM computation and is emitted as ARQ/MRQ.
+	for _, a := range annuals {
+		// Rebuild inputs each iteration so previously synthesized Q4s are
+		// available as preceding quarters for later annuals.
+		inputs := make([]synthesizeInput, len(quarters))
+		for i, q := range quarters {
+			inputs[i] = synthesizeInput{
+				periodEnd: q.period.PeriodEnd,
+				arEmit:    q.arEmit,
+				mrEmit:    q.mrEmit,
+			}
+		}
+
+		arQ4, mrQ4 := SynthesizeQ4(a.arFields, a.mrFields, a.period, inputs)
+		if arQ4 == nil {
+			continue
+		}
+
+		// Skip if a quarter already exists at this period end (e.g. if a
+		// company unusually filed a 10-Q for Q4 alongside its 10-K).
+		alreadyExists := false
+		for _, q := range quarters {
+			if q.period.PeriodEnd.Equal(a.period.PeriodEnd) {
+				alreadyExists = true
+				break
+			}
+		}
+
+		if alreadyExists {
+			continue
+		}
+
+		q4 := quarterData{
+			period: Period{
+				PeriodEnd:   a.period.PeriodEnd,
+				FormType:    "10-Q",
+				ARFiledDate: a.period.ARFiledDate,
+				MRFiledDate: a.period.MRFiledDate,
+			},
+			arFields: arQ4,
+			mrFields: mrQ4,
+			arEmit:   arQ4,
+			mrEmit:   mrQ4,
+		}
+
+		// Insert into sorted position by PeriodEnd.
+		idx := sort.Search(len(quarters), func(i int) bool {
+			return quarters[i].period.PeriodEnd.After(q4.period.PeriodEnd)
+		})
+
+		quarters = append(quarters, quarterData{})
+		copy(quarters[idx+1:], quarters[idx:])
+		quarters[idx] = q4
 	}
 
 	// Emit quarterly observations using de-cumulated values.

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -634,6 +634,7 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// Skip if a quarter already exists at this period end (e.g. if a
 		// company unusually filed a 10-Q for Q4 alongside its 10-K).
 		alreadyExists := false
+
 		for _, q := range quarters {
 			if q.period.PeriodEnd.Equal(a.period.PeriodEnd) {
 				alreadyExists = true

--- a/provider/sec/synthesize_q4.go
+++ b/provider/sec/synthesize_q4.go
@@ -1,0 +1,141 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sec
+
+import "time"
+
+// synthesizeInput holds the resolved field maps for a single de-cumulated quarter,
+// along with its period end date. arEmit is the as-reported view and mrEmit is the
+// most-recently-reported view.
+type synthesizeInput struct {
+	periodEnd time.Time
+	arEmit    map[string]float64
+	mrEmit    map[string]float64
+}
+
+// maxQ4QuarterSpanDays is the maximum number of days before the 10-K period end
+// that a quarter may fall and still be considered part of the same fiscal year.
+const maxQ4QuarterSpanDays = 400
+
+// SynthesizeQ4 derives single-quarter Q4 field maps from a 10-K annual filing by
+// subtracting the three preceding fiscal-year quarters from the annual total.
+//
+// annualAR and annualMR are the resolved field maps for the 10-K period in the
+// as-reported and most-recently-reported views respectively. annualPeriod is the
+// 10-K Period metadata. quarters is an ordered slice (ascending by periodEnd) of
+// de-cumulated quarter inputs.
+//
+// The function walks backwards through quarters to find exactly 3 quarters whose
+// periodEnd is strictly before the 10-K period end and within maxQ4QuarterSpanDays
+// of it. If fewer than 3 such quarters exist, both return values are nil.
+//
+// For each field:
+//   - StmtFlow: Q4 = annual value - sum(Q1+Q2+Q3 de-cumulated values)
+//   - StmtPointInTime: Q4 = annual value directly
+//   - StmtMetric with MappingDerived: recomputed from Q4 values via computeDerived
+func SynthesizeQ4(annualAR, annualMR map[string]float64, annualPeriod Period, quarters []synthesizeInput) (map[string]float64, map[string]float64) {
+	// Walk backwards through quarters to collect the 3 immediately preceding ones.
+	var preceding []synthesizeInput
+
+	for i := len(quarters) - 1; i >= 0; i-- {
+		q := quarters[i]
+
+		if !q.periodEnd.Before(annualPeriod.PeriodEnd) {
+			continue
+		}
+
+		daysBefore := annualPeriod.PeriodEnd.Sub(q.periodEnd).Hours() / 24
+		if daysBefore > maxQ4QuarterSpanDays {
+			continue
+		}
+
+		preceding = append(preceding, q)
+
+		if len(preceding) == 3 {
+			break
+		}
+	}
+
+	if len(preceding) < 3 {
+		return nil, nil
+	}
+
+	arResult := synthesizeFromPreceding(annualAR, preceding, func(q synthesizeInput) map[string]float64 {
+		return q.arEmit
+	})
+
+	mrResult := synthesizeFromPreceding(annualMR, preceding, func(q synthesizeInput) map[string]float64 {
+		return q.mrEmit
+	})
+
+	return arResult, mrResult
+}
+
+// synthesizeFromPreceding builds a Q4 field map from an annual field map and
+// the 3 preceding de-cumulated quarters. emitFn selects either the AR or MR
+// emit map from each quarter.
+func synthesizeFromPreceding(annual map[string]float64, preceding []synthesizeInput, emitFn func(synthesizeInput) map[string]float64) map[string]float64 {
+	result := make(map[string]float64, len(annual))
+
+	for _, m := range FieldMappings {
+		switch {
+		case m.StatementType == StmtFlow:
+			annualVal, hasAnnual := annual[m.FieldName]
+			if !hasAnnual {
+				continue
+			}
+
+			sum := 0.0
+			allFound := true
+
+			for _, q := range preceding {
+				emit := emitFn(q)
+				if v, ok := emit[m.FieldName]; ok {
+					sum += v
+				} else {
+					allFound = false
+					break
+				}
+			}
+
+			if allFound {
+				result[m.FieldName] = annualVal - sum
+			}
+
+		case m.StatementType == StmtPointInTime:
+			if v, ok := annual[m.FieldName]; ok {
+				result[m.FieldName] = v
+			}
+
+		case m.StatementType == StmtMetric && m.Type == MappingDerived:
+			// Recompute from Q4 values after all flow and point-in-time fields
+			// have been populated; handled in a second pass below.
+		}
+	}
+
+	// Second pass: recompute derived metric fields from the Q4 values.
+	for _, m := range FieldMappings {
+		if m.Type != MappingDerived || m.StatementType != StmtMetric {
+			continue
+		}
+
+		if val, ok := computeDerived(m, result); ok {
+			result[m.FieldName] = val
+		}
+	}
+
+	return result
+}

--- a/provider/sec/synthesize_q4_test.go
+++ b/provider/sec/synthesize_q4_test.go
@@ -20,6 +20,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/library"
 )
 
 var _ = Describe("SynthesizeQ4", func() {
@@ -206,5 +209,166 @@ var _ = Describe("SynthesizeQ4", func() {
 			// MR: 520 - (105+125+115) = 175
 			Expect(mrResult["Revenues"]).To(BeNumerically("~", 175, 0.001))
 		})
+	})
+})
+
+var _ = Describe("emitFundamentals Q4 synthesis", func() {
+	// Model a company with FY ending September (like Apple).
+	//
+	// Periods:
+	//   10-Q Q1: Oct-Dec 2023  (period end Dec 30 2023)
+	//   10-Q Q2: Jan-Mar 2024  (period end Mar 30 2024)
+	//   10-Q Q3: Apr-Jun 2024  (period end Jun 29 2024)
+	//   10-K FY: Oct 2023-Sep 2024 (period end Sep 28 2024, annual total)
+	//   10-Q Q1 next FY: Oct-Dec 2024 (period end Dec 28 2024)
+	//
+	// Revenues (flow):
+	//   Q1=110000, Q2=95000, Q3=90000, FY=400000 => Q4=105000
+	//   Q1 next FY=115000
+	//
+	// NetIncomeCommonStock (flow, mapped via NetIncomeLossAvailableToCommonStockholdersBasic):
+	//   Q1=30000, Q2=25000, Q3=22000, FY=100000 => Q4=23000
+	//   Q1 next FY=32000
+
+	d := func(y, m, day int) time.Time {
+		return time.Date(y, time.Month(m), day, 0, 0, 0, 0, time.UTC)
+	}
+
+	// Period boundaries
+	q1End := d(2023, 12, 30)
+	q1Start := d(2023, 10, 1)
+	q1Filed := d(2024, 1, 15)
+
+	q2End := d(2024, 3, 30)
+	q2Start := d(2024, 1, 1)
+	q2Filed := d(2024, 4, 15)
+
+	q3End := d(2024, 6, 29)
+	q3Start := d(2024, 4, 1)
+	q3Filed := d(2024, 7, 15)
+
+	fyEnd := d(2024, 9, 28)
+	fyStart := d(2023, 10, 1)
+	fyFiled := d(2024, 11, 15)
+
+	q1NextEnd := d(2024, 12, 28)
+	q1NextStart := d(2024, 10, 1)
+	q1NextFiled := d(2025, 1, 15)
+
+	// Build CompanyFacts with Revenues and NetIncomeLossAvailableToCommonStockholdersBasic
+	// facts. Facts must be sorted by Filed within each concept.
+	buildCF := func() *CompanyFacts {
+		return &CompanyFacts{
+			CIK:        12345,
+			EntityName: "Test Corp",
+			Facts: map[string][]Fact{
+				"Revenues": {
+					// Q1 single-quarter
+					{Start: q1Start, End: q1End, Val: 110000, Form: "10-Q", Filed: q1Filed, FP: "Q1", FY: 2024},
+					// Q2 single-quarter
+					{Start: q2Start, End: q2End, Val: 95000, Form: "10-Q", Filed: q2Filed, FP: "Q2", FY: 2024},
+					// Q3 single-quarter
+					{Start: q3Start, End: q3End, Val: 90000, Form: "10-Q", Filed: q3Filed, FP: "Q3", FY: 2024},
+					// 10-K full year
+					{Start: fyStart, End: fyEnd, Val: 400000, Form: "10-K", Filed: fyFiled, FP: "FY", FY: 2024},
+					// Q1 next FY
+					{Start: q1NextStart, End: q1NextEnd, Val: 115000, Form: "10-Q", Filed: q1NextFiled, FP: "Q1", FY: 2025},
+				},
+				"NetIncomeLossAvailableToCommonStockholdersBasic": {
+					{Start: q1Start, End: q1End, Val: 30000, Form: "10-Q", Filed: q1Filed, FP: "Q1", FY: 2024},
+					{Start: q2Start, End: q2End, Val: 25000, Form: "10-Q", Filed: q2Filed, FP: "Q2", FY: 2024},
+					{Start: q3Start, End: q3End, Val: 22000, Form: "10-Q", Filed: q3Filed, FP: "Q3", FY: 2024},
+					{Start: fyStart, End: fyEnd, Val: 100000, Form: "10-K", Filed: fyFiled, FP: "FY", FY: 2024},
+					{Start: q1NextStart, End: q1NextEnd, Val: 32000, Form: "10-Q", Filed: q1NextFiled, FP: "Q1", FY: 2025},
+				},
+			},
+		}
+	}
+
+	It("emits synthesized Q4 ARQ/MRQ observations", func() {
+		cf := buildCF()
+		sub := &library.Subscription{Name: "test"}
+		out := make(chan *data.Observation, 100)
+		numObs := 0
+
+		emitFundamentals(cf, AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST", CIK: 12345},
+			sub, time.Time{}, out, &numObs)
+		close(out)
+
+		// Collect observations by dimension and date_key.
+		type obsKey struct {
+			dimension string
+			dateKey   time.Time
+		}
+
+		observations := make(map[obsKey]*data.Fundamental)
+		for obs := range out {
+			key := obsKey{
+				dimension: obs.Fundamental.Dimension,
+				dateKey:   obs.Fundamental.DateKey,
+			}
+			observations[key] = obs.Fundamental
+		}
+
+		// Synthesized Q4 should have FormType "10-Q" so NormalizeEventDate snaps
+		// Sep 28 2024 to Sep 30 2024.
+		q4DateKey := d(2024, 9, 30)
+
+		// Verify Q4 ARQ exists with correct values.
+		arqQ4 := observations[obsKey{dimension: "ARQ", dateKey: q4DateKey}]
+		Expect(arqQ4).NotTo(BeNil(), "expected ARQ observation for Q4 at 2024-09-30")
+		Expect(arqQ4.Revenues).To(BeNumerically("==", 105000),
+			"Q4 Revenues = FY 400000 - (Q1 110000 + Q2 95000 + Q3 90000)")
+		Expect(arqQ4.NetIncomeCommonStock).To(BeNumerically("==", 23000),
+			"Q4 NetIncome = FY 100000 - (Q1 30000 + Q2 25000 + Q3 22000)")
+
+		// Verify Q4 MRQ exists with same values (no restatements in this test).
+		mrqQ4 := observations[obsKey{dimension: "MRQ", dateKey: q4DateKey}]
+		Expect(mrqQ4).NotTo(BeNil(), "expected MRQ observation for Q4 at 2024-09-30")
+		Expect(mrqQ4.Revenues).To(BeNumerically("==", 105000))
+		Expect(mrqQ4.NetIncomeCommonStock).To(BeNumerically("==", 23000))
+	})
+
+	It("includes synthesized Q4 in TTM computation", func() {
+		cf := buildCF()
+		sub := &library.Subscription{Name: "test"}
+		out := make(chan *data.Observation, 100)
+		numObs := 0
+
+		emitFundamentals(cf, AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST", CIK: 12345},
+			sub, time.Time{}, out, &numObs)
+		close(out)
+
+		type obsKey struct {
+			dimension string
+			dateKey   time.Time
+		}
+
+		observations := make(map[obsKey]*data.Fundamental)
+		for obs := range out {
+			key := obsKey{
+				dimension: obs.Fundamental.Dimension,
+				dateKey:   obs.Fundamental.DateKey,
+			}
+			observations[key] = obs.Fundamental
+		}
+
+		// The Q1 next FY (Oct-Dec 2024) normalized date is 2024-12-31.
+		// TTM at that date = Q1NextFY + Q4 + Q3 + Q2
+		//   Revenues: 115000 + 105000 + 90000 + 95000 = 405000
+		//   NetIncome: 32000 + 23000 + 22000 + 25000 = 102000
+		q1NextDateKey := d(2024, 12, 31)
+
+		artQ1Next := observations[obsKey{dimension: "ART", dateKey: q1NextDateKey}]
+		Expect(artQ1Next).NotTo(BeNil(), "expected ART observation at 2024-12-31")
+		Expect(artQ1Next.Revenues).To(BeNumerically("==", 405000),
+			"ART Revenues = Q1Next 115000 + Q4 105000 + Q3 90000 + Q2 95000")
+		Expect(artQ1Next.NetIncomeCommonStock).To(BeNumerically("==", 102000),
+			"ART NetIncome = Q1Next 32000 + Q4 23000 + Q3 22000 + Q2 25000")
+
+		mrtQ1Next := observations[obsKey{dimension: "MRT", dateKey: q1NextDateKey}]
+		Expect(mrtQ1Next).NotTo(BeNil(), "expected MRT observation at 2024-12-31")
+		Expect(mrtQ1Next.Revenues).To(BeNumerically("==", 405000))
+		Expect(mrtQ1Next.NetIncomeCommonStock).To(BeNumerically("==", 102000))
 	})
 })

--- a/provider/sec/synthesize_q4_test.go
+++ b/provider/sec/synthesize_q4_test.go
@@ -1,0 +1,210 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sec
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SynthesizeQ4", func() {
+	// Use a standard calendar-year fiscal period for clarity.
+	annualPeriodEnd := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	annualPeriod := Period{
+		PeriodEnd:   annualPeriodEnd,
+		FormType:    "10-K",
+		ARFiledDate: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+		MRFiledDate: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	// Three preceding quarters: Q1, Q2, Q3 (de-cumulated single-quarter values).
+	q1 := synthesizeInput{
+		periodEnd: time.Date(2023, 3, 31, 0, 0, 0, 0, time.UTC),
+		arEmit:    map[string]float64{"Revenues": 100, "TotalAssets": 1000},
+		mrEmit:    map[string]float64{"Revenues": 100, "TotalAssets": 1000},
+	}
+	q2 := synthesizeInput{
+		periodEnd: time.Date(2023, 6, 30, 0, 0, 0, 0, time.UTC),
+		arEmit:    map[string]float64{"Revenues": 120, "TotalAssets": 1100},
+		mrEmit:    map[string]float64{"Revenues": 120, "TotalAssets": 1100},
+	}
+	q3 := synthesizeInput{
+		periodEnd: time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC),
+		arEmit:    map[string]float64{"Revenues": 110, "TotalAssets": 1050},
+		mrEmit:    map[string]float64{"Revenues": 110, "TotalAssets": 1050},
+	}
+
+	// Annual totals: Revenues is a flow field; TotalAssets is point-in-time.
+	annualAR := map[string]float64{"Revenues": 500, "TotalAssets": 1200}
+	annualMR := map[string]float64{"Revenues": 500, "TotalAssets": 1200}
+
+	Describe("flow field computation", func() {
+		It("returns Q4 = annual - sum(Q1+Q2+Q3) for flow fields", func() {
+			quarters := []synthesizeInput{q1, q2, q3}
+			arResult, mrResult := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters)
+
+			Expect(arResult).NotTo(BeNil())
+			Expect(mrResult).NotTo(BeNil())
+
+			// Revenues is StmtFlow: 500 - (100 + 120 + 110) = 170
+			Expect(arResult["Revenues"]).To(BeNumerically("~", 170, 0.001))
+			Expect(mrResult["Revenues"]).To(BeNumerically("~", 170, 0.001))
+		})
+	})
+
+	Describe("point-in-time field computation", func() {
+		It("uses the annual value directly for point-in-time fields", func() {
+			quarters := []synthesizeInput{q1, q2, q3}
+			arResult, mrResult := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters)
+
+			Expect(arResult).NotTo(BeNil())
+			Expect(mrResult).NotTo(BeNil())
+
+			// TotalAssets is StmtPointInTime: use annual value = 1200
+			Expect(arResult["TotalAssets"]).To(BeNumerically("~", 1200, 0.001))
+			Expect(mrResult["TotalAssets"]).To(BeNumerically("~", 1200, 0.001))
+		})
+	})
+
+	Describe("insufficient quarters", func() {
+		It("returns nil when fewer than 3 quarters precede the 10-K", func() {
+			quarters := []synthesizeInput{q1, q2}
+			arResult, mrResult := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters)
+
+			Expect(arResult).To(BeNil())
+			Expect(mrResult).To(BeNil())
+		})
+
+		It("returns nil when no quarters precede the 10-K", func() {
+			arResult, mrResult := SynthesizeQ4(annualAR, annualMR, annualPeriod, []synthesizeInput{})
+
+			Expect(arResult).To(BeNil())
+			Expect(mrResult).To(BeNil())
+		})
+	})
+
+	Describe("quarters too far from 10-K period end", func() {
+		It("returns nil when quarters are more than 400 days before the 10-K period end", func() {
+			// Place Q3 over 400 days before the annual period end.
+			oldQ3 := synthesizeInput{
+				periodEnd: annualPeriodEnd.AddDate(0, 0, -410),
+				arEmit:    map[string]float64{"Revenues": 110},
+				mrEmit:    map[string]float64{"Revenues": 110},
+			}
+			quarters := []synthesizeInput{q1, q2, oldQ3}
+			arResult, mrResult := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters)
+
+			Expect(arResult).To(BeNil())
+			Expect(mrResult).To(BeNil())
+		})
+	})
+
+	Describe("quarter ordering", func() {
+		It("picks the 3 quarters immediately preceding the 10-K even when older quarters are present", func() {
+			// Add an old quarter from the prior fiscal year that should be ignored.
+			oldQ := synthesizeInput{
+				periodEnd: time.Date(2022, 12, 31, 0, 0, 0, 0, time.UTC),
+				arEmit:    map[string]float64{"Revenues": 999},
+				mrEmit:    map[string]float64{"Revenues": 999},
+			}
+			quarters := []synthesizeInput{oldQ, q1, q2, q3}
+			arResult, mrResult := SynthesizeQ4(annualAR, annualMR, annualPeriod, quarters)
+
+			Expect(arResult).NotTo(BeNil())
+			Expect(mrResult).NotTo(BeNil())
+
+			// Should still be 500 - (100+120+110) = 170, ignoring the old quarter.
+			Expect(arResult["Revenues"]).To(BeNumerically("~", 170, 0.001))
+		})
+	})
+
+	Describe("derived metric fields", func() {
+		It("recomputes GrossMargin (GrossProfit / Revenues) from synthesized Q4 flow values", func() {
+			// Annual totals for flow fields.
+			annualARLocal := map[string]float64{"Revenues": 500, "GrossProfit": 225}
+			annualMRLocal := map[string]float64{"Revenues": 500, "GrossProfit": 225}
+
+			// Three quarters whose flow values sum to 330 / 150.
+			q1gm := synthesizeInput{
+				periodEnd: q1.periodEnd,
+				arEmit:    map[string]float64{"Revenues": 100, "GrossProfit": 45},
+				mrEmit:    map[string]float64{"Revenues": 100, "GrossProfit": 45},
+			}
+			q2gm := synthesizeInput{
+				periodEnd: q2.periodEnd,
+				arEmit:    map[string]float64{"Revenues": 120, "GrossProfit": 55},
+				mrEmit:    map[string]float64{"Revenues": 120, "GrossProfit": 55},
+			}
+			q3gm := synthesizeInput{
+				periodEnd: q3.periodEnd,
+				arEmit:    map[string]float64{"Revenues": 110, "GrossProfit": 50},
+				mrEmit:    map[string]float64{"Revenues": 110, "GrossProfit": 50},
+			}
+
+			quarters := []synthesizeInput{q1gm, q2gm, q3gm}
+			arResult, mrResult := SynthesizeQ4(annualARLocal, annualMRLocal, annualPeriod, quarters)
+
+			Expect(arResult).NotTo(BeNil())
+			Expect(mrResult).NotTo(BeNil())
+
+			// Q4 Revenues = 500 - (100+120+110) = 170
+			Expect(arResult["Revenues"]).To(BeNumerically("~", 170, 0.001))
+			// Q4 GrossProfit = 225 - (45+55+50) = 75
+			Expect(arResult["GrossProfit"]).To(BeNumerically("~", 75, 0.001))
+			// Q4 GrossMargin = GrossProfit / Revenues = 75 / 170 ≈ 0.4412
+			Expect(arResult["GrossMargin"]).To(BeNumerically("~", 75.0/170.0, 0.0001))
+			Expect(mrResult["GrossMargin"]).To(BeNumerically("~", 75.0/170.0, 0.0001))
+		})
+	})
+
+	Describe("AR and MR emit independence", func() {
+		It("computes AR and MR independently when their values differ", func() {
+			// MR values reflect a restatement: Revenues was restated upward.
+			annualARLocal := map[string]float64{"Revenues": 500}
+			annualMRLocal := map[string]float64{"Revenues": 520}
+
+			q1mr := synthesizeInput{
+				periodEnd: q1.periodEnd,
+				arEmit:    map[string]float64{"Revenues": 100},
+				mrEmit:    map[string]float64{"Revenues": 105},
+			}
+			q2mr := synthesizeInput{
+				periodEnd: q2.periodEnd,
+				arEmit:    map[string]float64{"Revenues": 120},
+				mrEmit:    map[string]float64{"Revenues": 125},
+			}
+			q3mr := synthesizeInput{
+				periodEnd: q3.periodEnd,
+				arEmit:    map[string]float64{"Revenues": 110},
+				mrEmit:    map[string]float64{"Revenues": 115},
+			}
+
+			quarters := []synthesizeInput{q1mr, q2mr, q3mr}
+			arResult, mrResult := SynthesizeQ4(annualARLocal, annualMRLocal, annualPeriod, quarters)
+
+			Expect(arResult).NotTo(BeNil())
+			Expect(mrResult).NotTo(BeNil())
+
+			// AR: 500 - (100+120+110) = 170
+			Expect(arResult["Revenues"]).To(BeNumerically("~", 170, 0.001))
+			// MR: 520 - (105+125+115) = 175
+			Expect(mrResult["Revenues"]).To(BeNumerically("~", 175, 0.001))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Derives Q4 single-quarter values from 10-K annual data by subtracting the 3 preceding de-cumulated 10-Q quarters (Q4 = annual - Q1 - Q2 - Q3)
- Wires the synthesis into `emitFundamentals()` so Q4 ARQ/MRQ observations are emitted and TTM (ART/MRT) includes all 4 fiscal quarters
- Adds `--exclude-foreign` flag (default true) to `compare-fundamentals` to filter foreign issuers that lack 10-Q data

Fixes #42

## Root cause

`emitFundamentals()` only collected 10-Q periods into the `quarters` slice. No company files a 10-Q for its fiscal year-end quarter (Q4) -- Q4 data only exists in the 10-K. This caused `ComputeTTM` to sum 4 consecutive 10-Q periods spanning two fiscal years, skipping Q4 entirely. For AAPL: SEC TTM net income was 115.3B vs Sharadar's correct 96.2B.

## Test plan

- [ ] `ginkgo run -race ./provider/sec/` -- 88 tests pass (10 new), including:
  - Unit tests for `SynthesizeQ4` (flow fields, point-in-time, metrics, edge cases)
  - Integration tests verifying Q4 ARQ/MRQ emission and correct ART/MRT TTM values
- [ ] Run `pvdata compare-fundamentals --ticker AAPL --dimension ART` to verify TTM revenues/net_income now match Sharadar
- [ ] Verify `--exclude-foreign` filters foreign issuers from comparison output