### PR TITLE
fix(sec): reduce rounding differences vs Sharadar (#44)

### DIFF
--- a/docs/superpowers/plans/2026-04-12-sec-market-data-fields.md
+++ b/docs/superpowers/plans/2026-04-12-sec-market-data-fields.md
@@ -1,0 +1,737 @@
+# SEC Market-Data Field Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compute 14 market-data fields (price, market_cap, PE, PB, PS, etc.) on SEC fundamentals by looking up EOD close prices from the published `eod` view.
+
+**Architecture:** A new `enrichMarketData` function accepts a slice of `*data.Fundamental` for one company and a price-lookup function. It groups fundamentals by DateKey, looks up the EOD close for each EventDate, computes market-data fields on all dimensions, and copies ratio fields from trailing to quarterly dimensions. The price-lookup function is injectable for testability. In `emitFundamentals`, observations are buffered instead of sent immediately, enriched after all are built, then sent.
+
+**Tech Stack:** Go 1.25, pgx/v5 (EOD queries), Ginkgo v2 + Gomega (tests)
+
+---
+
+### Task 1: Pure market-data computation logic
+
+**Files:**
+- Create: `provider/sec/market_data.go`
+- Create: `provider/sec/market_data_test.go`
+
+This task creates the core computation function that populates the 14 market-data fields on `*data.Fundamental` structs, given a price lookup function. No database access.
+
+- [ ] **Step 1: Write failing tests**
+
+In `provider/sec/market_data_test.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+
+package sec
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/data"
+)
+
+var _ = Describe("EnrichMarketData", func() {
+	// stubPriceFn returns a fixed price for any lookup.
+	stubPriceFn := func(price float64) PriceLookupFn {
+		return func(compositeFigi string, eventDate time.Time) float64 {
+			return price
+		}
+	}
+
+	// noPriceFn simulates missing EOD data.
+	noPriceFn := stubPriceFn(0)
+
+	Describe("trailing/annual dimension fields", func() {
+		It("computes all 14 fields on an ART record", func() {
+			art := &data.Fundamental{
+				CompositeFigi:                "BBG000TEST01",
+				Dimension:                    "ART",
+				EventDate:                    time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey:                      time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+				SharesBasic:                  15000000000,
+				TotalDebt:                    100000000000,
+				CashAndEquivalents:           30000000000,
+				Equity:                       70000000000,
+				NetIncomeCommonStock:         100000000000,
+				Revenues:                     400000000000,
+				EPS:                          6.5,
+				EPSDiluted:                   6.3,
+				SalesPerShare:                26.0,
+				EBIT:                         130000000000,
+				EBITDA:                       140000000000,
+				DividendsPerBasicCommonShare: 1.0,
+			}
+
+			fundamentals := []*data.Fundamental{art}
+			EnrichMarketData(fundamentals, stubPriceFn(236.0))
+
+			Expect(art.Price).To(BeNumerically("~", 236.0, 0.001))
+			Expect(art.MarketCapitalization).To(Equal(int64(236.0 * 15000000000)))
+			Expect(art.EnterpriseValue).To(Equal(art.MarketCapitalization + 100000000000 - 30000000000))
+			Expect(art.ShareFactor).To(BeNumerically("~", 1.0, 0.001))
+			Expect(art.FxUSD).To(BeNumerically("~", 1.0, 0.001))
+
+			// Ratios
+			expectedMktCap := float64(art.MarketCapitalization)
+			Expect(art.PE).To(BeNumerically("~", expectedMktCap/100000000000, 0.001))
+			Expect(art.PB).To(BeNumerically("~", expectedMktCap/70000000000, 0.001))
+			Expect(art.PS).To(BeNumerically("~", expectedMktCap/400000000000, 0.001))
+			Expect(art.PE1).To(BeNumerically("~", 236.0/6.5, 0.001))
+			Expect(art.PS1).To(BeNumerically("~", 236.0/26.0, 0.001))
+			Expect(art.EVtoEBIT).To(Equal(int64(float64(art.EnterpriseValue) / 130000000000)))
+			Expect(art.EVtoEBITDA).To(BeNumerically("~", float64(art.EnterpriseValue)/140000000000, 0.001))
+			Expect(art.DividendYield).To(BeNumerically("~", 1.0/236.0, 0.00001))
+			Expect(art.PayoutRatio).To(BeNumerically("~", 1.0/6.3, 0.001))
+		})
+	})
+
+	Describe("quarterly dimension copies from trailing", func() {
+		It("copies ratio fields from ART to ARQ at the same DateKey", func() {
+			dateKey := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
+
+			art := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "ART",
+				EventDate: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey:   dateKey,
+				SharesBasic: 15000000000, TotalDebt: 100000000000,
+				CashAndEquivalents: 30000000000, Equity: 70000000000,
+				NetIncomeCommonStock: 100000000000, Revenues: 400000000000,
+				EPS: 6.5, EPSDiluted: 6.3, SalesPerShare: 26.0,
+				EBIT: 130000000000, EBITDA: 140000000000,
+				DividendsPerBasicCommonShare: 1.0,
+			}
+
+			arq := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "ARQ",
+				EventDate: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey:   dateKey,
+				SharesBasic: 15000000000, TotalDebt: 100000000000,
+				CashAndEquivalents: 30000000000, Equity: 70000000000,
+				NetIncomeCommonStock: 36000000000, Revenues: 124000000000,
+			}
+
+			EnrichMarketData([]*data.Fundamental{art, arq}, stubPriceFn(236.0))
+
+			// ARQ gets its own price, market_cap, EV, PB
+			Expect(arq.Price).To(BeNumerically("~", 236.0, 0.001))
+			Expect(arq.MarketCapitalization).To(Equal(art.MarketCapitalization))
+			Expect(arq.PB).To(BeNumerically("~", float64(arq.MarketCapitalization)/70000000000, 0.001))
+
+			// ARQ copies ratio fields from ART
+			Expect(arq.PE).To(Equal(art.PE))
+			Expect(arq.PS).To(Equal(art.PS))
+			Expect(arq.PE1).To(Equal(art.PE1))
+			Expect(arq.PS1).To(Equal(art.PS1))
+			Expect(arq.EVtoEBIT).To(Equal(art.EVtoEBIT))
+			Expect(arq.EVtoEBITDA).To(Equal(art.EVtoEBITDA))
+			Expect(arq.DividendYield).To(Equal(art.DividendYield))
+			Expect(arq.PayoutRatio).To(Equal(art.PayoutRatio))
+		})
+
+		It("copies from MRT to MRQ", func() {
+			dateKey := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
+
+			mrt := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "MRT",
+				EventDate: time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC),
+				DateKey: dateKey,
+				SharesBasic: 15000000000, TotalDebt: 100000000000,
+				CashAndEquivalents: 30000000000, Equity: 70000000000,
+				NetIncomeCommonStock: 100000000000, Revenues: 400000000000,
+				EPS: 6.5, EPSDiluted: 6.3, SalesPerShare: 26.0,
+				EBIT: 130000000000, EBITDA: 140000000000,
+				DividendsPerBasicCommonShare: 1.0,
+			}
+
+			mrq := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "MRQ",
+				EventDate: time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC),
+				DateKey: dateKey,
+				SharesBasic: 15000000000, Equity: 70000000000,
+			}
+
+			EnrichMarketData([]*data.Fundamental{mrt, mrq}, stubPriceFn(255.0))
+
+			Expect(mrq.PE).To(Equal(mrt.PE))
+			Expect(mrq.PS).To(Equal(mrt.PS))
+		})
+	})
+
+	Describe("division by zero", func() {
+		It("leaves ratio at zero when denominator is zero", func() {
+			art := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "ART",
+				EventDate: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey:   time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+				SharesBasic: 15000000000,
+				NetIncomeCommonStock: 0, // zero denominator
+				Revenues: 0,
+				Equity:   0,
+				EPS:      0,
+				EBIT:     0,
+				EBITDA:   0,
+			}
+
+			EnrichMarketData([]*data.Fundamental{art}, stubPriceFn(236.0))
+
+			Expect(art.Price).To(BeNumerically("~", 236.0, 0.001))
+			Expect(art.MarketCapitalization).To(BeNumerically(">", 0))
+			Expect(art.PE).To(BeNumerically("==", 0))
+			Expect(art.PB).To(BeNumerically("==", 0))
+			Expect(art.PS).To(BeNumerically("==", 0))
+			Expect(art.PE1).To(BeNumerically("==", 0))
+			Expect(art.EVtoEBIT).To(Equal(int64(0)))
+		})
+	})
+
+	Describe("missing EOD price", func() {
+		It("leaves all market-data fields at zero when price is zero", func() {
+			art := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "ART",
+				EventDate: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey:   time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+				SharesBasic: 15000000000,
+				NetIncomeCommonStock: 100000000000,
+			}
+
+			EnrichMarketData([]*data.Fundamental{art}, noPriceFn)
+
+			Expect(art.Price).To(BeNumerically("==", 0))
+			Expect(art.MarketCapitalization).To(Equal(int64(0)))
+			Expect(art.PE).To(BeNumerically("==", 0))
+		})
+	})
+
+	Describe("pe1 uses basic EPS", func() {
+		It("computes pe1 from EPS not EPSDiluted", func() {
+			art := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "ART",
+				EventDate: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey:   time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+				SharesBasic: 15000000000,
+				EPS:        6.5,
+				EPSDiluted: 6.3,
+			}
+
+			EnrichMarketData([]*data.Fundamental{art}, stubPriceFn(236.0))
+
+			// pe1 = price / eps (basic)
+			Expect(art.PE1).To(BeNumerically("~", 236.0/6.5, 0.001))
+			// NOT price / eps_diluted (which would be 236/6.3 = 37.46)
+			Expect(art.PE1).NotTo(BeNumerically("~", 236.0/6.3, 0.001))
+		})
+	})
+
+	Describe("PB computed independently for quarterly", func() {
+		It("uses the quarterly dimension's own equity for PB", func() {
+			dateKey := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
+
+			art := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "ART",
+				EventDate: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey: dateKey,
+				SharesBasic: 15000000000, Equity: 70000000000,
+				NetIncomeCommonStock: 100000000000, Revenues: 400000000000,
+				EPS: 6.5, EPSDiluted: 6.3, SalesPerShare: 26.0,
+				EBIT: 130000000000, EBITDA: 140000000000,
+				TotalDebt: 100000000000, CashAndEquivalents: 30000000000,
+				DividendsPerBasicCommonShare: 1.0,
+			}
+
+			arq := &data.Fundamental{
+				CompositeFigi: "BBG000TEST01", Dimension: "ARQ",
+				EventDate: time.Date(2025, 1, 31, 0, 0, 0, 0, time.UTC),
+				DateKey: dateKey,
+				SharesBasic: 15000000000,
+				Equity: 65000000000, // different equity than ART
+				TotalDebt: 100000000000, CashAndEquivalents: 30000000000,
+			}
+
+			EnrichMarketData([]*data.Fundamental{art, arq}, stubPriceFn(236.0))
+
+			// ARQ PB uses its own equity (65B), not ART's (70B)
+			expectedPB := float64(arq.MarketCapitalization) / 65000000000
+			Expect(arq.PB).To(BeNumerically("~", expectedPB, 0.001))
+			Expect(arq.PB).NotTo(Equal(art.PB))
+		})
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "EnrichMarketData" ./provider/sec/`
+Expected: FAIL -- `EnrichMarketData` and `PriceLookupFn` not defined.
+
+- [ ] **Step 3: Implement EnrichMarketData**
+
+In `provider/sec/market_data.go`:
+
+```go
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+
+package sec
+
+import (
+	"math"
+	"time"
+
+	"github.com/penny-vault/pvdata/data"
+)
+
+// PriceLookupFn returns the unadjusted close price for a given composite FIGI
+// and event date. Returns 0 if no price is available.
+type PriceLookupFn func(compositeFigi string, eventDate time.Time) float64
+
+// EnrichMarketData populates the 14 market-data fields on a slice of
+// Fundamental records for a single company. It groups records by DateKey,
+// looks up EOD close prices, computes fields on trailing/annual dimensions,
+// and copies ratio fields from trailing to quarterly dimensions.
+func EnrichMarketData(fundamentals []*data.Fundamental, lookupPrice PriceLookupFn) {
+	// Group by DateKey so we can find trailing/quarterly pairs.
+	type dateKeyGroup struct {
+		fundamentals []*data.Fundamental
+	}
+
+	groups := make(map[time.Time]*dateKeyGroup)
+
+	for _, f := range fundamentals {
+		g, ok := groups[f.DateKey]
+		if !ok {
+			g = &dateKeyGroup{}
+			groups[f.DateKey] = g
+		}
+
+		g.fundamentals = append(g.fundamentals, f)
+	}
+
+	for _, g := range groups {
+		enrichGroup(g.fundamentals, lookupPrice)
+	}
+}
+
+// enrichGroup enriches all fundamentals sharing the same DateKey.
+func enrichGroup(fundamentals []*data.Fundamental, lookupPrice PriceLookupFn) {
+	// Phase 1: compute price, market_cap, EV, PB, share_factor, fx_usd for all dimensions.
+	for _, f := range fundamentals {
+		price := lookupPrice(f.CompositeFigi, f.EventDate)
+		if price == 0 {
+			continue
+		}
+
+		f.Price = price
+		f.ShareFactor = 1.0
+		f.FxUSD = 1.0
+		f.MarketCapitalization = int64(price * float64(f.SharesBasic))
+		f.EnterpriseValue = f.MarketCapitalization + f.TotalDebt - f.CashAndEquivalents
+
+		if f.Equity != 0 {
+			f.PB = float64(f.MarketCapitalization) / float64(f.Equity)
+		}
+	}
+
+	// Phase 2: compute ratio fields on trailing/annual dimensions.
+	for _, f := range fundamentals {
+		if f.Price == 0 {
+			continue
+		}
+
+		dim := f.Dimension
+		if dim != "ART" && dim != "MRT" && dim != "ARY" && dim != "MRY" {
+			continue
+		}
+
+		mktCap := float64(f.MarketCapitalization)
+
+		if f.NetIncomeCommonStock != 0 {
+			f.PE = mktCap / float64(f.NetIncomeCommonStock)
+		}
+
+		if f.Revenues != 0 {
+			f.PS = mktCap / float64(f.Revenues)
+		}
+
+		if f.EPS != 0 {
+			f.PE1 = f.Price / f.EPS
+		}
+
+		if f.SalesPerShare != 0 {
+			f.PS1 = f.Price / f.SalesPerShare
+		}
+
+		if f.EBIT != 0 {
+			f.EVtoEBIT = int64(math.Round(float64(f.EnterpriseValue) / float64(f.EBIT)))
+		}
+
+		if f.EBITDA != 0 {
+			f.EVtoEBITDA = float64(f.EnterpriseValue) / float64(f.EBITDA)
+		}
+
+		if f.Price != 0 {
+			f.DividendYield = f.DividendsPerBasicCommonShare / f.Price
+		}
+
+		if f.EPSDiluted != 0 {
+			f.PayoutRatio = f.DividendsPerBasicCommonShare / f.EPSDiluted
+		}
+	}
+
+	// Phase 3: copy ratio fields from trailing to quarterly dimensions.
+	// ART -> ARQ, MRT -> MRQ. Matched by DateKey (already grouped).
+	trailingByPrefix := make(map[string]*data.Fundamental) // "AR" or "MR" -> trailing fundamental
+
+	for _, f := range fundamentals {
+		switch f.Dimension {
+		case "ART":
+			trailingByPrefix["AR"] = f
+		case "MRT":
+			trailingByPrefix["MR"] = f
+		}
+	}
+
+	for _, f := range fundamentals {
+		var prefix string
+
+		switch f.Dimension {
+		case "ARQ":
+			prefix = "AR"
+		case "MRQ":
+			prefix = "MR"
+		default:
+			continue
+		}
+
+		trailing, ok := trailingByPrefix[prefix]
+		if !ok {
+			continue
+		}
+
+		f.PE = trailing.PE
+		f.PS = trailing.PS
+		f.PE1 = trailing.PE1
+		f.PS1 = trailing.PS1
+		f.EVtoEBIT = trailing.EVtoEBIT
+		f.EVtoEBITDA = trailing.EVtoEBITDA
+		f.DividendYield = trailing.DividendYield
+		f.PayoutRatio = trailing.PayoutRatio
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "EnrichMarketData" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 5: Run all SEC tests for regressions**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add provider/sec/market_data.go provider/sec/market_data_test.go
+git commit -m "feat(sec): add EnrichMarketData to compute 14 market-data fields (#38)"
+```
+
+---
+
+### Task 2: EOD price lookup function
+
+**Files:**
+- Modify: `provider/sec/market_data.go` (add `NewEODPriceLookup`)
+
+This creates a `PriceLookupFn` that queries the published `eod` view for the most recent close on or before a given date.
+
+- [ ] **Step 1: Implement the EOD price lookup factory**
+
+Add to the bottom of `provider/sec/market_data.go`:
+
+```go
+// NewEODPriceLookup returns a PriceLookupFn that queries the given EOD view
+// for the unadjusted close price on or before the event date. It looks back
+// up to 7 calendar days to handle weekends and holidays. Returns 0 if no
+// price is found.
+//
+// The returned function acquires and releases a connection per call. For bulk
+// enrichment this is acceptable because the number of distinct event dates
+// per company is small (typically < 100).
+func NewEODPriceLookup(ctx context.Context, pool *pgxpool.Pool, eodViewName string) PriceLookupFn {
+	return func(compositeFigi string, eventDate time.Time) float64 {
+		conn, err := pool.Acquire(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("acquire connection for EOD price lookup")
+			return 0
+		}
+		defer conn.Release()
+
+		var price float64
+
+		err = conn.QueryRow(ctx,
+			fmt.Sprintf(`SELECT close FROM %s
+				WHERE composite_figi = $1 AND event_date <= $2 AND event_date >= $3
+				ORDER BY event_date DESC LIMIT 1`, eodViewName),
+			compositeFigi, eventDate, eventDate.AddDate(0, 0, -7),
+		).Scan(&price)
+
+		if err != nil {
+			// No price found is normal for historical data without EOD coverage.
+			return 0
+		}
+
+		return price
+	}
+}
+
+// FindEODViewName looks up the published view name for the "eod" data type.
+// Returns empty string if no published EOD view exists.
+func FindEODViewName(ctx context.Context, pool *pgxpool.Pool) string {
+	views, err := library.LoadPublishedViews(ctx, pool)
+	if err != nil {
+		log.Error().Err(err).Msg("load published views for EOD lookup")
+		return ""
+	}
+
+	for _, v := range views {
+		if v.DataTypeKey == "eod" {
+			return v.ViewName
+		}
+	}
+
+	return ""
+}
+```
+
+Add these imports to the file's import block:
+
+```go
+"context"
+"fmt"
+
+"github.com/jackc/pgx/v5/pgxpool"
+"github.com/penny-vault/pvdata/library"
+"github.com/rs/zerolog/log"
+```
+
+- [ ] **Step 2: Run lint**
+
+Run: `golangci-lint run --fix ./provider/sec/`
+Expected: 0 issues.
+
+- [ ] **Step 3: Run all SEC tests for regressions**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add provider/sec/market_data.go
+git commit -m "feat(sec): add EOD price lookup and view discovery for market-data enrichment (#38)"
+```
+
+---
+
+### Task 3: Wire enrichment into emitFundamentals
+
+**Files:**
+- Modify: `provider/sec/sec.go` (`emitFundamentals` function)
+
+Change `emitFundamentals` to buffer observations, enrich them, then send to the output channel.
+
+- [ ] **Step 1: Add a test verifying enrichment populates price on emitted observations**
+
+In `provider/sec/market_data_test.go`, add a new `Describe` block:
+
+```go
+var _ = Describe("emitFundamentals market-data enrichment", func() {
+	It("populates price on emitted fundamentals when priceLookupFn is set", func() {
+		cf := &CompanyFacts{
+			CIK:        999,
+			EntityName: "TestCo",
+			Facts: map[string][]Fact{
+				"Revenues": {
+					{Val: 100000, Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+		}
+
+		asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST01", CIK: 999}
+		sub := &library.Subscription{Name: "test"}
+		out := make(chan *data.Observation, 100)
+		numObs := 0
+
+		// Set the package-level price lookup function for testing.
+		SetPriceLookupFn(func(compositeFigi string, eventDate time.Time) float64 {
+			return 150.0
+		})
+		defer SetPriceLookupFn(nil)
+
+		emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+		close(out)
+
+		for obs := range out {
+			if obs.Fundamental != nil {
+				Expect(obs.Fundamental.Price).To(BeNumerically("~", 150.0, 0.001))
+			}
+		}
+	})
+
+	It("emits fundamentals with zero price when no lookup function is set", func() {
+		cf := &CompanyFacts{
+			CIK:        999,
+			EntityName: "TestCo",
+			Facts: map[string][]Fact{
+				"Revenues": {
+					{Val: 100000, Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+		}
+
+		asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST01", CIK: 999}
+		sub := &library.Subscription{Name: "test"}
+		out := make(chan *data.Observation, 100)
+		numObs := 0
+
+		SetPriceLookupFn(nil)
+
+		emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+		close(out)
+
+		for obs := range out {
+			if obs.Fundamental != nil {
+				Expect(obs.Fundamental.Price).To(BeNumerically("==", 0))
+			}
+		}
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "emitFundamentals market-data" ./provider/sec/`
+Expected: FAIL -- `SetPriceLookupFn` not defined.
+
+- [ ] **Step 3: Modify emitFundamentals to buffer and enrich**
+
+In `provider/sec/market_data.go`, add a package-level variable and setter:
+
+```go
+// priceLookupFn is the active price lookup function. Set by fetchFundamentals
+// when the published EOD view is available.
+var priceLookupFn PriceLookupFn
+
+// SetPriceLookupFn sets the package-level price lookup function. Passing nil
+// disables market-data enrichment.
+func SetPriceLookupFn(fn PriceLookupFn) {
+	priceLookupFn = fn
+}
+```
+
+In `provider/sec/sec.go`, make two changes to `emitFundamentals`:
+
+**Change 1:** Instead of sending observations directly to `out`, buffer them. Replace every `out <- &data.Observation{...}` with appending to a local `var buffered []*data.Observation` slice. There are 6 places where observations are sent:
+- ARY (line ~557)
+- MRY (line ~567)
+- ARQ (line ~684)
+- MRQ (line ~696)
+- ART (line ~777)
+- MRT (line ~794)
+
+For each, change from:
+
+```go
+out <- &data.Observation{
+    Fundamental:      fundamental,
+    ObservationDate:  calendarDate,
+    SubscriptionID:   sub.ID,
+    SubscriptionName: sub.Name,
+}
+```
+
+To:
+
+```go
+buffered = append(buffered, &data.Observation{
+    Fundamental:      fundamental,
+    ObservationDate:  calendarDate,
+    SubscriptionID:   sub.ID,
+    SubscriptionName: sub.Name,
+})
+```
+
+**Change 2:** After the TTM loop (after the coverage logging at the end of the function), add enrichment and emission:
+
+```go
+	// Enrich buffered observations with market-data fields if a price
+	// lookup function is available.
+	if priceLookupFn != nil {
+		var fundamentals []*data.Fundamental
+
+		for _, obs := range buffered {
+			if obs.Fundamental != nil {
+				fundamentals = append(fundamentals, obs.Fundamental)
+			}
+		}
+
+		EnrichMarketData(fundamentals, priceLookupFn)
+	}
+
+	// Send all buffered observations to the output channel.
+	for _, obs := range buffered {
+		out <- obs
+	}
+```
+
+**Change 3:** Declare the buffer at the top of the function (after `var quarters []quarterData`):
+
+```go
+	var buffered []*data.Observation
+```
+
+- [ ] **Step 4: Set up the price lookup in fetchFundamentals**
+
+In `provider/sec/sec.go`, in `fetchFundamentals` (around line 75), after the CIK map is built and before `isBackfill` (around line 224), add:
+
+```go
+	// Set up EOD price lookup for market-data enrichment.
+	eodView := FindEODViewName(ctx, sub.Library.Pool)
+	if eodView != "" {
+		SetPriceLookupFn(NewEODPriceLookup(ctx, sub.Library.Pool, eodView))
+		log.Info().Str("eod_view", eodView).Msg("market-data enrichment enabled")
+	} else {
+		SetPriceLookupFn(nil)
+		log.Warn().Msg("no published EOD view found; market-data fields will be zero")
+	}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "emitFundamentals market-data" ./provider/sec/`
+Expected: PASS
+
+- [ ] **Step 6: Run all SEC tests for regressions**
+
+Run: `ginkgo run -race ./provider/sec/`
+Expected: All tests pass.
+
+- [ ] **Step 7: Run lint**
+
+Run: `golangci-lint run --fix ./provider/sec/`
+Expected: 0 issues.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add provider/sec/sec.go provider/sec/market_data.go provider/sec/market_data_test.go
+git commit -m "feat(sec): wire market-data enrichment into emitFundamentals pipeline (#38)"
+```

--- a/docs/superpowers/plans/2026-04-12-sec-rounding-match.md
+++ b/docs/superpowers/plans/2026-04-12-sec-rounding-match.md
@@ -1,0 +1,323 @@
+# SEC Rounding Match Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix BookValuePerShare and TangibleAssetsBookValuePerShare to use WeightedAverageShares as denominator, and add configurable rounding to all derived float64 division fields so SEC output matches Sharadar exactly.
+
+**Architecture:** Add a `RoundDigits int` field to the `FieldMapping` struct. When > 0, `computeDerived` rounds the division result to that many decimal places. Change the two per-share fields to use `WeightedAverageShares` instead of `SharesBasic`.
+
+**Tech Stack:** Go, Ginkgo v2 + Gomega
+
+---
+
+### Task 1: Add RoundDigits field and rounding logic
+
+**Files:**
+- Modify: `provider/sec/mapping_config.go:44-69` (FieldMapping struct)
+- Modify: `provider/sec/mapping.go:277-282` (OpDivide case in computeDerived)
+- Test: `provider/sec/mapping_test.go`
+
+- [ ] **Step 1: Write failing test for rounding in computeDerived**
+
+Add a new `Describe` block in `provider/sec/mapping_test.go` after the existing `computeDerived with OptionalOperands` block (line 213):
+
+```go
+Describe("computeDerived rounding", func() {
+    It("rounds division result when RoundDigits is set", func() {
+        resolved := map[string]float64{
+            "A": 100,
+            "B": 3,
+        }
+        m := FieldMapping{
+            FieldName:   "Ratio",
+            Type:        MappingDerived,
+            Op:          OpDivide,
+            Operands:    []string{"A", "B"},
+            RoundDigits: 4,
+        }
+        val, ok := computeDerived(m, resolved)
+        Expect(ok).To(BeTrue())
+        Expect(val).To(Equal(33.3333))
+    })
+
+    It("does not round when RoundDigits is zero", func() {
+        resolved := map[string]float64{
+            "A": 100,
+            "B": 3,
+        }
+        m := FieldMapping{
+            FieldName: "Ratio",
+            Type:      MappingDerived,
+            Op:        OpDivide,
+            Operands:  []string{"A", "B"},
+        }
+        val, ok := computeDerived(m, resolved)
+        Expect(ok).To(BeTrue())
+        Expect(val).To(Equal(100.0 / 3.0))
+    })
+
+    It("rounds to 3 decimal places", func() {
+        resolved := map[string]float64{
+            "A": 74_236_000_000,
+            "B": 15_408_095_000,
+        }
+        m := FieldMapping{
+            FieldName:   "BVPS",
+            Type:        MappingDerived,
+            Op:          OpDivide,
+            Operands:    []string{"A", "B"},
+            RoundDigits: 3,
+        }
+        val, ok := computeDerived(m, resolved)
+        Expect(ok).To(BeTrue())
+        Expect(val).To(Equal(4.818))
+    })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "computeDerived rounding" ./provider/sec/`
+
+Expected: compilation error -- `RoundDigits` field does not exist on `FieldMapping`
+
+- [ ] **Step 3: Add RoundDigits field to FieldMapping struct**
+
+In `provider/sec/mapping_config.go`, add the `RoundDigits` field after `OptionalOperands` (line 68):
+
+```go
+// RoundDigits rounds OpDivide results to this many decimal places.
+// Zero (the default) means no rounding.
+RoundDigits int
+```
+
+- [ ] **Step 4: Add rounding logic to computeDerived**
+
+In `provider/sec/mapping.go`, add a `math` import if not already present, then replace the `OpDivide` case (lines 277-282):
+
+```go
+case OpDivide:
+    if len(vals) < 2 || vals[1] == 0 {
+        return 0, false
+    }
+
+    result := vals[0] / vals[1]
+    if m.RoundDigits > 0 {
+        pow := math.Pow(10, float64(m.RoundDigits))
+        result = math.Round(result*pow) / pow
+    }
+
+    return result, true
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "computeDerived rounding" ./provider/sec/`
+
+Expected: PASS (all 3 specs)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add provider/sec/mapping_config.go provider/sec/mapping.go provider/sec/mapping_test.go
+git commit -m "feat(sec): add RoundDigits field to FieldMapping for derived division rounding (#44)"
+```
+
+---
+
+### Task 2: Fix denominators and set RoundDigits on all OpDivide fields
+
+**Files:**
+- Modify: `provider/sec/mapping_config.go:598-666` (ratio and per-share metric definitions)
+- Test: `provider/sec/mapping_test.go`
+
+- [ ] **Step 1: Write failing test for BookValuePerShare denominator**
+
+Add a test in `provider/sec/mapping_test.go` inside the existing `Describe("Mapping Config", ...)` block (after line 75):
+
+```go
+It("BookValuePerShare uses WeightedAverageShares as denominator", func() {
+    for _, m := range FieldMappings {
+        if m.FieldName == "BookValuePerShare" {
+            Expect(m.Operands).To(Equal([]string{"Equity", "WeightedAverageShares"}))
+            return
+        }
+    }
+    Fail("BookValuePerShare not found in FieldMappings")
+})
+
+It("TangibleAssetsBookValuePerShare uses WeightedAverageShares as denominator", func() {
+    for _, m := range FieldMappings {
+        if m.FieldName == "TangibleAssetsBookValuePerShare" {
+            Expect(m.Operands).To(Equal([]string{"TangibleAssetValue", "WeightedAverageShares"}))
+            return
+        }
+    }
+    Fail("TangibleAssetsBookValuePerShare not found in FieldMappings")
+})
+
+It("all OpDivide float64 fields have RoundDigits set", func() {
+    for _, m := range FieldMappings {
+        if m.Type == MappingDerived && m.Op == OpDivide && m.ValueType == "float64" {
+            Expect(m.RoundDigits).To(BeNumerically(">", 0),
+                "derived OpDivide float64 field %s should have RoundDigits set", m.FieldName)
+        }
+    }
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "BookValuePerShare uses|TangibleAssetsBookValuePerShare uses|all OpDivide float64" ./provider/sec/`
+
+Expected: FAIL -- BookValuePerShare still uses SharesBasic, RoundDigits is 0
+
+- [ ] **Step 3: Fix denominators and set RoundDigits on all OpDivide float64 fields**
+
+In `provider/sec/mapping_config.go`, update these 11 field definitions:
+
+Replace the GrossMargin block (lines 598-603):
+```go
+// GrossMargin = GrossProfit / Revenues
+{
+    FieldName: "GrossMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"GrossProfit", "Revenues"},
+    RoundDigits: 4,
+},
+```
+
+Replace the ProfitMargin block (lines 604-609):
+```go
+// ProfitMargin = NetIncomeCommonStock / Revenues
+{
+    FieldName: "ProfitMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"NetIncomeCommonStock", "Revenues"},
+    RoundDigits: 4,
+},
+```
+
+Replace the EBITDAMargin block (lines 610-615):
+```go
+// EBITDAMargin = EBITDA / Revenues
+{
+    FieldName: "EBITDAMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"EBITDA", "Revenues"},
+    RoundDigits: 4,
+},
+```
+
+Replace the CurrentRatio block (lines 616-621):
+```go
+// CurrentRatio = CurrentAssets / CurrentLiabilities
+{
+    FieldName: "CurrentRatio", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"CurrentAssets", "CurrentLiabilities"},
+    RoundDigits: 4,
+},
+```
+
+Replace the DebtToEquityRatio block (lines 622-627):
+```go
+// DebtToEquityRatio = TotalDebt / Equity
+{
+    FieldName: "DebtToEquityRatio", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"TotalDebt", "Equity"},
+    RoundDigits: 4,
+},
+```
+
+Replace the AssetTurnover block (lines 628-633):
+```go
+// AssetTurnover = Revenues / TotalAssets
+{
+    FieldName: "AssetTurnover", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"Revenues", "TotalAssets"},
+    RoundDigits: 4,
+},
+```
+
+Replace the ReturnOnSales block (lines 634-639):
+```go
+// ReturnOnSales = EBIT / Revenues
+{
+    FieldName: "ReturnOnSales", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"EBIT", "Revenues"},
+    RoundDigits: 4,
+},
+```
+
+Replace the FreeCashFlowPerShare block (lines 643-648):
+```go
+// FreeCashFlowPerShare = FreeCashFlow / WeightedAverageShares
+{
+    FieldName: "FreeCashFlowPerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"FreeCashFlow", "WeightedAverageShares"},
+    RoundDigits: 4,
+},
+```
+
+Replace the BookValuePerShare block (lines 649-654) -- **denominator changes from SharesBasic to WeightedAverageShares**:
+```go
+// BookValuePerShare = Equity / WeightedAverageShares
+{
+    FieldName: "BookValuePerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"Equity", "WeightedAverageShares"},
+    RoundDigits: 4,
+},
+```
+
+Replace the SalesPerShare block (lines 655-660):
+```go
+// SalesPerShare = Revenues / WeightedAverageShares
+{
+    FieldName: "SalesPerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"Revenues", "WeightedAverageShares"},
+    RoundDigits: 4,
+},
+```
+
+Replace the TangibleAssetsBookValuePerShare block (lines 661-666) -- **denominator changes from SharesBasic to WeightedAverageShares**:
+```go
+// TangibleAssetsBookValuePerShare = TangibleAssetValue / WeightedAverageShares
+{
+    FieldName: "TangibleAssetsBookValuePerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
+    Op:       OpDivide,
+    Operands: []string{"TangibleAssetValue", "WeightedAverageShares"},
+    RoundDigits: 4,
+},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race --focus "BookValuePerShare uses|TangibleAssetsBookValuePerShare uses|all OpDivide float64" ./provider/sec/`
+
+Expected: PASS (all 3 specs)
+
+- [ ] **Step 5: Run the full test suite to check for regressions**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && ginkgo run -race ./provider/sec/`
+
+Expected: PASS -- existing tests should still pass. The rounding may cause small value changes in tests that check exact derived float values. If any test fails due to rounding, update the expected value to the rounded result.
+
+- [ ] **Step 6: Run lint**
+
+Run: `cd /Users/jdf/Developer/penny-vault/pv-data && golangci-lint run --fix ./provider/sec/...`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add provider/sec/mapping_config.go provider/sec/mapping_test.go
+git commit -m "feat(sec): fix per-share denominators and add rounding to derived float64 fields (#44)"
+```

--- a/docs/superpowers/specs/2026-04-12-sec-market-data-fields-design.md
+++ b/docs/superpowers/specs/2026-04-12-sec-market-data-fields-design.md
@@ -1,0 +1,89 @@
+# SEC: Compute market-data fields from EOD table
+
+**Issue:** #38
+
+## Problem
+
+The SEC provider leaves 14 fields at zero because they require market price data not available in the SEC XBRL companyfacts API. The EOD table already has the price data needed to compute them.
+
+## Approach
+
+Enrich during the SEC provider's Fetch function. A new `enrichMarketData` function is called from `emitFundamentals()` after all observations for a company are built but before they're sent to the output channel. It looks up EOD close prices from the published `eod` view and computes the derived fields.
+
+The function needs all dimensions for a given (composite_figi, date_key) at once so it can copy ratio fields from trailing to quarterly dimensions.
+
+## EOD price lookup
+
+- Source: the published `eod` view
+- Price = unadjusted `close` (not `adj_close`)
+- Date matching: most recent trading day on or before `event_date` (verified against Sharadar -- e.g., event_date Saturday 2024-12-28 uses Friday 2024-12-27 close)
+- If no EOD row is found within a reasonable lookback window (5 trading days), leave price at zero
+
+## Formulas
+
+All formulas verified against Sharadar data for AAPL and MSFT.
+
+### Computed for all dimensions
+
+| Field | Formula |
+|---|---|
+| `price` | EOD close on or before event_date |
+| `market_capitalization` | price * shares_basic |
+| `enterprise_value` | market_cap + total_debt - cash_and_equivalents |
+| `pb` | market_cap / equity |
+| `share_factor` | 1.0 |
+| `fx_usd` | 1.0 |
+
+### Computed for trailing/annual dimensions (ART, MRT, ARY, MRY)
+
+These use the record's own flow/TTM values. For quarterly dimensions (ARQ, MRQ), copy from the corresponding trailing dimension (ART, MRT) since they share the same event_date and therefore the same price/market_cap.
+
+| Field | Formula |
+|---|---|
+| `pe` | market_cap / net_income_common_stock |
+| `ps` | market_cap / revenues |
+| `pe1` | price / eps (basic EPS, not diluted) |
+| `ps1` | price / sales_per_share |
+| `ev_to_ebit` | round(enterprise_value / ebit) |
+| `ev_to_ebitda` | enterprise_value / ebitda |
+| `dividend_yield` | dividends_per_basic_common_share / price |
+| `payout_ratio` | dividends_per_basic_common_share / eps_diluted |
+
+### Division by zero
+
+When a denominator is zero (e.g., net_income_common_stock = 0), leave the ratio at zero.
+
+### pe1 note
+
+pe1 uses basic EPS (`eps` field), not diluted EPS (`eps_diluted`). Verified empirically: `price / eps` matches Sharadar's pe1 exactly across AAPL and MSFT for all trailing/annual dimensions. `price / eps_diluted` does not match.
+
+## Pipeline integration
+
+`emitFundamentals()` currently builds observations and sends them to the output channel one at a time. To enrich, we need to:
+
+1. Buffer all observations for a company before sending
+2. Group by (composite_figi, date_key) to find trailing/quarterly pairs
+3. For each group: look up EOD price, compute fields on trailing/annual dims, copy to quarterly dims
+4. Send all enriched observations to the output channel
+
+The enrichment function needs a database connection to query the EOD view. The `*library.Subscription` already carries `Library.Pool` which provides DB access. The published `eod` view name needs to be discovered -- query `published_views` for the view with `data_type_key = 'eod'`.
+
+If no published `eod` view exists (e.g., fresh install with no EOD subscription), skip enrichment and log a warning. The fundamentals are still valid, just without market-data fields.
+
+## Files modified
+
+- `provider/sec/market_data.go` -- new file with `enrichMarketData` function and helpers
+- `provider/sec/market_data_test.go` -- unit tests with synthetic data
+- `provider/sec/sec.go` -- modify `emitFundamentals()` to buffer observations and call enrichment
+
+## Testing
+
+Unit tests with synthetic data (no real database). Mock the EOD price lookup by accepting a function parameter or interface.
+
+Test cases:
+1. All 14 fields computed correctly for an ART record with known price and fundamentals
+2. Quarterly dims (ARQ, MRQ) get ratio fields copied from trailing dims (ART, MRT)
+3. PB computed independently for quarterly dims (uses own equity, not trailing)
+4. Division by zero leaves ratio at zero
+5. Missing EOD price leaves all market-data fields at zero
+6. pe1 uses basic EPS, not diluted

--- a/docs/superpowers/specs/2026-04-12-sec-rounding-match-design.md
+++ b/docs/superpowers/specs/2026-04-12-sec-rounding-match-design.md
@@ -1,0 +1,57 @@
+# SEC: Reduce Rounding Differences vs Sharadar
+
+**Issue:** #44
+**Date:** 2026-04-12
+
+## Problem
+
+`BookValuePerShare` and `TangibleAssetsBookValuePerShare` use `SharesBasic` (point-in-time shares outstanding) as their denominator, but Sharadar computes them as `value / (SharesWA * ShareFactor)`. For standard US equities where `ShareFactor = 1.0`, this means the denominator should be `WeightedAverageShares`.
+
+Additionally, all derived `OpDivide` float64 fields (per-share metrics and ratio metrics) produce full-precision float64 results, while Sharadar delivers values rounded to a fixed number of decimal places. This causes sub-1% comparison diffs even when the formulas and underlying integers agree.
+
+## Changes
+
+### 1. Fix denominators
+
+| Field | Current formula | Corrected formula |
+|---|---|---|
+| `BookValuePerShare` | `Equity / SharesBasic` | `Equity / WeightedAverageShares` |
+| `TangibleAssetsBookValuePerShare` | `TangibleAssetValue / SharesBasic` | `TangibleAssetValue / WeightedAverageShares` |
+
+In `mapping_config.go`, change the second operand from `"SharesBasic"` to `"WeightedAverageShares"` for both fields.
+
+### 2. Add rounding to derived float64 fields
+
+Add an optional `RoundDigits int` field to the `FieldMapping` struct. When `RoundDigits > 0`, `computeDerived` rounds the division result:
+
+```go
+result = math.Round(result * math.Pow(10, float64(m.RoundDigits))) / math.Pow(10, float64(m.RoundDigits))
+```
+
+Set `RoundDigits` on all `OpDivide` fields that produce `float64` values:
+
+- Per-share metrics: `BookValuePerShare`, `FreeCashFlowPerShare`, `SalesPerShare`, `TangibleAssetsBookValuePerShare`
+- Ratio metrics: `GrossMargin`, `ProfitMargin`, `EBITDAMargin`, `CurrentRatio`, `DebtToEquityRatio`, `AssetTurnover`, `ReturnOnSales`
+
+The exact digit count will be determined by inspecting actual Sharadar values. Based on issue examples (`4.816`, `0.466`, `0.26`), 4 decimal places is the likely target.
+
+### 3. Testing
+
+Update existing unit tests for `computeDerived` and `BuildFundamental` to verify:
+
+- `BookValuePerShare` uses `WeightedAverageShares` as its denominator
+- `TangibleAssetsBookValuePerShare` uses `WeightedAverageShares` as its denominator
+- Rounding is applied when `RoundDigits > 0` (e.g., `1.23456` with `RoundDigits=4` produces `1.2346`)
+- Rounding is not applied when `RoundDigits` is 0 (default zero value)
+
+## Files changed
+
+- `provider/sec/mapping_config.go` -- denominator swap + `RoundDigits` field on struct + values on each OpDivide mapping
+- `provider/sec/mapping.go` -- rounding logic in `computeDerived`
+- `provider/sec/*_test.go` -- updated tests
+
+## Out of scope
+
+- `ShareFactor` computation (not derivable from SEC filings alone)
+- XBRL tag selection changes for margins or shares_basic
+- Tolerance adjustment in `compare-fundamentals`

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -16,6 +16,7 @@
 package sec
 
 import (
+	"math"
 	"time"
 )
 
@@ -285,7 +286,14 @@ func computeDerived(m FieldMapping, resolved map[string]float64) (float64, bool)
 			return 0, false
 		}
 
-		return vals[0] / vals[1], true
+		result := vals[0] / vals[1]
+
+		if m.RoundDigits > 0 {
+			pow := math.Pow(10, float64(m.RoundDigits))
+			result = math.Round(result*pow) / pow
+		}
+
+		return result, true
 
 	case OpLinearCombination:
 		if len(vals) != len(m.Coefficients) {

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -611,49 +611,49 @@ var FieldMappings = []FieldMapping{
 		FieldName: "GrossMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"GrossProfit", "Revenues"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// ProfitMargin = NetIncomeCommonStock / Revenues
 	{
 		FieldName: "ProfitMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"NetIncomeCommonStock", "Revenues"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// EBITDAMargin = EBITDA / Revenues
 	{
 		FieldName: "EBITDAMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"EBITDA", "Revenues"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// CurrentRatio = CurrentAssets / CurrentLiabilities
 	{
 		FieldName: "CurrentRatio", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"CurrentAssets", "CurrentLiabilities"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// DebtToEquityRatio = TotalLiabilities / Equity
 	{
 		FieldName: "DebtToEquityRatio", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"TotalLiabilities", "Equity"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// AssetTurnover = Revenues / TotalAssets
 	{
 		FieldName: "AssetTurnover", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"Revenues", "TotalAssets"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// ReturnOnSales = EBIT / Revenues
 	{
 		FieldName: "ReturnOnSales", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"EBIT", "Revenues"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 
 	// ==================== PER-SHARE METRICS (derived) ====================
@@ -663,28 +663,28 @@ var FieldMappings = []FieldMapping{
 		FieldName: "FreeCashFlowPerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"FreeCashFlow", "WeightedAverageShares"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// BookValuePerShare = Equity / WeightedAverageShares
 	{
 		FieldName: "BookValuePerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"Equity", "WeightedAverageShares"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// SalesPerShare = Revenues / WeightedAverageShares
 	{
 		FieldName: "SalesPerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"Revenues", "WeightedAverageShares"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 	// TangibleAssetsBookValuePerShare = TangibleAssetValue / WeightedAverageShares
 	{
 		FieldName: "TangibleAssetsBookValuePerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
 		Op:          OpDivide,
 		Operands:    []string{"TangibleAssetValue", "WeightedAverageShares"},
-		RoundDigits: 4,
+		RoundDigits: 3,
 	},
 
 	// Note: The following Sharadar fields require market price data and are

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -68,6 +68,10 @@ type FieldMapping struct {
 	// OptionalOperands makes OpAdd treat missing operands as 0 and resolve
 	// when at least one operand is present, instead of requiring all.
 	OptionalOperands bool
+
+	// RoundDigits rounds OpDivide results to this many decimal places.
+	// Zero (the default) means no rounding.
+	RoundDigits int
 }
 
 // FieldMappings defines the complete mapping from XBRL to data.Fundamental fields.

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -609,44 +609,51 @@ var FieldMappings = []FieldMapping{
 	// GrossMargin = GrossProfit / Revenues
 	{
 		FieldName: "GrossMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"GrossProfit", "Revenues"},
+		Op:          OpDivide,
+		Operands:    []string{"GrossProfit", "Revenues"},
+		RoundDigits: 4,
 	},
 	// ProfitMargin = NetIncomeCommonStock / Revenues
 	{
 		FieldName: "ProfitMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"NetIncomeCommonStock", "Revenues"},
+		Op:          OpDivide,
+		Operands:    []string{"NetIncomeCommonStock", "Revenues"},
+		RoundDigits: 4,
 	},
 	// EBITDAMargin = EBITDA / Revenues
 	{
 		FieldName: "EBITDAMargin", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"EBITDA", "Revenues"},
+		Op:          OpDivide,
+		Operands:    []string{"EBITDA", "Revenues"},
+		RoundDigits: 4,
 	},
 	// CurrentRatio = CurrentAssets / CurrentLiabilities
 	{
 		FieldName: "CurrentRatio", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"CurrentAssets", "CurrentLiabilities"},
+		Op:          OpDivide,
+		Operands:    []string{"CurrentAssets", "CurrentLiabilities"},
+		RoundDigits: 4,
 	},
 	// DebtToEquityRatio = TotalLiabilities / Equity
 	{
 		FieldName: "DebtToEquityRatio", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"TotalLiabilities", "Equity"},
+		Op:          OpDivide,
+		Operands:    []string{"TotalLiabilities", "Equity"},
+		RoundDigits: 4,
 	},
 	// AssetTurnover = Revenues / TotalAssets
 	{
 		FieldName: "AssetTurnover", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"Revenues", "TotalAssets"},
+		Op:          OpDivide,
+		Operands:    []string{"Revenues", "TotalAssets"},
+		RoundDigits: 4,
 	},
 	// ReturnOnSales = EBIT / Revenues
 	{
 		FieldName: "ReturnOnSales", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"EBIT", "Revenues"},
+		Op:          OpDivide,
+		Operands:    []string{"EBIT", "Revenues"},
+		RoundDigits: 4,
 	},
 
 	// ==================== PER-SHARE METRICS (derived) ====================
@@ -654,26 +661,30 @@ var FieldMappings = []FieldMapping{
 	// FreeCashFlowPerShare = FreeCashFlow / WeightedAverageShares
 	{
 		FieldName: "FreeCashFlowPerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"FreeCashFlow", "WeightedAverageShares"},
+		Op:          OpDivide,
+		Operands:    []string{"FreeCashFlow", "WeightedAverageShares"},
+		RoundDigits: 4,
 	},
-	// BookValuePerShare = Equity / SharesBasic
+	// BookValuePerShare = Equity / WeightedAverageShares
 	{
 		FieldName: "BookValuePerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"Equity", "SharesBasic"},
+		Op:          OpDivide,
+		Operands:    []string{"Equity", "WeightedAverageShares"},
+		RoundDigits: 4,
 	},
 	// SalesPerShare = Revenues / WeightedAverageShares
 	{
 		FieldName: "SalesPerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"Revenues", "WeightedAverageShares"},
+		Op:          OpDivide,
+		Operands:    []string{"Revenues", "WeightedAverageShares"},
+		RoundDigits: 4,
 	},
-	// TangibleAssetsBookValuePerShare = TangibleAssetValue / SharesBasic
+	// TangibleAssetsBookValuePerShare = TangibleAssetValue / WeightedAverageShares
 	{
 		FieldName: "TangibleAssetsBookValuePerShare", Type: MappingDerived, StatementType: StmtMetric, ValueType: "float64",
-		Op:       OpDivide,
-		Operands: []string{"TangibleAssetValue", "SharesBasic"},
+		Op:          OpDivide,
+		Operands:    []string{"TangibleAssetValue", "WeightedAverageShares"},
+		RoundDigits: 4,
 	},
 
 	// Note: The following Sharadar fields require market price data and are

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -83,6 +83,37 @@ var _ = Describe("Mapping Config", func() {
 				"mapping %s has invalid statement type: %s", m.FieldName, m.StatementType)
 		}
 	})
+
+	It("BookValuePerShare uses WeightedAverageShares as denominator", func() {
+		for _, m := range FieldMappings {
+			if m.FieldName == "BookValuePerShare" {
+				Expect(m.Operands).To(Equal([]string{"Equity", "WeightedAverageShares"}))
+				return
+			}
+		}
+
+		Fail("BookValuePerShare not found in FieldMappings")
+	})
+
+	It("TangibleAssetsBookValuePerShare uses WeightedAverageShares as denominator", func() {
+		for _, m := range FieldMappings {
+			if m.FieldName == "TangibleAssetsBookValuePerShare" {
+				Expect(m.Operands).To(Equal([]string{"TangibleAssetValue", "WeightedAverageShares"}))
+				return
+			}
+		}
+
+		Fail("TangibleAssetsBookValuePerShare not found in FieldMappings")
+	})
+
+	It("all OpDivide float64 fields have RoundDigits set", func() {
+		for _, m := range FieldMappings {
+			if m.Type == MappingDerived && m.Op == OpDivide && m.ValueType == "float64" {
+				Expect(m.RoundDigits).To(BeNumerically(">", 0),
+					"derived OpDivide float64 field %s should have RoundDigits set", m.FieldName)
+			}
+		}
+	})
 })
 
 var _ = Describe("Mapping Engine", func() {

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -260,6 +260,58 @@ var _ = Describe("Mapping Engine", func() {
 		})
 	})
 
+	Describe("computeDerived rounding", func() {
+		It("rounds division result when RoundDigits is set", func() {
+			resolved := map[string]float64{
+				"A": 100,
+				"B": 3,
+			}
+			m := FieldMapping{
+				FieldName:   "Ratio",
+				Type:        MappingDerived,
+				Op:          OpDivide,
+				Operands:    []string{"A", "B"},
+				RoundDigits: 4,
+			}
+			val, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(33.3333))
+		})
+
+		It("does not round when RoundDigits is zero", func() {
+			resolved := map[string]float64{
+				"A": 100,
+				"B": 3,
+			}
+			m := FieldMapping{
+				FieldName: "Ratio",
+				Type:      MappingDerived,
+				Op:        OpDivide,
+				Operands:  []string{"A", "B"},
+			}
+			val, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(100.0 / 3.0))
+		})
+
+		It("rounds to 3 decimal places", func() {
+			resolved := map[string]float64{
+				"A": 74_236_000_000,
+				"B": 15_408_095_000,
+			}
+			m := FieldMapping{
+				FieldName:   "BVPS",
+				Type:        MappingDerived,
+				Op:          OpDivide,
+				Operands:    []string{"A", "B"},
+				RoundDigits: 3,
+			}
+			val, ok := computeDerived(m, resolved)
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(4.818))
+		})
+	})
+
 	Describe("ResolveAllFields", func() {
 		It("resolves both direct and derived fields", func() {
 			periodEnd := time.Date(2018, 9, 29, 0, 0, 0, 0, time.UTC)

--- a/provider/sec/synthesize_q4_test.go
+++ b/provider/sec/synthesize_q4_test.go
@@ -170,9 +170,9 @@ var _ = Describe("SynthesizeQ4", func() {
 			Expect(arResult["Revenues"]).To(BeNumerically("~", 170, 0.001))
 			// Q4 GrossProfit = 225 - (45+55+50) = 75
 			Expect(arResult["GrossProfit"]).To(BeNumerically("~", 75, 0.001))
-			// Q4 GrossMargin = GrossProfit / Revenues = 75 / 170 ≈ 0.4412
-			Expect(arResult["GrossMargin"]).To(BeNumerically("~", 75.0/170.0, 0.0001))
-			Expect(mrResult["GrossMargin"]).To(BeNumerically("~", 75.0/170.0, 0.0001))
+			// Q4 GrossMargin = GrossProfit / Revenues = 75 / 170 ≈ 0.441 (rounded to 3 decimal places)
+			Expect(arResult["GrossMargin"]).To(Equal(0.441))
+			Expect(mrResult["GrossMargin"]).To(Equal(0.441))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Fix `BookValuePerShare` and `TangibleAssetsBookValuePerShare` denominators from `SharesBasic` to `WeightedAverageShares` to match Sharadar's documented formula
- Add `RoundDigits` field to `FieldMapping` struct so derived `OpDivide` float64 fields can be rounded to a fixed number of decimal places
- Set `RoundDigits: 3` on all 11 `OpDivide` float64 fields (7 ratios + 4 per-share metrics) to match Sharadar's 3-decimal-place precision

## Results

Verified with `compare-fundamentals --ticker AAPL --dimension ARQ`: 5 of 6 fields from issue #44 now produce exact matches (book_value_per_share, gross_margin, profit_margin, ebitda_margin, free_cash_flow_per_share). The remaining diff (tangible_assets_book_value_per_share=0) is a missing XBRL tag issue, not rounding.

## Test plan

- [x] 108/108 specs pass (`ginkgo run -race ./provider/sec/`)
- [x] SEC subscription runs successfully for AAPL (292 observations, 0 errors)
- [x] `compare-fundamentals` confirms margin and per-share diffs eliminated
- [x] Lint clean (`golangci-lint run --fix`)

Closes #44