### PR TITLE
feat(sec): compute period-average fields (#43)

### DIFF
--- a/cmd/compare_fundamentals.go
+++ b/cmd/compare_fundamentals.go
@@ -982,9 +982,8 @@ func runCompareFundamentals(cmd *cobra.Command, args []string) {
 		domesticSQL := fmt.Sprintf("SELECT DISTINCT ticker FROM %s WHERE dimension = 'ARQ'", secTable)
 
 		arqRows, arqErr := conn.Query(ctx, domesticSQL)
-		conn.Release()
-
 		if arqErr != nil {
+			conn.Release()
 			log.Fatal().Err(arqErr).Msg("could not query domestic tickers from sec table")
 		}
 
@@ -994,6 +993,7 @@ func runCompareFundamentals(cmd *cobra.Command, args []string) {
 			var t string
 			if scanErr := arqRows.Scan(&t); scanErr != nil {
 				arqRows.Close()
+				conn.Release()
 				log.Fatal().Err(scanErr).Msg("could not scan domestic ticker")
 			}
 
@@ -1003,8 +1003,11 @@ func runCompareFundamentals(cmd *cobra.Command, args []string) {
 		arqRows.Close()
 
 		if arqErr = arqRows.Err(); arqErr != nil {
+			conn.Release()
 			log.Fatal().Err(arqErr).Msg("error reading domestic ticker rows")
 		}
+
+		conn.Release()
 
 		log.Info().Int("count", len(domesticTickers)).Msg("domestic tickers found (have ARQ data in sec table)")
 

--- a/docs/superpowers/plans/2026-04-12-period-average-fields.md
+++ b/docs/superpowers/plans/2026-04-12-period-average-fields.md
@@ -1,0 +1,1122 @@
+# Period-Average Fields Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compute 7 fields the SEC provider is missing (`InvestedCapital`, `AverageAssets`, `EquityAvg`, `InvestedCapitalAverage`, `ROA`, `ROE`, `ROIC`) so they match Sharadar exactly.
+
+**Architecture:** Extend the derivation engine with `OpLinearCombination` to support InvestedCapital's 5-term formula. Add a `ComputePeriodAverages` function that takes current and prior period field maps and produces the 6 average/ratio fields. Wire it into `emitFundamentals` after de-cumulation (quarterly), in a new annuals collection loop (annual), and after `ComputeTTM` (TTM).
+
+**Tech Stack:** Go, Ginkgo v2, Gomega.
+
+---
+
+## File Structure
+
+- **Modify:** `provider/sec/mapping_config.go` -- add `Coefficients` field to `FieldMapping`, add `OpLinearCombination` constant, add `InvestedCapital` mapping entry, remove deferred-fields comments
+- **Modify:** `provider/sec/mapping.go` -- add `OpLinearCombination` case to `computeDerived`
+- **Modify:** `provider/sec/dimensions.go` -- add `ComputePeriodAverages` function, add 7 field mappings to `BuildFundamental`
+- **Modify:** `provider/sec/sec.go` -- wire period averages into quarterly, annual, and TTM emission loops
+- **Modify:** `provider/sec/mapping_test.go` -- tests for `OpLinearCombination` and `InvestedCapital`
+- **Modify:** `provider/sec/dimensions_test.go` -- tests for `ComputePeriodAverages` and integration tests
+
+---
+
+### Task 1: Add OpLinearCombination to the derivation engine
+
+**Files:**
+- Modify: `provider/sec/mapping_config.go:36-42` (FormulaOp constants)
+- Modify: `provider/sec/mapping_config.go:44-69` (FieldMapping struct)
+- Modify: `provider/sec/mapping.go:226-286` (computeDerived)
+- Modify: `provider/sec/mapping_test.go`
+
+- [ ] **Step 1: Write failing tests for OpLinearCombination**
+
+Add to `provider/sec/mapping_test.go` inside the `Describe("Mapping Engine"` block, after the existing `computeDerived with OptionalOperands` describe:
+
+```go
+Describe("computeDerived with OpLinearCombination", func() {
+    It("computes weighted sum of operands", func() {
+        resolved := map[string]float64{
+            "A": 100,
+            "B": 200,
+            "C": 30,
+            "D": 20,
+            "E": 10,
+        }
+        m := FieldMapping{
+            FieldName:    "Result",
+            Type:         MappingDerived,
+            Op:           OpLinearCombination,
+            Operands:     []string{"A", "B", "C", "D", "E"},
+            Coefficients: []float64{1, 1, -1, -1, -1},
+        }
+        val, ok := computeDerived(m, resolved)
+        Expect(ok).To(BeTrue())
+        Expect(val).To(Equal(240.0))
+    })
+
+    It("returns false when any operand is missing", func() {
+        resolved := map[string]float64{
+            "A": 100,
+            "B": 200,
+        }
+        m := FieldMapping{
+            FieldName:    "Result",
+            Type:         MappingDerived,
+            Op:           OpLinearCombination,
+            Operands:     []string{"A", "B", "C"},
+            Coefficients: []float64{1, 1, -1},
+        }
+        _, ok := computeDerived(m, resolved)
+        Expect(ok).To(BeFalse())
+    })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "OpLinearCombination" ./provider/sec/`
+Expected: compilation error -- `OpLinearCombination` and `Coefficients` are undefined.
+
+- [ ] **Step 3: Add OpLinearCombination constant and Coefficients field**
+
+In `provider/sec/mapping_config.go`, add the new constant after the existing three:
+
+```go
+const (
+	OpAdd               FormulaOp = "add"                // A + B + ...
+	OpSubtract          FormulaOp = "subtract"           // A - B
+	OpDivide            FormulaOp = "divide"             // A / B
+	OpLinearCombination FormulaOp = "linear_combination" // C0*A + C1*B + ...
+)
+```
+
+Add the `Coefficients` field to the `FieldMapping` struct, after the `Operands` field:
+
+```go
+	// For derived mappings: formula
+	Op           FormulaOp // Operation to apply
+	Operands     []string  // Field names to use as operands
+	Coefficients []float64 // Per-operand multipliers (for OpLinearCombination)
+```
+
+- [ ] **Step 4: Implement OpLinearCombination in computeDerived**
+
+In `provider/sec/mapping.go`, add a new case in the `switch m.Op` block inside `computeDerived`, after the `OpDivide` case:
+
+```go
+	case OpLinearCombination:
+		if len(vals) != len(m.Coefficients) {
+			return 0, false
+		}
+
+		sum := 0.0
+		for i, v := range vals {
+			sum += m.Coefficients[i] * v
+		}
+
+		return sum, true
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "OpLinearCombination" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add provider/sec/mapping_config.go provider/sec/mapping.go provider/sec/mapping_test.go
+git commit -m "feat(sec): add OpLinearCombination to derivation engine (#43)"
+```
+
+---
+
+### Task 2: Add InvestedCapital field mapping
+
+**Files:**
+- Modify: `provider/sec/mapping_config.go:590-594` (replace omission comment with mapping)
+- Modify: `provider/sec/mapping_config.go:668-678` (update trailing comment)
+- Modify: `provider/sec/dimensions.go:730-735` (add to BuildFundamental)
+- Modify: `provider/sec/mapping_test.go`
+
+- [ ] **Step 1: Write failing test for InvestedCapital resolution**
+
+Add to `provider/sec/mapping_test.go` inside `Describe("ResolveAllFields"`:
+
+```go
+It("resolves InvestedCapital from component fields", func() {
+    periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+    filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+    icCF := &CompanyFacts{
+        CIK: 1, EntityName: "Test Co",
+        Facts: map[string][]Fact{
+            "LongTermDebtCurrent":                        {{End: periodEnd, Filed: filed, Val: 10_000, Form: "10-Q"}},
+            "LongTermDebtNoncurrent":                     {{End: periodEnd, Filed: filed, Val: 90_000, Form: "10-Q"}},
+            "Assets":                                     {{End: periodEnd, Filed: filed, Val: 350_000, Form: "10-Q"}},
+            "IntangibleAssetsNetIncludingGoodwill":        {{End: periodEnd, Filed: filed, Val: 50_000, Form: "10-Q"}},
+            "CashAndCashEquivalentsAtCarryingValue":       {{End: periodEnd, Filed: filed, Val: 25_000, Form: "10-Q"}},
+            "LiabilitiesCurrent":                         {{End: periodEnd, Filed: filed, Val: 60_000, Form: "10-Q"}},
+        },
+    }
+
+    resolved := ResolveAllFields(icCF, periodEnd, "10-Q")
+
+    // TotalDebt = DebtCurrent(10_000) + DebtNonCurrent(90_000) = 100_000
+    // InvestedCapital = 100_000 + 350_000 - 50_000 - 25_000 - 60_000 = 315_000
+    Expect(resolved).To(HaveKey("InvestedCapital"))
+    Expect(resolved["InvestedCapital"]).To(Equal(315_000.0))
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "resolves InvestedCapital" ./provider/sec/`
+Expected: FAIL -- `InvestedCapital` key not present.
+
+- [ ] **Step 3: Add InvestedCapital mapping and update comments**
+
+In `provider/sec/mapping_config.go`, replace the omission comment (lines 590-594) with:
+
+```go
+	// InvestedCapital = TotalDebt + TotalAssets - Intangibles - CashAndEquivalents - CurrentLiabilities
+	{
+		FieldName: "InvestedCapital", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+		Op:           OpLinearCombination,
+		Operands:     []string{"TotalDebt", "TotalAssets", "Intangibles", "CashAndEquivalents", "CurrentLiabilities"},
+		Coefficients: []float64{1, 1, -1, -1, -1},
+	},
+```
+
+Update the trailing comment (lines 668-678) to remove the three lines about ROA/ROE/ROIC and AverageAssets/EquityAvg/InvestedCapitalAverage:
+
+```go
+	// Note: The following Sharadar fields require market price data and are
+	// NOT computable from SEC filings alone. They are intentionally omitted:
+	// - MarketCapitalization, EnterpriseValue, PE, PB, PS, PE1, PS1
+	// - EVtoEBIT, EVtoEBITDA, DividendYield, PayoutRatio, Price
+	// - ShareFactor, FxUSD
+```
+
+- [ ] **Step 4: Add InvestedCapital to BuildFundamental**
+
+In `provider/sec/dimensions.go`, add the following after the `TangibleAssetValue` mapping (after line 733):
+
+```go
+	if v, ok := fields["InvestedCapital"]; ok {
+		f.InvestedCapital = int64(v)
+	}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "resolves InvestedCapital" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass (including the `BuildFundamental coverage` test which checks all FieldMappings entries are referenced).
+
+- [ ] **Step 7: Run lint**
+
+Run: `make lint`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add provider/sec/mapping_config.go provider/sec/dimensions.go provider/sec/mapping_test.go
+git commit -m "feat(sec): add InvestedCapital field mapping (#43)"
+```
+
+---
+
+### Task 3: Implement ComputePeriodAverages
+
+**Files:**
+- Modify: `provider/sec/dimensions.go` (add function after `ComputeTTM`)
+- Modify: `provider/sec/dimensions_test.go`
+
+- [ ] **Step 1: Write failing tests for ComputePeriodAverages**
+
+Add to `provider/sec/dimensions_test.go` inside the top-level `Describe("Dimensions"` block:
+
+```go
+Describe("ComputePeriodAverages", func() {
+    It("computes all 6 fields from complete inputs", func() {
+        current := map[string]float64{
+            "TotalAssets":          400_000,
+            "Equity":              200_000,
+            "InvestedCapital":     300_000,
+            "NetIncomeCommonStock": 50_000,
+            "EBIT":                60_000,
+        }
+        prior := map[string]float64{
+            "TotalAssets":      360_000,
+            "Equity":          180_000,
+            "InvestedCapital": 280_000,
+        }
+
+        result := ComputePeriodAverages(current, prior)
+
+        // Averages
+        Expect(result["AverageAssets"]).To(Equal(380_000.0))
+        Expect(result["EquityAvg"]).To(Equal(190_000.0))
+        Expect(result["InvestedCapitalAverage"]).To(Equal(290_000.0))
+
+        // Ratios
+        Expect(result["ROA"]).To(BeNumerically("~", 50_000.0/380_000.0, 1e-10))
+        Expect(result["ROE"]).To(BeNumerically("~", 50_000.0/190_000.0, 1e-10))
+        Expect(result["ROIC"]).To(BeNumerically("~", 60_000.0/290_000.0, 1e-10))
+    })
+
+    It("omits average when prior is missing the balance sheet field", func() {
+        current := map[string]float64{
+            "TotalAssets":          400_000,
+            "Equity":              200_000,
+            "NetIncomeCommonStock": 50_000,
+            "EBIT":                60_000,
+        }
+        prior := map[string]float64{
+            "TotalAssets": 360_000,
+            // Equity missing
+        }
+
+        result := ComputePeriodAverages(current, prior)
+
+        Expect(result).To(HaveKey("AverageAssets"))
+        Expect(result).To(HaveKey("ROA"))
+        Expect(result).NotTo(HaveKey("EquityAvg"))
+        Expect(result).NotTo(HaveKey("ROE"))
+    })
+
+    It("omits ratio when numerator is missing", func() {
+        current := map[string]float64{
+            "TotalAssets": 400_000,
+            "Equity":     200_000,
+            // NetIncomeCommonStock missing
+        }
+        prior := map[string]float64{
+            "TotalAssets": 360_000,
+            "Equity":     180_000,
+        }
+
+        result := ComputePeriodAverages(current, prior)
+
+        Expect(result).To(HaveKey("AverageAssets"))
+        Expect(result).To(HaveKey("EquityAvg"))
+        Expect(result).NotTo(HaveKey("ROA"))
+        Expect(result).NotTo(HaveKey("ROE"))
+    })
+
+    It("omits ratio when average denominator is zero", func() {
+        current := map[string]float64{
+            "TotalAssets":          100,
+            "NetIncomeCommonStock": 50,
+        }
+        prior := map[string]float64{
+            "TotalAssets": -100, // average = 0
+        }
+
+        result := ComputePeriodAverages(current, prior)
+
+        Expect(result).To(HaveKey("AverageAssets"))
+        Expect(result["AverageAssets"]).To(Equal(0.0))
+        Expect(result).NotTo(HaveKey("ROA"))
+    })
+
+    It("returns empty map when prior is nil", func() {
+        current := map[string]float64{
+            "TotalAssets":          400_000,
+            "Equity":              200_000,
+            "NetIncomeCommonStock": 50_000,
+        }
+
+        result := ComputePeriodAverages(current, nil)
+        Expect(result).To(BeEmpty())
+    })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "ComputePeriodAverages" ./provider/sec/`
+Expected: compilation error -- `ComputePeriodAverages` is undefined.
+
+- [ ] **Step 3: Implement ComputePeriodAverages**
+
+Add to `provider/sec/dimensions.go`, after the `ComputeTTM` function (after line 404):
+
+```go
+// ComputePeriodAverages computes period-average balance sheet fields and the
+// ratios that depend on them. current is the emit-ready field map for the
+// period being computed; prior is the emit-ready field map for the immediately
+// preceding period of the same type (prior quarter for quarterly, prior year
+// for annual, quarter before the TTM window for TTM).
+//
+// Returns a map containing only the computed fields; the caller merges these
+// into the emit map. Fields whose inputs are missing are silently omitted.
+func ComputePeriodAverages(current, prior map[string]float64) map[string]float64 {
+	result := make(map[string]float64)
+
+	if prior == nil {
+		return result
+	}
+
+	// Helper: compute (prior[field] + current[field]) / 2 if both exist.
+	avg := func(field string) (float64, bool) {
+		cv, cOK := current[field]
+		pv, pOK := prior[field]
+		if !cOK || !pOK {
+			return 0, false
+		}
+
+		return (pv + cv) / 2, true
+	}
+
+	// Averages
+	if v, ok := avg("TotalAssets"); ok {
+		result["AverageAssets"] = v
+	}
+
+	if v, ok := avg("Equity"); ok {
+		result["EquityAvg"] = v
+	}
+
+	if v, ok := avg("InvestedCapital"); ok {
+		result["InvestedCapitalAverage"] = v
+	}
+
+	// Ratios (only when both numerator and denominator are available and non-zero)
+	ratio := func(numField, denomField string) (float64, bool) {
+		num, nOK := current[numField]
+		denom, dOK := result[denomField]
+		if !nOK || !dOK || denom == 0 {
+			return 0, false
+		}
+
+		return num / denom, true
+	}
+
+	if v, ok := ratio("NetIncomeCommonStock", "AverageAssets"); ok {
+		result["ROA"] = v
+	}
+
+	if v, ok := ratio("NetIncomeCommonStock", "EquityAvg"); ok {
+		result["ROE"] = v
+	}
+
+	if v, ok := ratio("EBIT", "InvestedCapitalAverage"); ok {
+		result["ROIC"] = v
+	}
+
+	return result
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "ComputePeriodAverages" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add provider/sec/dimensions.go provider/sec/dimensions_test.go
+git commit -m "feat(sec): add ComputePeriodAverages function (#43)"
+```
+
+---
+
+### Task 4: Add period-average fields to BuildFundamental
+
+**Files:**
+- Modify: `provider/sec/dimensions.go:730-735` (add field mappings)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `provider/sec/dimensions_test.go` inside `Describe("BuildFundamental coverage"`:
+
+```go
+It("references all period-average fields", func() {
+    src, err := os.ReadFile("dimensions.go")
+    Expect(err).NotTo(HaveOccurred())
+    srcStr := string(src)
+
+    avgFields := []string{
+        "AverageAssets", "EquityAvg", "InvestedCapitalAverage",
+        "ROA", "ROE", "ROIC",
+    }
+
+    var missing []string
+    for _, name := range avgFields {
+        pattern := fmt.Sprintf(`fields[%q]`, name)
+        if !strings.Contains(srcStr, pattern) {
+            missing = append(missing, name)
+        }
+    }
+
+    Expect(missing).To(BeEmpty(),
+        "period-average fields not referenced in BuildFundamental: %v", missing)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "references all period-average" ./provider/sec/`
+Expected: FAIL -- fields not yet present in BuildFundamental.
+
+- [ ] **Step 3: Add the 6 field mappings to BuildFundamental**
+
+In `provider/sec/dimensions.go`, add the following after the `InvestedCapital` mapping (added in Task 2) inside `BuildFundamental`:
+
+```go
+	if v, ok := fields["AverageAssets"]; ok {
+		f.AverageAssets = int64(v)
+	}
+
+	if v, ok := fields["EquityAvg"]; ok {
+		f.EquityAvg = int64(v)
+	}
+
+	if v, ok := fields["InvestedCapitalAverage"]; ok {
+		f.InvestedCapitalAverage = int64(v)
+	}
+
+	if v, ok := fields["ROA"]; ok {
+		f.ROA = v
+	}
+
+	if v, ok := fields["ROE"]; ok {
+		f.ROE = v
+	}
+
+	if v, ok := fields["ROIC"]; ok {
+		f.ROIC = v
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "references all period-average" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add provider/sec/dimensions.go provider/sec/dimensions_test.go
+git commit -m "feat(sec): add period-average fields to BuildFundamental (#43)"
+```
+
+---
+
+### Task 5: Wire period averages into quarterly emission
+
+**Files:**
+- Modify: `provider/sec/sec.go:602-638` (add average pass after de-cumulation, before quarterly emission)
+- Modify: `provider/sec/dimensions_test.go`
+
+- [ ] **Step 1: Write failing integration test for quarterly period averages**
+
+Add to `provider/sec/dimensions_test.go` inside the top-level `Describe("Dimensions"` block:
+
+```go
+Describe("quarterly period averages", func() {
+    It("computes averages from consecutive quarters", func() {
+        cf := &CompanyFacts{
+            CIK:        1,
+            EntityName: "Avg Co",
+            Facts:      make(map[string][]Fact),
+        }
+
+        q1End := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+        q2End := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+        q1Filed := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+        q2Filed := time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)
+        fyStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+        // Balance sheet (instant)
+        cf.Facts["Assets"] = []Fact{
+            {End: q1End, Filed: q1Filed, Val: 1000, Form: "10-Q"},
+            {End: q2End, Filed: q2Filed, Val: 1200, Form: "10-Q"},
+        }
+        cf.Facts["StockholdersEquity"] = []Fact{
+            {End: q1End, Filed: q1Filed, Val: 500, Form: "10-Q"},
+            {End: q2End, Filed: q2Filed, Val: 600, Form: "10-Q"},
+        }
+
+        // Income statement (duration, quarterly facts)
+        cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"] = []Fact{
+            {Start: fyStart, End: q1End, Filed: q1Filed, Val: 100, Form: "10-Q"},
+            {Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 120, Form: "10-Q"},
+        }
+        cf.Facts["Revenues"] = []Fact{
+            {Start: fyStart, End: q1End, Filed: q1Filed, Val: 500, Form: "10-Q"},
+            {Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 600, Form: "10-Q"},
+        }
+
+        asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+        out := make(chan *data.Observation, 256)
+        sub := &library.Subscription{Name: "test"}
+
+        done := make(chan struct{})
+        var q1Fund, q2Fund *data.Fundamental
+
+        go func() {
+            for obs := range out {
+                f := obs.Fundamental
+                dateKey := obs.ObservationDate.Format("2006-01-02")
+                if f.Dimension == "ARQ" && dateKey == "2024-03-31" {
+                    q1Fund = f
+                }
+                if f.Dimension == "ARQ" && dateKey == "2024-06-30" {
+                    q2Fund = f
+                }
+            }
+            close(done)
+        }()
+
+        numObs := 0
+        emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+        close(out)
+        <-done
+
+        // Q1: no prior quarter, averages should be zero (absent)
+        Expect(q1Fund).NotTo(BeNil())
+        Expect(q1Fund.AverageAssets).To(Equal(int64(0)))
+        Expect(q1Fund.ROA).To(Equal(0.0))
+
+        // Q2: has prior quarter
+        Expect(q2Fund).NotTo(BeNil())
+        Expect(q2Fund.AverageAssets).To(Equal(int64(1100)))  // (1000+1200)/2
+        Expect(q2Fund.EquityAvg).To(Equal(int64(550)))       // (500+600)/2
+        Expect(q2Fund.ROA).To(BeNumerically("~", 120.0/1100.0, 1e-10))
+        Expect(q2Fund.ROE).To(BeNumerically("~", 120.0/550.0, 1e-10))
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "computes averages from consecutive quarters" ./provider/sec/`
+Expected: FAIL -- `q2Fund.AverageAssets` is 0.
+
+- [ ] **Step 3: Wire period averages into the quarterly loop**
+
+In `provider/sec/sec.go`, after the de-cumulation loop (after line 602, the closing `}`), add a new loop:
+
+```go
+	// Compute period-average fields (AverageAssets, EquityAvg,
+	// InvestedCapitalAverage) and derived ratios (ROA, ROE, ROIC) from
+	// consecutive quarterly balance sheet values.
+	for i := range quarters {
+		q := &quarters[i]
+
+		if i == 0 {
+			continue
+		}
+
+		prev := &quarters[i-1]
+		gapDays := q.period.PeriodEnd.Sub(prev.period.PeriodEnd).Hours() / 24
+
+		if gapDays > maxQuarterGapDays {
+			continue
+		}
+
+		for k, v := range ComputePeriodAverages(q.arEmit, prev.arEmit) {
+			q.arEmit[k] = v
+		}
+
+		for k, v := range ComputePeriodAverages(q.mrEmit, prev.mrEmit) {
+			q.mrEmit[k] = v
+		}
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "computes averages from consecutive quarters" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add provider/sec/sec.go provider/sec/dimensions_test.go
+git commit -m "feat(sec): wire period averages into quarterly emission (#43)"
+```
+
+---
+
+### Task 6: Wire period averages into annual emission
+
+**Files:**
+- Modify: `provider/sec/sec.go:536-568` (refactor annual emission to collect then emit)
+- Modify: `provider/sec/dimensions_test.go`
+
+- [ ] **Step 1: Write failing integration test for annual period averages**
+
+Add to `provider/sec/dimensions_test.go` inside the top-level `Describe("Dimensions"` block:
+
+```go
+Describe("annual period averages", func() {
+    It("computes averages from consecutive annual periods", func() {
+        cf := &CompanyFacts{
+            CIK:        1,
+            EntityName: "Annual Co",
+            Facts:      make(map[string][]Fact),
+        }
+
+        fy1End := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
+        fy2End := time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC)
+        fy1Filed := time.Date(2023, 11, 1, 0, 0, 0, 0, time.UTC)
+        fy2Filed := time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)
+
+        // Balance sheet (instant)
+        cf.Facts["Assets"] = []Fact{
+            {End: fy1End, Filed: fy1Filed, Val: 2000, Form: "10-K"},
+            {End: fy2End, Filed: fy2Filed, Val: 2400, Form: "10-K"},
+        }
+        cf.Facts["StockholdersEquity"] = []Fact{
+            {End: fy1End, Filed: fy1Filed, Val: 800, Form: "10-K"},
+            {End: fy2End, Filed: fy2Filed, Val: 1000, Form: "10-K"},
+        }
+
+        // Income statement (duration)
+        cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"] = []Fact{
+            {Start: time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC), End: fy1End, Filed: fy1Filed, Val: 200, Form: "10-K"},
+            {Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC), End: fy2End, Filed: fy2Filed, Val: 250, Form: "10-K"},
+        }
+        cf.Facts["Revenues"] = []Fact{
+            {Start: time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC), End: fy1End, Filed: fy1Filed, Val: 1000, Form: "10-K"},
+            {Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC), End: fy2End, Filed: fy2Filed, Val: 1200, Form: "10-K"},
+        }
+
+        asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+        out := make(chan *data.Observation, 256)
+        sub := &library.Subscription{Name: "test"}
+
+        done := make(chan struct{})
+        var fy1Fund, fy2Fund *data.Fundamental
+
+        go func() {
+            for obs := range out {
+                f := obs.Fundamental
+                dateKey := obs.ObservationDate.Format("2006-01-02")
+                if f.Dimension == "ARY" && dateKey == "2023-12-31" {
+                    fy1Fund = f
+                }
+                if f.Dimension == "ARY" && dateKey == "2024-12-31" {
+                    fy2Fund = f
+                }
+            }
+            close(done)
+        }()
+
+        numObs := 0
+        emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+        close(out)
+        <-done
+
+        // FY1: no prior year, averages absent
+        Expect(fy1Fund).NotTo(BeNil())
+        Expect(fy1Fund.AverageAssets).To(Equal(int64(0)))
+
+        // FY2: has prior year
+        Expect(fy2Fund).NotTo(BeNil())
+        Expect(fy2Fund.AverageAssets).To(Equal(int64(2200)))  // (2000+2400)/2
+        Expect(fy2Fund.EquityAvg).To(Equal(int64(900)))       // (800+1000)/2
+        Expect(fy2Fund.ROA).To(BeNumerically("~", 250.0/2200.0, 1e-10))
+        Expect(fy2Fund.ROE).To(BeNumerically("~", 250.0/900.0, 1e-10))
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "computes averages from consecutive annual" ./provider/sec/`
+Expected: FAIL -- `fy2Fund.AverageAssets` is 0.
+
+- [ ] **Step 3: Refactor annual emission to collect, compute averages, then emit**
+
+In `provider/sec/sec.go`, the current annual emission block (inside `for _, p := range periods`, the `if p.FormType == "10-K"` block starting around line 538) emits immediately. Refactor it to collect annuals and emit later.
+
+First, add a new type alias alongside `quarterData` (around line 495). The existing `quarterData` struct works for annuals too -- reuse it:
+
+After the `var quarters []quarterData` line (line 503), add:
+
+```go
+	var annuals []quarterData
+```
+
+Replace the existing `if p.FormType == "10-K"` block (lines 538-568) with:
+
+```go
+		if p.FormType == "10-K" {
+			annuals = append(annuals, quarterData{period: p, arFields: arFields, mrFields: mrFields})
+		}
+```
+
+Then, after the quarterly period-average loop (the one added in Task 5) and before the quarterly emission loop (the `// Emit quarterly observations` comment around line 604), add the annual average + emission block:
+
+```go
+	// Compute period averages and emit annual observations.
+	const maxAnnualGapDays = 425 // ~14 months, handles fiscal year shifts
+
+	for i := range annuals {
+		a := &annuals[i]
+
+		// Annual data is full-year; no de-cumulation needed. Store
+		// directly in arEmit/mrEmit.
+		a.arEmit = a.arFields
+		a.mrEmit = a.mrFields
+
+		if i > 0 {
+			prev := &annuals[i-1]
+			gapDays := a.period.PeriodEnd.Sub(prev.period.PeriodEnd).Hours() / 24
+
+			if gapDays <= maxAnnualGapDays {
+				for k, v := range ComputePeriodAverages(a.arEmit, prev.arEmit) {
+					a.arEmit[k] = v
+				}
+
+				for k, v := range ComputePeriodAverages(a.mrEmit, prev.mrEmit) {
+					a.mrEmit[k] = v
+				}
+			}
+		}
+
+		calendarDate := NormalizeEventDate(a.period.PeriodEnd, a.period.FormType)
+
+		if !since.IsZero() && a.period.MRFiledDate.Before(since) {
+			continue
+		}
+
+		// ARY
+		fundamental := BuildFundamental(a.arEmit, asset.Ticker, asset.CompositeFigi, "ARY",
+			a.period.ARFiledDate, calendarDate, a.period.PeriodEnd, a.period.ARFiledDate)
+		out <- &data.Observation{
+			Fundamental:      fundamental,
+			ObservationDate:  calendarDate,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		*numObservations++
+
+		// MRY
+		fundamental = BuildFundamental(a.mrEmit, asset.Ticker, asset.CompositeFigi, "MRY",
+			a.period.PeriodEnd, calendarDate, a.period.PeriodEnd, a.period.MRFiledDate)
+		out <- &data.Observation{
+			Fundamental:      fundamental,
+			ObservationDate:  calendarDate,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		*numObservations++
+
+		periodsEmitted++
+	}
+```
+
+Also move the `latestPeriodEnd`/`latestPeriodCoverage` tracking out of the `if p.FormType == "10-K"` block if needed -- it was above the removed block so should still work. Verify that the coverage tracking at lines 531-534 still runs for both 10-K and 10-Q periods (it does, since it's before the FormType check).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "computes averages from consecutive annual" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass. The existing `emitFundamentals` tests should still pass because they only use quarterly data (no 10-K periods).
+
+- [ ] **Step 6: Run lint**
+
+Run: `make lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add provider/sec/sec.go provider/sec/dimensions_test.go
+git commit -m "feat(sec): wire period averages into annual emission (#43)"
+```
+
+---
+
+### Task 7: Wire period averages into TTM emission
+
+**Files:**
+- Modify: `provider/sec/sec.go:640-737` (add averages after ComputeTTM)
+- Modify: `provider/sec/dimensions_test.go`
+
+- [ ] **Step 1: Write failing integration test for TTM period averages**
+
+Add to `provider/sec/dimensions_test.go` inside the top-level `Describe("Dimensions"` block:
+
+```go
+Describe("TTM period averages", func() {
+    It("computes averages using quarter before TTM window", func() {
+        cf := &CompanyFacts{
+            CIK:        1,
+            EntityName: "TTM Co",
+            Facts:      make(map[string][]Fact),
+        }
+
+        // 5 consecutive quarters: q0 through q4.
+        // TTM window for q4 = [q1..q4], prior balance sheet = q0.
+        ends := []time.Time{
+            time.Date(2023, 3, 31, 0, 0, 0, 0, time.UTC),
+            time.Date(2023, 6, 30, 0, 0, 0, 0, time.UTC),
+            time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC),
+            time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC),
+            time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+        }
+
+        for i, end := range ends {
+            start := end.AddDate(0, 0, -89)
+            filed := end.AddDate(0, 0, 30)
+            assets := float64(1000 + i*100) // 1000, 1100, 1200, 1300, 1400
+            equity := float64(500 + i*50)   // 500, 550, 600, 650, 700
+
+            cf.Facts["Assets"] = append(cf.Facts["Assets"],
+                Fact{End: end, Filed: filed, Val: assets, Form: "10-Q"})
+            cf.Facts["StockholdersEquity"] = append(cf.Facts["StockholdersEquity"],
+                Fact{End: end, Filed: filed, Val: equity, Form: "10-Q"})
+            cf.Facts["Revenues"] = append(cf.Facts["Revenues"],
+                Fact{Start: start, End: end, Filed: filed, Val: 200, Form: "10-Q"})
+            cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"] = append(
+                cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"],
+                Fact{Start: start, End: end, Filed: filed, Val: 50, Form: "10-Q"})
+            cf.Facts["NetIncomeLoss"] = append(cf.Facts["NetIncomeLoss"],
+                Fact{Start: start, End: end, Filed: filed, Val: 50, Form: "10-Q"})
+        }
+
+        asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+        out := make(chan *data.Observation, 256)
+        sub := &library.Subscription{Name: "test"}
+
+        done := make(chan struct{})
+        var ttmFund *data.Fundamental
+
+        go func() {
+            for obs := range out {
+                if obs.Fundamental.Dimension == "ART" {
+                    ttmFund = obs.Fundamental
+                }
+            }
+            close(done)
+        }()
+
+        numObs := 0
+        emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+        close(out)
+        <-done
+
+        // TTM window = q1..q4, prior = q0
+        // AverageAssets = (q0 assets + q4 assets) / 2 = (1000 + 1400) / 2 = 1200
+        // EquityAvg = (q0 equity + q4 equity) / 2 = (500 + 700) / 2 = 600
+        // TTM NetIncomeCommonStock = 50*4 = 200
+        // ROA = 200 / 1200
+        Expect(ttmFund).NotTo(BeNil())
+        Expect(ttmFund.AverageAssets).To(Equal(int64(1200)))
+        Expect(ttmFund.EquityAvg).To(Equal(int64(600)))
+        Expect(ttmFund.ROA).To(BeNumerically("~", 200.0/1200.0, 1e-10))
+        Expect(ttmFund.ROE).To(BeNumerically("~", 200.0/600.0, 1e-10))
+    })
+
+    It("skips TTM averages when fewer than 5 quarters", func() {
+        // Only 4 quarters -- enough for TTM sums but no prior for averages
+        cf := buildSyntheticQuarterlyFacts([]time.Time{
+            time.Date(2023, 6, 30, 0, 0, 0, 0, time.UTC),
+            time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC),
+            time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC),
+            time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+        })
+
+        asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+        out := make(chan *data.Observation, 256)
+        sub := &library.Subscription{Name: "test"}
+
+        done := make(chan struct{})
+        var ttmFund *data.Fundamental
+
+        go func() {
+            for obs := range out {
+                if obs.Fundamental.Dimension == "ART" {
+                    ttmFund = obs.Fundamental
+                }
+            }
+            close(done)
+        }()
+
+        numObs := 0
+        emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+        close(out)
+        <-done
+
+        // TTM should exist but without averages
+        Expect(ttmFund).NotTo(BeNil())
+        Expect(ttmFund.AverageAssets).To(Equal(int64(0)))
+    })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "TTM period averages" ./provider/sec/`
+Expected: FAIL -- `ttmFund.AverageAssets` is 0.
+
+- [ ] **Step 3: Wire period averages into TTM computation**
+
+In `provider/sec/sec.go`, inside the TTM loop, after `ComputeTTM` is called for both AR and MR (around lines 706-717 for ART and 725-736 for MRT), add the average computation.
+
+Modify the ART block. Currently it looks like:
+
+```go
+		if ttm := ComputeTTM(arQSlice); ttm != nil {
+			fundamental := BuildFundamental(ttm, ...)
+			...
+		}
+```
+
+Change it to:
+
+```go
+		if ttm := ComputeTTM(arQSlice); ttm != nil {
+			if i >= 4 {
+				for k, v := range ComputePeriodAverages(ttm, quarters[i-4].arEmit) {
+					ttm[k] = v
+				}
+			}
+
+			fundamental := BuildFundamental(ttm, asset.Ticker, asset.CompositeFigi, "ART",
+				q.period.ARFiledDate, calendarDate, q.period.PeriodEnd, latestARFiled)
+			out <- &data.Observation{
+				Fundamental:      fundamental,
+				ObservationDate:  calendarDate,
+				SubscriptionID:   sub.ID,
+				SubscriptionName: sub.Name,
+			}
+
+			*numObservations++
+		}
+```
+
+Apply the same pattern for the MRT block:
+
+```go
+		if ttm := ComputeTTM(mrQSlice); ttm != nil {
+			if i >= 4 {
+				for k, v := range ComputePeriodAverages(ttm, quarters[i-4].mrEmit) {
+					ttm[k] = v
+				}
+			}
+
+			fundamental := BuildFundamental(ttm, asset.Ticker, asset.CompositeFigi, "MRT",
+				q.period.PeriodEnd, calendarDate, q.period.PeriodEnd, latestMRFiled)
+			out <- &data.Observation{
+				Fundamental:      fundamental,
+				ObservationDate:  calendarDate,
+				SubscriptionID:   sub.ID,
+				SubscriptionName: sub.Name,
+			}
+
+			*numObservations++
+		}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "TTM period averages" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass.
+
+- [ ] **Step 6: Run lint**
+
+Run: `make lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add provider/sec/sec.go provider/sec/dimensions_test.go
+git commit -m "feat(sec): wire period averages into TTM emission (#43)"
+```
+
+---
+
+### Task 8: Validate with existing mapping config tests
+
+**Files:**
+- Modify: `provider/sec/mapping_test.go` (if needed)
+
+- [ ] **Step 1: Run the full test suite one final time**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: all tests pass. In particular:
+- `BuildFundamental coverage / references every FieldMappings entry` must pass (InvestedCapital is now in FieldMappings and BuildFundamental).
+- `derived formula operands reference existing field names` must pass (InvestedCapital's operands all exist).
+- `derived mappings have a formula` must pass (InvestedCapital has operands).
+
+- [ ] **Step 2: Run lint**
+
+Run: `make lint`
+Expected: clean.
+
+- [ ] **Step 3: Run the full project test suite**
+
+Run: `make test`
+Expected: all tests pass.
+
+- [ ] **Step 4: Verify the mapping config validation test accepts Coefficients**
+
+The existing test `derived mappings have a formula` checks `len(m.Operands) > 0`. The `InvestedCapital` mapping has 5 operands, so this passes. No test changes needed.
+
+Optionally, add a test to verify Coefficients length matches Operands length for OpLinearCombination mappings. Add inside `Describe("Mapping Config"`:
+
+```go
+It("OpLinearCombination mappings have matching Coefficients length", func() {
+    for _, m := range FieldMappings {
+        if m.Op == OpLinearCombination {
+            Expect(len(m.Coefficients)).To(Equal(len(m.Operands)),
+                "mapping %s: Coefficients length (%d) must match Operands length (%d)",
+                m.FieldName, len(m.Coefficients), len(m.Operands))
+        }
+    }
+})
+```
+
+- [ ] **Step 5: Final commit if validation test was added**
+
+```bash
+git add provider/sec/mapping_test.go
+git commit -m "test(sec): add Coefficients length validation for OpLinearCombination (#43)"
+```

--- a/docs/superpowers/specs/2026-04-12-period-average-fields-design.md
+++ b/docs/superpowers/specs/2026-04-12-period-average-fields-design.md
@@ -1,0 +1,143 @@
+# SEC: Compute Period-Average Fields
+
+**Issue:** #43
+**Date:** 2026-04-12
+
+## Problem
+
+Six fields in the Fundamental struct are populated by Sharadar but not by the SEC provider: `AverageAssets`, `EquityAvg`, `InvestedCapitalAverage`, `ROA`, `ROE`, `ROIC`. These require averaging balance sheet values across consecutive periods. A prerequisite field, `InvestedCapital`, is also missing because the derivation engine only supports two-operand subtraction and the formula has five terms.
+
+## Sharadar Formulas (source of truth)
+
+All formulas come from the Sharadar field definitions documented in `data/fundamental.go`.
+
+### Single-period derived field
+
+| Field | Formula | Type |
+|---|---|---|
+| `InvestedCapital` | `TotalDebt + TotalAssets - Intangibles - CashAndEquivalents - CurrentLiabilities` | int64 |
+
+### Period-average fields (require prior period balance sheet)
+
+| Field | Formula | Type |
+|---|---|---|
+| `AverageAssets` | `(prior TotalAssets + current TotalAssets) / 2` | int64 |
+| `EquityAvg` | `(prior Equity + current Equity) / 2` | int64 |
+| `InvestedCapitalAverage` | `(prior InvestedCapital + current InvestedCapital) / 2` | int64 |
+
+### Ratio fields (derived from averages)
+
+| Field | Numerator | Denominator | Type |
+|---|---|---|---|
+| `ROA` | `NetIncomeCommonStock` | `AverageAssets` | float64 |
+| `ROE` | `NetIncomeCommonStock` | `EquityAvg` | float64 |
+| `ROIC` | `EBIT` | `InvestedCapitalAverage` | float64 |
+
+## Design
+
+### 1. Extend the derivation engine
+
+**File:** `provider/sec/mapping.go`
+
+Add a new operation `OpLinearCombination` and a `Coefficients []float64` field to `FieldMapping`. The `computeDerived` function gets a new case that multiplies each operand by its corresponding coefficient and sums the results. Existing operations are untouched.
+
+**File:** `provider/sec/mapping_config.go`
+
+Add the `InvestedCapital` mapping using the new operation:
+
+```go
+{
+    FieldName: "InvestedCapital", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+    Op:           OpLinearCombination,
+    Operands:     []string{"TotalDebt", "TotalAssets", "Intangibles", "CashAndEquivalents", "CurrentLiabilities"},
+    Coefficients: []float64{1, 1, -1, -1, -1},
+}
+```
+
+Remove the comment at line 549-553 about InvestedCapital being intentionally omitted. Remove the trailing comment at lines 632-636 about these fields being deferred.
+
+### 2. ComputePeriodAverages function
+
+**File:** `provider/sec/dimensions.go`
+
+New function alongside `DecumulateYTD` and `ComputeTTM`:
+
+```go
+func ComputePeriodAverages(current, prior map[string]float64) map[string]float64
+```
+
+Behavior:
+
+1. Compute three averages from balance sheet values present in both maps:
+   - `AverageAssets = (prior["TotalAssets"] + current["TotalAssets"]) / 2`
+   - `EquityAvg = (prior["Equity"] + current["Equity"]) / 2`
+   - `InvestedCapitalAverage = (prior["InvestedCapital"] + current["InvestedCapital"]) / 2`
+
+2. Derive three ratios from averaged denominators and current-period flow values:
+   - `ROA = current["NetIncomeCommonStock"] / AverageAssets`
+   - `ROE = current["NetIncomeCommonStock"] / EquityAvg`
+   - `ROIC = current["EBIT"] / InvestedCapitalAverage`
+
+3. Return a map containing only the computed fields. Caller merges into the emit map.
+
+If either period is missing a required input, dependent fields are omitted from the result. Division by zero produces no output (field omitted).
+
+### 3. Integration into emitFundamentals
+
+**File:** `provider/sec/sec.go`
+
+Three insertion points corresponding to the three dimension types:
+
+#### Quarterly (ARQ/MRQ)
+
+After the existing de-cumulation loop, add a new loop over `quarters`:
+
+```
+for i := range quarters:
+    if i > 0 and gap <= maxQuarterGapDays:
+        merge ComputePeriodAverages(quarters[i].arEmit, quarters[i-1].arEmit) into quarters[i].arEmit
+        merge ComputePeriodAverages(quarters[i].mrEmit, quarters[i-1].mrEmit) into quarters[i].mrEmit
+```
+
+When `i == 0` or the gap exceeds the threshold, the 6 fields are simply absent from that period.
+
+#### Annual (ARY/MRY)
+
+Currently 10-K periods are emitted immediately with no history tracking. Change to:
+
+1. Collect annual periods in an `annuals` slice using the same `quarterData` struct (no rename -- the struct is internal and a comment suffices).
+2. After the periods loop, iterate `annuals` and compute averages using `annuals[i-1]` as the prior period. Gap threshold for consecutive annuals: 425 days (~14 months) to handle fiscal year shifts.
+3. Emit annual observations from this loop instead of inside the periods loop.
+
+No de-cumulation is needed for annuals (10-K values are full-year), so the annuals loop is simpler than the quarterly one.
+
+#### TTM (ART/MRT)
+
+After computing the TTM field map via `ComputeTTM`, compute averages using:
+- **Prior:** balance sheet values from `quarters[i-4]` (the quarter immediately before the TTM window)
+- **Current:** the TTM field map (which uses the latest quarter's balance sheet for point-in-time fields)
+
+Requires `i >= 4` (5 quarters of history). When `i < 4`, the 6 fields are absent from the TTM observation.
+
+### 4. No changes to BuildFundamental
+
+`BuildFundamental` in `dimensions.go` already maps field name strings to `Fundamental` struct fields for all 7 fields (`InvestedCapital`, `AverageAssets`, `EquityAvg`, `InvestedCapitalAverage`, `ROA`, `ROE`, `ROIC`). They just never appear in the input map today. Once the upstream computation produces them, they flow through automatically.
+
+### 5. Testing
+
+**File:** `provider/sec/dimensions_test.go`
+
+- `ComputePeriodAverages` with known inputs: verify all 6 output fields match expected values.
+- Missing-input cases: prior lacks Equity, current lacks EBIT, etc. Confirm dependent fields are omitted and independent fields still compute.
+- Division by zero: average denominator is zero, confirm ratio is omitted.
+
+**File:** `provider/sec/mapping_test.go`
+
+- `OpLinearCombination` in `computeDerived`: verify InvestedCapital formula produces correct result.
+- Missing operand: confirm field is omitted.
+
+**File:** `provider/sec/dimensions_test.go` (emitFundamentals integration)
+
+- Use Apple testdata (`CIK0000320193.json`) to verify a few quarterly and annual periods produce the expected average and ratio values.
+
+**Final validation:** Run `pvdata compare-fundamentals` against real Sharadar data to confirm the ~84 diffs from issue #43 disappear.

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -403,6 +403,73 @@ func ComputeTTM(quarters []map[string]float64) map[string]float64 {
 	return result
 }
 
+// ComputePeriodAverages computes period-average balance sheet fields and the
+// ratios that depend on them. current is the emit-ready field map for the
+// period being computed; prior is the emit-ready field map for the immediately
+// preceding period of the same type (prior quarter for quarterly, prior year
+// for annual, quarter before the TTM window for TTM).
+//
+// Returns a map containing only the computed fields; the caller merges these
+// into the emit map. Fields whose inputs are missing are silently omitted.
+func ComputePeriodAverages(current, prior map[string]float64) map[string]float64 {
+	result := make(map[string]float64)
+
+	if prior == nil {
+		return result
+	}
+
+	// Helper: compute (prior[field] + current[field]) / 2 if both exist.
+	avg := func(field string) (float64, bool) {
+		cv, cOK := current[field]
+		pv, pOK := prior[field]
+
+		if !cOK || !pOK {
+			return 0, false
+		}
+
+		return (pv + cv) / 2, true
+	}
+
+	// Averages
+	if v, ok := avg("TotalAssets"); ok {
+		result["AverageAssets"] = v
+	}
+
+	if v, ok := avg("Equity"); ok {
+		result["EquityAvg"] = v
+	}
+
+	if v, ok := avg("InvestedCapital"); ok {
+		result["InvestedCapitalAverage"] = v
+	}
+
+	// Ratios (only when both numerator and denominator are available and non-zero)
+	ratio := func(numField, denomField string) (float64, bool) {
+		num, nOK := current[numField]
+		denom, dOK := result[denomField]
+
+		if !nOK || !dOK || denom == 0 {
+			return 0, false
+		}
+
+		return num / denom, true
+	}
+
+	if v, ok := ratio("NetIncomeCommonStock", "AverageAssets"); ok {
+		result["ROA"] = v
+	}
+
+	if v, ok := ratio("NetIncomeCommonStock", "EquityAvg"); ok {
+		result["ROE"] = v
+	}
+
+	if v, ok := ratio("EBIT", "InvestedCapitalAverage"); ok {
+		result["ROIC"] = v
+	}
+
+	return result
+}
+
 // BuildFundamental converts a resolved field map into a data.Fundamental struct.
 //
 // lastUpdated is the timestamp the caller wants to record as the data's

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -803,5 +803,29 @@ func BuildFundamental(fields map[string]float64, ticker, compositeFigi, dimensio
 		f.InvestedCapital = int64(v)
 	}
 
+	if v, ok := fields["AverageAssets"]; ok {
+		f.AverageAssets = int64(v)
+	}
+
+	if v, ok := fields["EquityAvg"]; ok {
+		f.EquityAvg = int64(v)
+	}
+
+	if v, ok := fields["InvestedCapitalAverage"]; ok {
+		f.InvestedCapitalAverage = int64(v)
+	}
+
+	if v, ok := fields["ROA"]; ok {
+		f.ROA = v
+	}
+
+	if v, ok := fields["ROE"]; ok {
+		f.ROE = v
+	}
+
+	if v, ok := fields["ROIC"]; ok {
+		f.ROIC = v
+	}
+
 	return f
 }

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -732,5 +732,9 @@ func BuildFundamental(fields map[string]float64, ticker, compositeFigi, dimensio
 		f.TangibleAssetValue = int64(v)
 	}
 
+	if v, ok := fields["InvestedCapital"]; ok {
+		f.InvestedCapital = int64(v)
+	}
+
 	return f
 }

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -744,6 +744,78 @@ var _ = Describe("Dimensions", func() {
 			Expect(q2Fund.ROE).To(BeNumerically("~", 120.0/550.0, 1e-10))
 		})
 	})
+
+	Describe("annual period averages", func() {
+		It("computes averages from consecutive annual periods", func() {
+			cf := &CompanyFacts{
+				CIK:        1,
+				EntityName: "Annual Co",
+				Facts:      make(map[string][]Fact),
+			}
+
+			fy1End := time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC)
+			fy2End := time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC)
+			fy1Filed := time.Date(2023, 11, 1, 0, 0, 0, 0, time.UTC)
+			fy2Filed := time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)
+
+			// Balance sheet (instant)
+			cf.Facts["Assets"] = []Fact{
+				{End: fy1End, Filed: fy1Filed, Val: 2000, Form: "10-K"},
+				{End: fy2End, Filed: fy2Filed, Val: 2400, Form: "10-K"},
+			}
+			cf.Facts["StockholdersEquity"] = []Fact{
+				{End: fy1End, Filed: fy1Filed, Val: 800, Form: "10-K"},
+				{End: fy2End, Filed: fy2Filed, Val: 1000, Form: "10-K"},
+			}
+
+			// Income statement (duration)
+			cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"] = []Fact{
+				{Start: time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC), End: fy1End, Filed: fy1Filed, Val: 200, Form: "10-K"},
+				{Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC), End: fy2End, Filed: fy2Filed, Val: 250, Form: "10-K"},
+			}
+			cf.Facts["Revenues"] = []Fact{
+				{Start: time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC), End: fy1End, Filed: fy1Filed, Val: 1000, Form: "10-K"},
+				{Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC), End: fy2End, Filed: fy2Filed, Val: 1200, Form: "10-K"},
+			}
+
+			asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+			out := make(chan *data.Observation, 256)
+			sub := &library.Subscription{Name: "test"}
+
+			done := make(chan struct{})
+			var fy1Fund, fy2Fund *data.Fundamental
+
+			go func() {
+				for obs := range out {
+					f := obs.Fundamental
+					dateKey := obs.ObservationDate.Format("2006-01-02")
+					if f.Dimension == "ARY" && dateKey == "2023-12-31" {
+						fy1Fund = f
+					}
+					if f.Dimension == "ARY" && dateKey == "2024-12-31" {
+						fy2Fund = f
+					}
+				}
+				close(done)
+			}()
+
+			numObs := 0
+			emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+			close(out)
+			<-done
+
+			// FY1: no prior year, averages absent
+			Expect(fy1Fund).NotTo(BeNil())
+			Expect(fy1Fund.AverageAssets).To(Equal(int64(0)))
+
+			// FY2: has prior year
+			Expect(fy2Fund).NotTo(BeNil())
+			Expect(fy2Fund.AverageAssets).To(Equal(int64(2200)))  // (2000+2400)/2
+			Expect(fy2Fund.EquityAvg).To(Equal(int64(900)))       // (800+1000)/2
+			Expect(fy2Fund.ROA).To(BeNumerically("~", 250.0/2200.0, 1e-10))
+			Expect(fy2Fund.ROE).To(BeNumerically("~", 250.0/900.0, 1e-10))
+		})
+	})
 })
 
 // buildSyntheticQuarterlyFacts constructs a minimal CompanyFacts containing one

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -435,8 +435,8 @@ var _ = Describe("Dimensions", func() {
 			// Q1=50, cumulative Q2=110 (Q2 alone=60), cumulative Q3=180 (Q3 alone=70)
 			cf.Facts["NetCashProvidedByUsedInOperatingActivities"] = []Fact{
 				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 50, Form: "10-Q", FP: "Q1"},
-				{Start: fyStart, End: q2End, Filed: q2Filed, Val: 110, Form: "10-Q", FP: "Q2"},  // YTD
-				{Start: fyStart, End: q3End, Filed: q3Filed, Val: 180, Form: "10-Q", FP: "Q3"},  // YTD
+				{Start: fyStart, End: q2End, Filed: q2Filed, Val: 110, Form: "10-Q", FP: "Q2"}, // YTD
+				{Start: fyStart, End: q3End, Filed: q3Filed, Val: 180, Form: "10-Q", FP: "Q3"}, // YTD
 			}
 
 			// CapEx: YTD ONLY
@@ -624,11 +624,11 @@ var _ = Describe("Dimensions", func() {
 			// Intermediate fields used only as operands for derived fields;
 			// they are intentionally not mapped to Fundamental struct fields.
 			intermediate := map[string]bool{
-				"TradeReceivables":            true,
-				"NonTradeReceivables":         true,
-				"ShortTermDebt":               true,
+				"TradeReceivables":              true,
+				"NonTradeReceivables":           true,
+				"ShortTermDebt":                 true,
 				"LongTermDebtCurrentMaturities": true,
-				"CommercialPaperDebt":         true,
+				"CommercialPaperDebt":           true,
 			}
 
 			var missing []string
@@ -738,8 +738,8 @@ var _ = Describe("Dimensions", func() {
 
 			// Q2: has prior quarter
 			Expect(q2Fund).NotTo(BeNil())
-			Expect(q2Fund.AverageAssets).To(Equal(int64(1100)))  // (1000+1200)/2
-			Expect(q2Fund.EquityAvg).To(Equal(int64(550)))       // (500+600)/2
+			Expect(q2Fund.AverageAssets).To(Equal(int64(1100))) // (1000+1200)/2
+			Expect(q2Fund.EquityAvg).To(Equal(int64(550)))      // (500+600)/2
 			Expect(q2Fund.ROA).To(BeNumerically("~", 120.0/1100.0, 1e-10))
 			Expect(q2Fund.ROE).To(BeNumerically("~", 120.0/550.0, 1e-10))
 		})
@@ -810,8 +810,8 @@ var _ = Describe("Dimensions", func() {
 
 			// FY2: has prior year
 			Expect(fy2Fund).NotTo(BeNil())
-			Expect(fy2Fund.AverageAssets).To(Equal(int64(2200)))  // (2000+2400)/2
-			Expect(fy2Fund.EquityAvg).To(Equal(int64(900)))       // (800+1000)/2
+			Expect(fy2Fund.AverageAssets).To(Equal(int64(2200))) // (2000+2400)/2
+			Expect(fy2Fund.EquityAvg).To(Equal(int64(900)))      // (800+1000)/2
 			Expect(fy2Fund.ROA).To(BeNumerically("~", 250.0/2200.0, 1e-10))
 			Expect(fy2Fund.ROE).To(BeNumerically("~", 250.0/900.0, 1e-10))
 		})

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -816,6 +816,112 @@ var _ = Describe("Dimensions", func() {
 			Expect(fy2Fund.ROE).To(BeNumerically("~", 250.0/900.0, 1e-10))
 		})
 	})
+
+	Describe("TTM period averages", func() {
+		It("computes averages using quarter before TTM window", func() {
+			cf := &CompanyFacts{
+				CIK:        1,
+				EntityName: "TTM Co",
+				Facts:      make(map[string][]Fact),
+			}
+
+			// 5 consecutive quarters: q0 through q4.
+			// TTM window for q4 = [q1..q4], prior balance sheet = q0.
+			ends := []time.Time{
+				time.Date(2023, 3, 31, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 6, 30, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+			}
+
+			for i, end := range ends {
+				start := end.AddDate(0, 0, -89)
+				filed := end.AddDate(0, 0, 30)
+				assets := float64(1000 + i*100) // 1000, 1100, 1200, 1300, 1400
+				equity := float64(500 + i*50)   // 500, 550, 600, 650, 700
+
+				cf.Facts["Assets"] = append(cf.Facts["Assets"],
+					Fact{End: end, Filed: filed, Val: assets, Form: "10-Q"})
+				cf.Facts["StockholdersEquity"] = append(cf.Facts["StockholdersEquity"],
+					Fact{End: end, Filed: filed, Val: equity, Form: "10-Q"})
+				cf.Facts["Revenues"] = append(cf.Facts["Revenues"],
+					Fact{Start: start, End: end, Filed: filed, Val: 200, Form: "10-Q"})
+				cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"] = append(
+					cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"],
+					Fact{Start: start, End: end, Filed: filed, Val: 50, Form: "10-Q"})
+				cf.Facts["NetIncomeLoss"] = append(cf.Facts["NetIncomeLoss"],
+					Fact{Start: start, End: end, Filed: filed, Val: 50, Form: "10-Q"})
+			}
+
+			asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+			out := make(chan *data.Observation, 256)
+			sub := &library.Subscription{Name: "test"}
+
+			done := make(chan struct{})
+			var ttmFund *data.Fundamental
+
+			go func() {
+				for obs := range out {
+					if obs.Fundamental.Dimension == "ART" {
+						ttmFund = obs.Fundamental
+					}
+				}
+				close(done)
+			}()
+
+			numObs := 0
+			emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+			close(out)
+			<-done
+
+			// TTM window = q1..q4, prior = q0
+			// AverageAssets = (q0 assets + q4 assets) / 2 = (1000 + 1400) / 2 = 1200
+			// EquityAvg = (q0 equity + q4 equity) / 2 = (500 + 700) / 2 = 600
+			// TTM NetIncomeCommonStock = 50*4 = 200
+			// ROA = 200 / 1200
+			Expect(ttmFund).NotTo(BeNil())
+			Expect(ttmFund.AverageAssets).To(Equal(int64(1200)))
+			Expect(ttmFund.EquityAvg).To(Equal(int64(600)))
+			Expect(ttmFund.ROA).To(BeNumerically("~", 200.0/1200.0, 1e-10))
+			Expect(ttmFund.ROE).To(BeNumerically("~", 200.0/600.0, 1e-10))
+		})
+
+		It("skips TTM averages when fewer than 5 quarters", func() {
+			// Only 4 quarters -- enough for TTM sums but no prior for averages
+			cf := buildSyntheticQuarterlyFacts([]time.Time{
+				time.Date(2023, 6, 30, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC),
+				time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+			})
+
+			asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+			out := make(chan *data.Observation, 256)
+			sub := &library.Subscription{Name: "test"}
+
+			done := make(chan struct{})
+			var ttmFund *data.Fundamental
+
+			go func() {
+				for obs := range out {
+					if obs.Fundamental.Dimension == "ART" {
+						ttmFund = obs.Fundamental
+					}
+				}
+				close(done)
+			}()
+
+			numObs := 0
+			emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+			close(out)
+			<-done
+
+			// TTM should exist but without averages
+			Expect(ttmFund).NotTo(BeNil())
+			Expect(ttmFund.AverageAssets).To(Equal(int64(0)))
+		})
+	})
 })
 
 // buildSyntheticQuarterlyFacts constructs a minimal CompanyFacts containing one

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -647,6 +647,102 @@ var _ = Describe("Dimensions", func() {
 			Expect(missing).To(BeEmpty(),
 				"FieldMappings entries not referenced in BuildFundamental: %v", missing)
 		})
+
+		It("references all period-average fields", func() {
+			src, err := os.ReadFile("dimensions.go")
+			Expect(err).NotTo(HaveOccurred())
+			srcStr := string(src)
+
+			avgFields := []string{
+				"AverageAssets", "EquityAvg", "InvestedCapitalAverage",
+				"ROA", "ROE", "ROIC",
+			}
+
+			var missing []string
+			for _, name := range avgFields {
+				pattern := fmt.Sprintf(`fields[%q]`, name)
+				if !strings.Contains(srcStr, pattern) {
+					missing = append(missing, name)
+				}
+			}
+
+			Expect(missing).To(BeEmpty(),
+				"period-average fields not referenced in BuildFundamental: %v", missing)
+		})
+	})
+
+	Describe("quarterly period averages", func() {
+		It("computes averages from consecutive quarters", func() {
+			cf := &CompanyFacts{
+				CIK:        1,
+				EntityName: "Avg Co",
+				Facts:      make(map[string][]Fact),
+			}
+
+			q1End := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+			q2End := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+			q1Filed := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+			q2Filed := time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)
+			fyStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			// Balance sheet (instant)
+			cf.Facts["Assets"] = []Fact{
+				{End: q1End, Filed: q1Filed, Val: 1000, Form: "10-Q"},
+				{End: q2End, Filed: q2Filed, Val: 1200, Form: "10-Q"},
+			}
+			cf.Facts["StockholdersEquity"] = []Fact{
+				{End: q1End, Filed: q1Filed, Val: 500, Form: "10-Q"},
+				{End: q2End, Filed: q2Filed, Val: 600, Form: "10-Q"},
+			}
+
+			// Income statement (duration, quarterly facts)
+			cf.Facts["NetIncomeLossAvailableToCommonStockholdersBasic"] = []Fact{
+				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 100, Form: "10-Q"},
+				{Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 120, Form: "10-Q"},
+			}
+			cf.Facts["Revenues"] = []Fact{
+				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 500, Form: "10-Q"},
+				{Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 600, Form: "10-Q"},
+			}
+
+			asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
+			out := make(chan *data.Observation, 256)
+			sub := &library.Subscription{Name: "test"}
+
+			done := make(chan struct{})
+			var q1Fund, q2Fund *data.Fundamental
+
+			go func() {
+				for obs := range out {
+					f := obs.Fundamental
+					dateKey := obs.ObservationDate.Format("2006-01-02")
+					if f.Dimension == "ARQ" && dateKey == "2024-03-31" {
+						q1Fund = f
+					}
+					if f.Dimension == "ARQ" && dateKey == "2024-06-30" {
+						q2Fund = f
+					}
+				}
+				close(done)
+			}()
+
+			numObs := 0
+			emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+			close(out)
+			<-done
+
+			// Q1: no prior quarter, averages should be zero (absent)
+			Expect(q1Fund).NotTo(BeNil())
+			Expect(q1Fund.AverageAssets).To(Equal(int64(0)))
+			Expect(q1Fund.ROA).To(Equal(0.0))
+
+			// Q2: has prior quarter
+			Expect(q2Fund).NotTo(BeNil())
+			Expect(q2Fund.AverageAssets).To(Equal(int64(1100)))  // (1000+1200)/2
+			Expect(q2Fund.EquityAvg).To(Equal(int64(550)))       // (500+600)/2
+			Expect(q2Fund.ROA).To(BeNumerically("~", 120.0/1100.0, 1e-10))
+			Expect(q2Fund.ROE).To(BeNumerically("~", 120.0/550.0, 1e-10))
+		})
 	})
 })
 

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -515,6 +515,101 @@ var _ = Describe("Dimensions", func() {
 		})
 	})
 
+	Describe("ComputePeriodAverages", func() {
+		It("computes all 6 fields from complete inputs", func() {
+			current := map[string]float64{
+				"TotalAssets":          400_000,
+				"Equity":               200_000,
+				"InvestedCapital":      300_000,
+				"NetIncomeCommonStock": 50_000,
+				"EBIT":                 60_000,
+			}
+			prior := map[string]float64{
+				"TotalAssets":     360_000,
+				"Equity":          180_000,
+				"InvestedCapital": 280_000,
+			}
+
+			result := ComputePeriodAverages(current, prior)
+
+			// Averages
+			Expect(result["AverageAssets"]).To(Equal(380_000.0))
+			Expect(result["EquityAvg"]).To(Equal(190_000.0))
+			Expect(result["InvestedCapitalAverage"]).To(Equal(290_000.0))
+
+			// Ratios
+			Expect(result["ROA"]).To(BeNumerically("~", 50_000.0/380_000.0, 1e-10))
+			Expect(result["ROE"]).To(BeNumerically("~", 50_000.0/190_000.0, 1e-10))
+			Expect(result["ROIC"]).To(BeNumerically("~", 60_000.0/290_000.0, 1e-10))
+		})
+
+		It("omits average when prior is missing the balance sheet field", func() {
+			current := map[string]float64{
+				"TotalAssets":          400_000,
+				"Equity":               200_000,
+				"NetIncomeCommonStock": 50_000,
+				"EBIT":                 60_000,
+			}
+			prior := map[string]float64{
+				"TotalAssets": 360_000,
+				// Equity missing
+			}
+
+			result := ComputePeriodAverages(current, prior)
+
+			Expect(result).To(HaveKey("AverageAssets"))
+			Expect(result).To(HaveKey("ROA"))
+			Expect(result).NotTo(HaveKey("EquityAvg"))
+			Expect(result).NotTo(HaveKey("ROE"))
+		})
+
+		It("omits ratio when numerator is missing", func() {
+			current := map[string]float64{
+				"TotalAssets": 400_000,
+				"Equity":      200_000,
+				// NetIncomeCommonStock missing
+			}
+			prior := map[string]float64{
+				"TotalAssets": 360_000,
+				"Equity":      180_000,
+			}
+
+			result := ComputePeriodAverages(current, prior)
+
+			Expect(result).To(HaveKey("AverageAssets"))
+			Expect(result).To(HaveKey("EquityAvg"))
+			Expect(result).NotTo(HaveKey("ROA"))
+			Expect(result).NotTo(HaveKey("ROE"))
+		})
+
+		It("omits ratio when average denominator is zero", func() {
+			current := map[string]float64{
+				"TotalAssets":          100,
+				"NetIncomeCommonStock": 50,
+			}
+			prior := map[string]float64{
+				"TotalAssets": -100, // average = 0
+			}
+
+			result := ComputePeriodAverages(current, prior)
+
+			Expect(result).To(HaveKey("AverageAssets"))
+			Expect(result["AverageAssets"]).To(Equal(0.0))
+			Expect(result).NotTo(HaveKey("ROA"))
+		})
+
+		It("returns empty map when prior is nil", func() {
+			current := map[string]float64{
+				"TotalAssets":          400_000,
+				"Equity":               200_000,
+				"NetIncomeCommonStock": 50_000,
+			}
+
+			result := ComputePeriodAverages(current, nil)
+			Expect(result).To(BeEmpty())
+		})
+	})
+
 	// BuildFundamental is a long manual switch over fields["X"] keys. Without
 	// this guard, adding a new entry to FieldMappings without a corresponding
 	// clause in BuildFundamental would silently drop the field from emitted

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -280,6 +280,18 @@ func computeDerived(m FieldMapping, resolved map[string]float64) (float64, bool)
 		}
 
 		return vals[0] / vals[1], true
+
+	case OpLinearCombination:
+		if len(vals) != len(m.Coefficients) {
+			return 0, false
+		}
+
+		sum := 0.0
+		for i, v := range vals {
+			sum += m.Coefficients[i] * v
+		}
+
+		return sum, true
 	}
 
 	return 0, false

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -225,17 +225,23 @@ func ResolveAllFields(cf *CompanyFacts, periodEnd time.Time, formType string) ma
 
 // computeDerived evaluates a derived field's formula using already-resolved values.
 func computeDerived(m FieldMapping, resolved map[string]float64) (float64, bool) {
-	// When OptionalOperands is set, OpAdd sums whatever operands are present
-	// and resolves if at least one exists. This handles fields like
-	// Investments = InvestmentsCurrent + InvestmentsNonCurrent where a
-	// company may report only one component.
-	if m.OptionalOperands && m.Op == OpAdd {
+	// When OptionalOperands is set, missing operands are treated as 0 and the
+	// formula resolves if at least one operand is present. This handles fields
+	// like Investments = InvestmentsCurrent + InvestmentsNonCurrent where a
+	// company may report only one component, and InvestedCapital where
+	// Intangibles may be absent (the company has none).
+	if m.OptionalOperands && (m.Op == OpAdd || m.Op == OpLinearCombination) {
 		sum := 0.0
 		found := false
 
-		for _, op := range m.Operands {
+		for i, op := range m.Operands {
 			if v, ok := resolved[op]; ok {
-				sum += v
+				if m.Op == OpLinearCombination {
+					sum += m.Coefficients[i] * v
+				} else {
+					sum += v
+				}
+
 				found = true
 			}
 		}

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -589,11 +589,13 @@ var FieldMappings = []FieldMapping{
 		Op:       OpSubtract,
 		Operands: []string{"TotalAssets", "Intangibles"},
 	},
-	// InvestedCapital is intentionally omitted: the proper formula is
-	//   TotalDebt + TotalAssets - Intangibles - CashAndEquivalents - CurrentLiabilities
-	// which requires multi-term subtract support that the derivation engine does
-	// not yet have. Add it back in a follow-up once the engine can express that
-	// formula correctly; computing only TotalDebt + TotalAssets would be wrong.
+	// InvestedCapital = TotalDebt + TotalAssets - Intangibles - CashAndEquivalents - CurrentLiabilities
+	{
+		FieldName: "InvestedCapital", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+		Op:           OpLinearCombination,
+		Operands:     []string{"TotalDebt", "TotalAssets", "Intangibles", "CashAndEquivalents", "CurrentLiabilities"},
+		Coefficients: []float64{1, 1, -1, -1, -1},
+	},
 
 	// ==================== RATIO METRICS (derived) ====================
 
@@ -672,9 +674,4 @@ var FieldMappings = []FieldMapping{
 	// - MarketCapitalization, EnterpriseValue, PE, PB, PS, PE1, PS1
 	// - EVtoEBIT, EVtoEBITDA, DividendYield, PayoutRatio, Price
 	// - ShareFactor, FxUSD
-	// - ROA, ROE, ROIC (these need average values across periods)
-	// - AverageAssets, EquityAvg, InvestedCapitalAverage (need prior period)
-	//
-	// These will be computed in a later pass once we have multi-period data
-	// available (see dimensions.go for average computations).
 }

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -36,9 +36,10 @@ const (
 type FormulaOp string
 
 const (
-	OpAdd      FormulaOp = "add"      // A + B + ...
-	OpSubtract FormulaOp = "subtract" // A - B
-	OpDivide   FormulaOp = "divide"   // A / B
+	OpAdd               FormulaOp = "add"                // A + B + ...
+	OpSubtract          FormulaOp = "subtract"           // A - B
+	OpDivide            FormulaOp = "divide"             // A / B
+	OpLinearCombination FormulaOp = "linear_combination" // C0*A + C1*B + ...
 )
 
 // FieldMapping maps a data.Fundamental field to XBRL tag(s) or a formula.
@@ -57,8 +58,9 @@ type FieldMapping struct {
 	Negate bool
 
 	// For derived mappings: formula
-	Op       FormulaOp // Operation to apply
-	Operands []string  // Field names to use as operands
+	Op           FormulaOp // Operation to apply
+	Operands     []string  // Field names to use as operands
+	Coefficients []float64 // Per-operand multipliers (for OpLinearCombination)
 
 	// For derived mappings that also have a direct XBRL fallback
 	FallbackTags []string

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -590,11 +590,14 @@ var FieldMappings = []FieldMapping{
 		Operands: []string{"TotalAssets", "Intangibles"},
 	},
 	// InvestedCapital = TotalDebt + TotalAssets - Intangibles - CashAndEquivalents - CurrentLiabilities
+	// OptionalOperands: some companies (e.g. Apple) have no intangible assets
+	// and do not report the Intangibles XBRL tag; treat missing components as 0.
 	{
 		FieldName: "InvestedCapital", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
-		Op:           OpLinearCombination,
-		Operands:     []string{"TotalDebt", "TotalAssets", "Intangibles", "CashAndEquivalents", "CurrentLiabilities"},
-		Coefficients: []float64{1, 1, -1, -1, -1},
+		Op:               OpLinearCombination,
+		Operands:         []string{"TotalDebt", "TotalAssets", "Intangibles", "CashAndEquivalents", "CurrentLiabilities"},
+		Coefficients:     []float64{1, 1, -1, -1, -1},
+		OptionalOperands: true,
 	},
 
 	// ==================== RATIO METRICS (derived) ====================

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -212,6 +212,44 @@ var _ = Describe("Mapping Engine", func() {
 		})
 	})
 
+	Describe("computeDerived with OpLinearCombination", func() {
+		It("computes weighted sum of operands", func() {
+			resolved := map[string]float64{
+				"A": 100,
+				"B": 200,
+				"C": 30,
+				"D": 20,
+				"E": 10,
+			}
+			m := FieldMapping{
+				FieldName:    "Result",
+				Type:         MappingDerived,
+				Op:           OpLinearCombination,
+				Operands:     []string{"A", "B", "C", "D", "E"},
+				Coefficients: []float64{1, 1, -1, -1, -1},
+			}
+			val, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(240.0))
+		})
+
+		It("returns false when any operand is missing", func() {
+			resolved := map[string]float64{
+				"A": 100,
+				"B": 200,
+			}
+			m := FieldMapping{
+				FieldName:    "Result",
+				Type:         MappingDerived,
+				Op:           OpLinearCombination,
+				Operands:     []string{"A", "B", "C"},
+				Coefficients: []float64{1, 1, -1},
+			}
+			_, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
 	Describe("ResolveAllFields", func() {
 		It("resolves both direct and derived fields", func() {
 			periodEnd := time.Date(2018, 9, 29, 0, 0, 0, 0, time.UTC)

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -67,6 +67,16 @@ var _ = Describe("Mapping Config", func() {
 		}
 	})
 
+	It("OpLinearCombination mappings have matching Coefficients length", func() {
+		for _, m := range FieldMappings {
+			if m.Op == OpLinearCombination {
+				Expect(len(m.Coefficients)).To(Equal(len(m.Operands)),
+					"mapping %s: Coefficients length (%d) must match Operands length (%d)",
+					m.FieldName, len(m.Coefficients), len(m.Operands))
+			}
+		}
+	})
+
 	It("all mappings have a valid statement type", func() {
 		for _, m := range FieldMappings {
 			Expect(m.StatementType).To(BeElementOf(StmtFlow, StmtPointInTime, StmtMetric),

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -393,7 +393,7 @@ var _ = Describe("Mapping Engine", func() {
 					"Assets":                                {{End: periodEnd, Filed: filed, Val: 350_000, Form: "10-Q"}},
 					"IntangibleAssetsNetIncludingGoodwill":  {{End: periodEnd, Filed: filed, Val: 50_000, Form: "10-Q"}},
 					"CashAndCashEquivalentsAtCarryingValue": {{End: periodEnd, Filed: filed, Val: 25_000, Form: "10-Q"}},
-					"LiabilitiesCurrent":                   {{End: periodEnd, Filed: filed, Val: 60_000, Form: "10-Q"}},
+					"LiabilitiesCurrent":                    {{End: periodEnd, Filed: filed, Val: 60_000, Form: "10-Q"}},
 				},
 			}
 

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -381,6 +381,30 @@ var _ = Describe("Mapping Engine", func() {
 				"TotalDebt should cascade from corrected DebtCurrent + DebtNonCurrent")
 		})
 
+		It("resolves InvestedCapital from component fields", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			icCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"LongTermDebtCurrent":                   {{End: periodEnd, Filed: filed, Val: 10_000, Form: "10-Q"}},
+					"LongTermDebtNoncurrent":                {{End: periodEnd, Filed: filed, Val: 90_000, Form: "10-Q"}},
+					"Assets":                                {{End: periodEnd, Filed: filed, Val: 350_000, Form: "10-Q"}},
+					"IntangibleAssetsNetIncludingGoodwill":  {{End: periodEnd, Filed: filed, Val: 50_000, Form: "10-Q"}},
+					"CashAndCashEquivalentsAtCarryingValue": {{End: periodEnd, Filed: filed, Val: 25_000, Form: "10-Q"}},
+					"LiabilitiesCurrent":                   {{End: periodEnd, Filed: filed, Val: 60_000, Form: "10-Q"}},
+				},
+			}
+
+			resolved := ResolveAllFields(icCF, periodEnd, "10-Q")
+
+			// TotalDebt = DebtCurrent(10_000) + DebtNonCurrent(90_000) = 100_000
+			// InvestedCapital = 100_000 + 350_000 - 50_000 - 25_000 - 60_000 = 315_000
+			Expect(resolved).To(HaveKey("InvestedCapital"))
+			Expect(resolved["InvestedCapital"]).To(Equal(315_000.0))
+		})
+
 		It("falls back to basic weighted-average shares when diluted tags are absent", func() {
 			// Simulates a loss-quarter filer (e.g. Nordstrom during COVID,
 			// Vaxart as a pre-revenue biotech) that reports only the basic

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -759,6 +759,12 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		}
 
 		if ttm := ComputeTTM(arQSlice); ttm != nil {
+			if i >= 4 {
+				for k, v := range ComputePeriodAverages(ttm, quarters[i-4].arEmit) {
+					ttm[k] = v
+				}
+			}
+
 			fundamental := BuildFundamental(ttm, asset.Ticker, asset.CompositeFigi, "ART",
 				q.period.ARFiledDate, calendarDate, q.period.PeriodEnd, latestARFiled)
 			out <- &data.Observation{
@@ -778,6 +784,12 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		}
 
 		if ttm := ComputeTTM(mrQSlice); ttm != nil {
+			if i >= 4 {
+				for k, v := range ComputePeriodAverages(ttm, quarters[i-4].mrEmit) {
+					ttm[k] = v
+				}
+			}
+
 			fundamental := BuildFundamental(ttm, asset.Ticker, asset.CompositeFigi, "MRT",
 				q.period.PeriodEnd, calendarDate, q.period.PeriodEnd, latestMRFiled)
 			out <- &data.Observation{

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -476,6 +476,16 @@ const coverageWarnThresholdPct = 50
 // MRFiledDate is used for the comparison so that restatements filed after
 // since are re-emitted even if the period itself is older.
 //
+// copyFieldMap returns a shallow copy of a resolved field map.
+func copyFieldMap(m map[string]float64) map[string]float64 {
+	cp := make(map[string]float64, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+
+	return cp
+}
+
 // Returns the number of fields resolved for the company's most recent period
 // and the count of non-TTM periods emitted (ARQ + ARY). The caller uses these
 // to track coverage statistics across the run. latestPeriodCoverage is zero if
@@ -603,10 +613,12 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 	for i := range annuals {
 		a := &annuals[i]
 
-		// Annual data is full-year; no de-cumulation needed. Store
-		// directly in arEmit/mrEmit.
-		a.arEmit = a.arFields
-		a.mrEmit = a.mrFields
+		// Annual data is full-year; no de-cumulation needed. Copy into
+		// arEmit/mrEmit so that merging period averages does not mutate
+		// the original arFields (which may be read as prev in the next
+		// iteration).
+		a.arEmit = copyFieldMap(a.arFields)
+		a.mrEmit = copyFieldMap(a.mrFields)
 
 		if i > 0 {
 			prev := &annuals[i-1]

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -502,9 +502,9 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 	var quarters []quarterData
 
-	for _, p := range periods {
-		calendarDate := NormalizeEventDate(p.PeriodEnd, p.FormType)
+	var annuals []quarterData
 
+	for _, p := range periods {
 		// AR: resolve using only facts available at the earliest filing date
 		arFields := ResolveFieldsForFiling(cf, p.PeriodEnd, p.FormType, p.ARFiledDate)
 
@@ -533,38 +533,8 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			latestPeriodCoverage = len(arFields)
 		}
 
-		// Emit annual observations immediately (10-K data is always full-year,
-		// no de-cumulation needed).
 		if p.FormType == "10-K" {
-			if !since.IsZero() && p.MRFiledDate.Before(since) {
-				continue
-			}
-
-			// ARY
-			fundamental := BuildFundamental(arFields, asset.Ticker, asset.CompositeFigi, "ARY",
-				p.ARFiledDate, calendarDate, p.PeriodEnd, p.ARFiledDate)
-			out <- &data.Observation{
-				Fundamental:      fundamental,
-				ObservationDate:  calendarDate,
-				SubscriptionID:   sub.ID,
-				SubscriptionName: sub.Name,
-			}
-
-			*numObservations++
-
-			// MRY
-			fundamental = BuildFundamental(mrFields, asset.Ticker, asset.CompositeFigi, "MRY",
-				p.PeriodEnd, calendarDate, p.PeriodEnd, p.MRFiledDate)
-			out <- &data.Observation{
-				Fundamental:      fundamental,
-				ObservationDate:  calendarDate,
-				SubscriptionID:   sub.ID,
-				SubscriptionName: sub.Name,
-			}
-
-			*numObservations++
-
-			periodsEmitted++
+			annuals = append(annuals, quarterData{period: p, arFields: arFields, mrFields: mrFields})
 		}
 	}
 
@@ -625,6 +595,65 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		for k, v := range ComputePeriodAverages(q.mrEmit, prev.mrEmit) {
 			q.mrEmit[k] = v
 		}
+	}
+
+	// Compute period averages and emit annual observations.
+	const maxAnnualGapDays = 425 // ~14 months, handles fiscal year shifts
+
+	for i := range annuals {
+		a := &annuals[i]
+
+		// Annual data is full-year; no de-cumulation needed. Store
+		// directly in arEmit/mrEmit.
+		a.arEmit = a.arFields
+		a.mrEmit = a.mrFields
+
+		if i > 0 {
+			prev := &annuals[i-1]
+			gapDays := a.period.PeriodEnd.Sub(prev.period.PeriodEnd).Hours() / 24
+
+			if gapDays <= maxAnnualGapDays {
+				for k, v := range ComputePeriodAverages(a.arEmit, prev.arEmit) {
+					a.arEmit[k] = v
+				}
+
+				for k, v := range ComputePeriodAverages(a.mrEmit, prev.mrEmit) {
+					a.mrEmit[k] = v
+				}
+			}
+		}
+
+		calendarDate := NormalizeEventDate(a.period.PeriodEnd, a.period.FormType)
+
+		if !since.IsZero() && a.period.MRFiledDate.Before(since) {
+			continue
+		}
+
+		// ARY
+		fundamental := BuildFundamental(a.arEmit, asset.Ticker, asset.CompositeFigi, "ARY",
+			a.period.ARFiledDate, calendarDate, a.period.PeriodEnd, a.period.ARFiledDate)
+		out <- &data.Observation{
+			Fundamental:      fundamental,
+			ObservationDate:  calendarDate,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		*numObservations++
+
+		// MRY
+		fundamental = BuildFundamental(a.mrEmit, asset.Ticker, asset.CompositeFigi, "MRY",
+			a.period.PeriodEnd, calendarDate, a.period.PeriodEnd, a.period.MRFiledDate)
+		out <- &data.Observation{
+			Fundamental:      fundamental,
+			ObservationDate:  calendarDate,
+			SubscriptionID:   sub.ID,
+			SubscriptionName: sub.Name,
+		}
+
+		*numObservations++
+
+		periodsEmitted++
 	}
 
 	// Emit quarterly observations using de-cumulated values.

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -601,6 +601,32 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		q.mrEmit = q.mrFields
 	}
 
+	// Compute period-average fields (AverageAssets, EquityAvg,
+	// InvestedCapitalAverage) and derived ratios (ROA, ROE, ROIC) from
+	// consecutive quarterly balance sheet values.
+	for i := range quarters {
+		q := &quarters[i]
+
+		if i == 0 {
+			continue
+		}
+
+		prev := &quarters[i-1]
+		gapDays := q.period.PeriodEnd.Sub(prev.period.PeriodEnd).Hours() / 24
+
+		if gapDays > maxQuarterGapDays {
+			continue
+		}
+
+		for k, v := range ComputePeriodAverages(q.arEmit, prev.arEmit) {
+			q.arEmit[k] = v
+		}
+
+		for k, v := range ComputePeriodAverages(q.mrEmit, prev.mrEmit) {
+			q.mrEmit[k] = v
+		}
+	}
+
 	// Emit quarterly observations using de-cumulated values.
 	for i := range quarters {
 		q := &quarters[i]


### PR DESCRIPTION
## Summary

- Extend derivation engine with `OpLinearCombination` for multi-term formulas
- Add `InvestedCapital` field mapping (TotalDebt + TotalAssets - Intangibles - CashAndEquivalents - CurrentLiabilities)
- Add `ComputePeriodAverages` function that computes `AverageAssets`, `EquityAvg`, `InvestedCapitalAverage`, `ROA`, `ROE`, `ROIC` from consecutive period balance sheets
- Wire period averages into quarterly (ARQ/MRQ), annual (ARY/MRY), and TTM (ART/MRT) emission

Closes #43

## Test plan

- [x] `OpLinearCombination` unit tests (weighted sum, missing operand)
- [x] `InvestedCapital` end-to-end through `ResolveAllFields`
- [x] `ComputePeriodAverages` unit tests (complete inputs, partial inputs, zero denominator, nil prior)
- [x] Quarterly integration test (Q1 has no averages, Q2 computes from Q1)
- [x] Annual integration test (FY1 has no averages, FY2 computes from FY1)
- [x] TTM integration test (5 quarters: averages use quarters[i-4] as prior; 4 quarters: no averages)
- [x] `BuildFundamental` coverage test (all 7 new fields referenced)
- [x] Coefficients length validation test
- [x] 92/92 tests passing, lint clean
- [ ] Run `pvdata compare-fundamentals` against Sharadar data to verify ~84 diffs disappear