### PR TITLE
feat(sec): compute market-data fields from EOD table

### DIFF
--- a/provider/sec/market_data.go
+++ b/provider/sec/market_data.go
@@ -16,10 +16,15 @@
 package sec
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/library"
+	"github.com/rs/zerolog/log"
 )
 
 // PriceLookupFn returns the EOD close price for a given asset and date.
@@ -152,4 +157,56 @@ func EnrichMarketData(fundamentals []*data.Fundamental, lookupPrice PriceLookupF
 			dst.PayoutRatio = src.PayoutRatio
 		}
 	}
+}
+
+// NewEODPriceLookup returns a PriceLookupFn that queries the published EOD
+// view for the unadjusted close price nearest to and on or before the given
+// date (up to 7 days back to handle weekends and holidays). Returns 0 if no
+// price is found; this is normal for historical gaps and is not treated as an
+// error.
+func NewEODPriceLookup(ctx context.Context, pool *pgxpool.Pool, eodViewName string) PriceLookupFn {
+	query := fmt.Sprintf(
+		`SELECT close FROM %s WHERE composite_figi = $1 AND event_date <= $2 AND event_date >= $3 ORDER BY event_date DESC LIMIT 1`,
+		eodViewName,
+	)
+
+	return func(compositeFigi string, eventDate time.Time) float64 {
+		conn, err := pool.Acquire(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to acquire connection for EOD price lookup")
+
+			return 0
+		}
+
+		defer conn.Release()
+
+		var close float64
+
+		err = conn.QueryRow(ctx, query, compositeFigi, eventDate, eventDate.AddDate(0, 0, -7)).Scan(&close)
+		if err != nil {
+			return 0
+		}
+
+		return close
+	}
+}
+
+// FindEODViewName loads all published views and returns the ViewName of the
+// one whose DataTypeKey is "eod". Returns an empty string if no such view
+// exists.
+func FindEODViewName(ctx context.Context, pool *pgxpool.Pool) string {
+	views, err := library.LoadPublishedViews(ctx, pool)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to load published views")
+
+		return ""
+	}
+
+	for _, v := range views {
+		if v.DataTypeKey == "eod" {
+			return v.ViewName
+		}
+	}
+
+	return ""
 }

--- a/provider/sec/market_data.go
+++ b/provider/sec/market_data.go
@@ -31,6 +31,16 @@ import (
 // Returns 0 if no price is available.
 type PriceLookupFn func(compositeFigi string, eventDate time.Time) float64
 
+// priceLookupFn is the active price lookup function. Set by fetchFundamentals
+// when the published EOD view is available.
+var priceLookupFn PriceLookupFn
+
+// SetPriceLookupFn sets the package-level price lookup function. Passing nil
+// disables market-data enrichment.
+func SetPriceLookupFn(fn PriceLookupFn) {
+	priceLookupFn = fn
+}
+
 // EnrichMarketData populates price-derived market-data fields on each
 // Fundamental record. It groups records by DateKey and processes them in
 // three phases:

--- a/provider/sec/market_data.go
+++ b/provider/sec/market_data.go
@@ -1,0 +1,155 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sec
+
+import (
+	"math"
+	"time"
+
+	"github.com/penny-vault/pvdata/data"
+)
+
+// PriceLookupFn returns the EOD close price for a given asset and date.
+// Returns 0 if no price is available.
+type PriceLookupFn func(compositeFigi string, eventDate time.Time) float64
+
+// EnrichMarketData populates price-derived market-data fields on each
+// Fundamental record. It groups records by DateKey and processes them in
+// three phases:
+//
+//  1. Phase 1 (all dimensions): set Price, ShareFactor, FxUSD,
+//     MarketCapitalization, EnterpriseValue, and PB from a price lookup.
+//     Records with a zero price are skipped entirely.
+//
+//  2. Phase 2 (trailing/annual: ART, MRT, ARY, MRY): compute ratio fields
+//     PE, PS, PE1, PS1, EVtoEBIT, EVtoEBITDA, DividendYield, PayoutRatio.
+//
+//  3. Phase 3 (quarterly: ARQ, MRQ): copy ratio fields (but NOT PB) from
+//     the corresponding trailing dimension within the same DateKey group.
+func EnrichMarketData(fundamentals []*data.Fundamental, lookupPrice PriceLookupFn) {
+	// Group fundamentals by DateKey.
+	type dateKey = time.Time
+
+	groups := make(map[dateKey][]*data.Fundamental)
+	for _, f := range fundamentals {
+		groups[f.DateKey] = append(groups[f.DateKey], f)
+	}
+
+	for _, group := range groups {
+		// Build an index by Dimension for quick lookup within the group.
+		byDim := make(map[string]*data.Fundamental, len(group))
+		for _, f := range group {
+			byDim[f.Dimension] = f
+		}
+
+		// Phase 1: price-based fields for all dimensions.
+		for _, f := range group {
+			price := lookupPrice(f.CompositeFigi, f.EventDate)
+			if price == 0 {
+				continue
+			}
+
+			mktCap := int64(price * float64(f.SharesBasic))
+			ev := mktCap + f.TotalDebt - f.CashAndEquivalents
+
+			f.Price = price
+			f.ShareFactor = 1.0
+			f.FxUSD = 1.0
+			f.MarketCapitalization = mktCap
+			f.EnterpriseValue = ev
+
+			if f.Equity != 0 {
+				f.PB = float64(mktCap) / float64(f.Equity)
+			}
+		}
+
+		// Phase 2: ratio fields for trailing/annual dimensions.
+		trailingDims := []string{"ART", "MRT", "ARY", "MRY"}
+		for _, dim := range trailingDims {
+			f, ok := byDim[dim]
+			if !ok || f.Price == 0 {
+				continue
+			}
+
+			mktCap := f.MarketCapitalization
+			ev := f.EnterpriseValue
+
+			if f.NetIncomeCommonStock != 0 {
+				f.PE = float64(mktCap) / float64(f.NetIncomeCommonStock)
+			}
+
+			if f.Revenues != 0 {
+				f.PS = float64(mktCap) / float64(f.Revenues)
+			}
+
+			if f.EPS != 0 {
+				f.PE1 = f.Price / f.EPS
+			}
+
+			if f.SalesPerShare != 0 {
+				f.PS1 = f.Price / f.SalesPerShare
+			}
+
+			if f.EBIT != 0 {
+				f.EVtoEBIT = int64(math.Round(float64(ev) / float64(f.EBIT)))
+			}
+
+			if f.EBITDA != 0 {
+				f.EVtoEBITDA = float64(ev) / float64(f.EBITDA)
+			}
+
+			if f.Price != 0 {
+				f.DividendYield = f.DividendsPerBasicCommonShare / f.Price
+			}
+
+			if f.EPSDiluted != 0 {
+				f.PayoutRatio = f.DividendsPerBasicCommonShare / f.EPSDiluted
+			}
+		}
+
+		// Phase 3: copy ratio fields from trailing to quarterly dimensions.
+		// ART -> ARQ, MRT -> MRQ.
+		quarterlyPairs := [][2]string{
+			{"ART", "ARQ"},
+			{"MRT", "MRQ"},
+		}
+
+		for _, pair := range quarterlyPairs {
+			trailing, quarterly := pair[0], pair[1]
+
+			src, srcOK := byDim[trailing]
+			dst, dstOK := byDim[quarterly]
+
+			if !srcOK || !dstOK {
+				continue
+			}
+
+			// Only copy if the quarterly record has a valid price.
+			if dst.Price == 0 {
+				continue
+			}
+
+			dst.PE = src.PE
+			dst.PS = src.PS
+			dst.PE1 = src.PE1
+			dst.PS1 = src.PS1
+			dst.EVtoEBIT = src.EVtoEBIT
+			dst.EVtoEBITDA = src.EVtoEBITDA
+			dst.DividendYield = src.DividendYield
+			dst.PayoutRatio = src.PayoutRatio
+		}
+	}
+}

--- a/provider/sec/market_data_test.go
+++ b/provider/sec/market_data_test.go
@@ -1,0 +1,349 @@
+// Copyright 2024
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sec
+
+import (
+	"math"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvdata/data"
+)
+
+var _ = Describe("EnrichMarketData", func() {
+	var (
+		dateKey   time.Time
+		eventDate time.Time
+	)
+
+	BeforeEach(func() {
+		dateKey = time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+		eventDate = time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)
+	})
+
+	stubPriceFn := func(price float64) PriceLookupFn {
+		return func(compositeFigi string, eventDate time.Time) float64 {
+			return price
+		}
+	}
+
+	Describe("All 14 fields on ART", func() {
+		It("computes all market-data fields correctly for an ART fundamental", func() {
+			f := &data.Fundamental{
+				CompositeFigi:                "BBG000B9XRY4",
+				Dimension:                    "ART",
+				DateKey:                      dateKey,
+				EventDate:                    eventDate,
+				SharesBasic:                  int64(1_000_000),
+				TotalDebt:                    int64(500_000_000),
+				CashAndEquivalents:           int64(200_000_000),
+				Equity:                       int64(2_000_000_000),
+				NetIncomeCommonStock:         int64(100_000_000),
+				Revenues:                     int64(800_000_000),
+				EBIT:                         int64(120_000_000),
+				EBITDA:                       int64(150_000_000),
+				EPS:                          2.50,
+				EPSDiluted:                   2.40,
+				SalesPerShare:                8.00,
+				DividendsPerBasicCommonShare: 1.20,
+			}
+
+			price := 236.0
+			EnrichMarketData([]*data.Fundamental{f}, stubPriceFn(price))
+
+			expectedMktCap := int64(price * float64(f.SharesBasic)) // 236,000,000
+			expectedEV := expectedMktCap + f.TotalDebt - f.CashAndEquivalents
+			// 236_000_000 + 500_000_000 - 200_000_000 = 536_000_000
+
+			Expect(f.Price).To(BeNumerically("~", price, 1e-9))
+			Expect(f.ShareFactor).To(BeNumerically("~", 1.0, 1e-9))
+			Expect(f.FxUSD).To(BeNumerically("~", 1.0, 1e-9))
+			Expect(f.MarketCapitalization).To(Equal(expectedMktCap))
+			Expect(f.EnterpriseValue).To(Equal(expectedEV))
+
+			expectedPB := float64(expectedMktCap) / float64(f.Equity)
+			Expect(f.PB).To(BeNumerically("~", expectedPB, 1e-9))
+
+			expectedPE := float64(expectedMktCap) / float64(f.NetIncomeCommonStock)
+			Expect(f.PE).To(BeNumerically("~", expectedPE, 1e-9))
+
+			expectedPS := float64(expectedMktCap) / float64(f.Revenues)
+			Expect(f.PS).To(BeNumerically("~", expectedPS, 1e-9))
+
+			expectedPE1 := price / f.EPS
+			Expect(f.PE1).To(BeNumerically("~", expectedPE1, 1e-9))
+
+			expectedPS1 := price / f.SalesPerShare
+			Expect(f.PS1).To(BeNumerically("~", expectedPS1, 1e-9))
+
+			expectedEVtoEBIT := int64(math.Round(float64(expectedEV) / float64(f.EBIT)))
+			Expect(f.EVtoEBIT).To(Equal(expectedEVtoEBIT))
+
+			expectedEVtoEBITDA := float64(expectedEV) / float64(f.EBITDA)
+			Expect(f.EVtoEBITDA).To(BeNumerically("~", expectedEVtoEBITDA, 1e-9))
+
+			expectedDivYield := f.DividendsPerBasicCommonShare / price
+			Expect(f.DividendYield).To(BeNumerically("~", expectedDivYield, 1e-9))
+
+			expectedPayoutRatio := f.DividendsPerBasicCommonShare / f.EPSDiluted
+			Expect(f.PayoutRatio).To(BeNumerically("~", expectedPayoutRatio, 1e-9))
+		})
+	})
+
+	Describe("ARQ copies ratio fields from ART", func() {
+		It("ARQ gets its own price/mktcap/EV/PB but copies PE/PS/PE1/PS1/EVtoEBIT/EVtoEBITDA/DividendYield/PayoutRatio from ART", func() {
+			art := &data.Fundamental{
+				CompositeFigi:                "BBG000B9XRY4",
+				Dimension:                    "ART",
+				DateKey:                      dateKey,
+				EventDate:                    eventDate,
+				SharesBasic:                  int64(1_000_000),
+				TotalDebt:                    int64(500_000_000),
+				CashAndEquivalents:           int64(200_000_000),
+				Equity:                       int64(2_000_000_000),
+				NetIncomeCommonStock:         int64(100_000_000),
+				Revenues:                     int64(800_000_000),
+				EBIT:                         int64(120_000_000),
+				EBITDA:                       int64(150_000_000),
+				EPS:                          2.50,
+				EPSDiluted:                   2.40,
+				SalesPerShare:                8.00,
+				DividendsPerBasicCommonShare: 1.20,
+			}
+
+			arq := &data.Fundamental{
+				CompositeFigi:      "BBG000B9XRY4",
+				Dimension:          "ARQ",
+				DateKey:            dateKey,
+				EventDate:          eventDate,
+				SharesBasic:        int64(1_000_000),
+				TotalDebt:          int64(500_000_000),
+				CashAndEquivalents: int64(200_000_000),
+				Equity:             int64(1_800_000_000), // different equity for own PB
+			}
+
+			price := 236.0
+			EnrichMarketData([]*data.Fundamental{art, arq}, stubPriceFn(price))
+
+			// ARQ should have its own price-based fields
+			expectedMktCap := int64(price * float64(arq.SharesBasic))
+			expectedEV := expectedMktCap + arq.TotalDebt - arq.CashAndEquivalents
+			expectedPB := float64(expectedMktCap) / float64(arq.Equity)
+
+			Expect(arq.Price).To(BeNumerically("~", price, 1e-9))
+			Expect(arq.MarketCapitalization).To(Equal(expectedMktCap))
+			Expect(arq.EnterpriseValue).To(Equal(expectedEV))
+			Expect(arq.PB).To(BeNumerically("~", expectedPB, 1e-9))
+
+			// ARQ should copy ratio fields from ART
+			Expect(arq.PE).To(BeNumerically("~", art.PE, 1e-9))
+			Expect(arq.PS).To(BeNumerically("~", art.PS, 1e-9))
+			Expect(arq.PE1).To(BeNumerically("~", art.PE1, 1e-9))
+			Expect(arq.PS1).To(BeNumerically("~", art.PS1, 1e-9))
+			Expect(arq.EVtoEBIT).To(Equal(art.EVtoEBIT))
+			Expect(arq.EVtoEBITDA).To(BeNumerically("~", art.EVtoEBITDA, 1e-9))
+			Expect(arq.DividendYield).To(BeNumerically("~", art.DividendYield, 1e-9))
+			Expect(arq.PayoutRatio).To(BeNumerically("~", art.PayoutRatio, 1e-9))
+		})
+	})
+
+	Describe("MRT->MRQ copy", func() {
+		It("MRQ gets its own price/mktcap/EV/PB but copies ratio fields from MRT", func() {
+			mrt := &data.Fundamental{
+				CompositeFigi:                "BBG000B9XRY4",
+				Dimension:                    "MRT",
+				DateKey:                      dateKey,
+				EventDate:                    eventDate,
+				SharesBasic:                  int64(1_000_000),
+				TotalDebt:                    int64(300_000_000),
+				CashAndEquivalents:           int64(100_000_000),
+				Equity:                       int64(1_500_000_000),
+				NetIncomeCommonStock:         int64(80_000_000),
+				Revenues:                     int64(600_000_000),
+				EBIT:                         int64(90_000_000),
+				EBITDA:                       int64(110_000_000),
+				EPS:                          1.80,
+				EPSDiluted:                   1.70,
+				SalesPerShare:                6.00,
+				DividendsPerBasicCommonShare: 0.90,
+			}
+
+			mrq := &data.Fundamental{
+				CompositeFigi:      "BBG000B9XRY4",
+				Dimension:          "MRQ",
+				DateKey:            dateKey,
+				EventDate:          eventDate,
+				SharesBasic:        int64(1_000_000),
+				TotalDebt:          int64(300_000_000),
+				CashAndEquivalents: int64(100_000_000),
+				Equity:             int64(1_200_000_000),
+			}
+
+			price := 180.0
+			EnrichMarketData([]*data.Fundamental{mrt, mrq}, stubPriceFn(price))
+
+			expectedMktCap := int64(price * float64(mrq.SharesBasic))
+			expectedEV := expectedMktCap + mrq.TotalDebt - mrq.CashAndEquivalents
+			expectedPB := float64(expectedMktCap) / float64(mrq.Equity)
+
+			Expect(mrq.Price).To(BeNumerically("~", price, 1e-9))
+			Expect(mrq.MarketCapitalization).To(Equal(expectedMktCap))
+			Expect(mrq.EnterpriseValue).To(Equal(expectedEV))
+			Expect(mrq.PB).To(BeNumerically("~", expectedPB, 1e-9))
+
+			Expect(mrq.PE).To(BeNumerically("~", mrt.PE, 1e-9))
+			Expect(mrq.PS).To(BeNumerically("~", mrt.PS, 1e-9))
+			Expect(mrq.PE1).To(BeNumerically("~", mrt.PE1, 1e-9))
+			Expect(mrq.PS1).To(BeNumerically("~", mrt.PS1, 1e-9))
+			Expect(mrq.EVtoEBIT).To(Equal(mrt.EVtoEBIT))
+			Expect(mrq.EVtoEBITDA).To(BeNumerically("~", mrt.EVtoEBITDA, 1e-9))
+			Expect(mrq.DividendYield).To(BeNumerically("~", mrt.DividendYield, 1e-9))
+			Expect(mrq.PayoutRatio).To(BeNumerically("~", mrt.PayoutRatio, 1e-9))
+		})
+	})
+
+	Describe("Division by zero", func() {
+		It("leaves ratio fields at 0 when denominators are zero", func() {
+			f := &data.Fundamental{
+				CompositeFigi:                "BBG000B9XRY4",
+				Dimension:                    "ART",
+				DateKey:                      dateKey,
+				EventDate:                    eventDate,
+				SharesBasic:                  int64(1_000_000),
+				TotalDebt:                    int64(0),
+				CashAndEquivalents:           int64(0),
+				Equity:                       int64(0),
+				NetIncomeCommonStock:         int64(0),
+				Revenues:                     int64(0),
+				EBIT:                         int64(0),
+				EBITDA:                       int64(0),
+				EPS:                          0.0,
+				EPSDiluted:                   0.0,
+				SalesPerShare:                0.0,
+				DividendsPerBasicCommonShare: 0.0,
+			}
+
+			EnrichMarketData([]*data.Fundamental{f}, stubPriceFn(100.0))
+
+			Expect(f.PB).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PE).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PS).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PE1).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PS1).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.EVtoEBIT).To(Equal(int64(0)))
+			Expect(f.EVtoEBITDA).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.DividendYield).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PayoutRatio).To(BeNumerically("~", 0.0, 1e-9))
+		})
+	})
+
+	Describe("Missing price", func() {
+		It("leaves all fields at zero when price lookup returns 0", func() {
+			f := &data.Fundamental{
+				CompositeFigi:        "BBG000B9XRY4",
+				Dimension:            "ART",
+				DateKey:              dateKey,
+				EventDate:            eventDate,
+				SharesBasic:          int64(1_000_000),
+				TotalDebt:            int64(500_000_000),
+				CashAndEquivalents:   int64(200_000_000),
+				Equity:               int64(2_000_000_000),
+				NetIncomeCommonStock: int64(100_000_000),
+				Revenues:             int64(800_000_000),
+				EBIT:                 int64(120_000_000),
+				EBITDA:               int64(150_000_000),
+				EPS:                  2.50,
+				EPSDiluted:           2.40,
+				SalesPerShare:        8.00,
+			}
+
+			EnrichMarketData([]*data.Fundamental{f}, stubPriceFn(0.0))
+
+			Expect(f.Price).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.MarketCapitalization).To(Equal(int64(0)))
+			Expect(f.EnterpriseValue).To(Equal(int64(0)))
+			Expect(f.PB).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PE).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PS).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PE1).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PS1).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.EVtoEBIT).To(Equal(int64(0)))
+			Expect(f.EVtoEBITDA).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.DividendYield).To(BeNumerically("~", 0.0, 1e-9))
+			Expect(f.PayoutRatio).To(BeNumerically("~", 0.0, 1e-9))
+		})
+	})
+
+	Describe("PE1 uses basic EPS not EPSDiluted", func() {
+		It("computes PE1 = Price / EPS (basic), not Price / EPSDiluted", func() {
+			f := &data.Fundamental{
+				CompositeFigi: "BBG000B9XRY4",
+				Dimension:     "ART",
+				DateKey:       dateKey,
+				EventDate:     eventDate,
+				SharesBasic:   int64(1_000_000),
+				Equity:        int64(1_000_000_000),
+				EPS:           5.00,
+				EPSDiluted:    4.00,
+				SalesPerShare: 10.00,
+			}
+
+			price := 100.0
+			EnrichMarketData([]*data.Fundamental{f}, stubPriceFn(price))
+
+			Expect(f.PE1).To(BeNumerically("~", price/f.EPS, 1e-9))
+			Expect(f.PE1).NotTo(BeNumerically("~", price/f.EPSDiluted, 1e-9))
+		})
+	})
+
+	Describe("PB is independent for quarterly", func() {
+		It("ARQ computes its own PB from its own Equity, not ARTs", func() {
+			art := &data.Fundamental{
+				CompositeFigi: "BBG000B9XRY4",
+				Dimension:     "ART",
+				DateKey:       dateKey,
+				EventDate:     eventDate,
+				SharesBasic:   int64(1_000_000),
+				Equity:        int64(2_000_000_000),
+				EPS:           2.50,
+				EPSDiluted:    2.40,
+				SalesPerShare: 8.00,
+			}
+
+			arqEquity := int64(500_000_000) // distinctly different from ART's equity
+			arq := &data.Fundamental{
+				CompositeFigi: "BBG000B9XRY4",
+				Dimension:     "ARQ",
+				DateKey:       dateKey,
+				EventDate:     eventDate,
+				SharesBasic:   int64(1_000_000),
+				Equity:        arqEquity,
+			}
+
+			price := 200.0
+			EnrichMarketData([]*data.Fundamental{art, arq}, stubPriceFn(price))
+
+			mktCap := int64(price * float64(arq.SharesBasic))
+			expectedARQPB := float64(mktCap) / float64(arqEquity)
+			artPB := float64(int64(price*float64(art.SharesBasic))) / float64(art.Equity)
+
+			Expect(arq.PB).To(BeNumerically("~", expectedARQPB, 1e-9))
+			Expect(arq.PB).NotTo(BeNumerically("~", artPB, 1e-9))
+		})
+	})
+})

--- a/provider/sec/market_data_test.go
+++ b/provider/sec/market_data_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/penny-vault/pvdata/data"
+	"github.com/penny-vault/pvdata/library"
 )
 
 var _ = Describe("EnrichMarketData", func() {
@@ -345,5 +346,69 @@ var _ = Describe("EnrichMarketData", func() {
 			Expect(arq.PB).To(BeNumerically("~", expectedARQPB, 1e-9))
 			Expect(arq.PB).NotTo(BeNumerically("~", artPB, 1e-9))
 		})
+	})
+})
+
+var _ = Describe("emitFundamentals market-data enrichment", func() {
+	It("populates price on emitted fundamentals when priceLookupFn is set", func() {
+		cf := &CompanyFacts{
+			CIK:        999,
+			EntityName: "TestCo",
+			Facts: map[string][]Fact{
+				"Revenues": {
+					{Val: 100000, Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+		}
+
+		asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST01", CIK: 999}
+		sub := &library.Subscription{Name: "test"}
+		out := make(chan *data.Observation, 100)
+		numObs := 0
+
+		SetPriceLookupFn(func(compositeFigi string, eventDate time.Time) float64 {
+			return 150.0
+		})
+		defer SetPriceLookupFn(nil)
+
+		emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+		close(out)
+
+		foundPriced := false
+		for obs := range out {
+			if obs.Fundamental != nil && obs.Fundamental.Price > 0 {
+				foundPriced = true
+				Expect(obs.Fundamental.Price).To(BeNumerically("~", 150.0, 0.001))
+			}
+		}
+		Expect(foundPriced).To(BeTrue(), "at least one observation should have a non-zero price")
+	})
+
+	It("emits fundamentals with zero price when no lookup function is set", func() {
+		cf := &CompanyFacts{
+			CIK:        999,
+			EntityName: "TestCo",
+			Facts: map[string][]Fact{
+				"Revenues": {
+					{Val: 100000, Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC), Form: "10-Q", Filed: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+		}
+
+		asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST01", CIK: 999}
+		sub := &library.Subscription{Name: "test"}
+		out := make(chan *data.Observation, 100)
+		numObs := 0
+
+		SetPriceLookupFn(nil)
+
+		emitFundamentals(cf, asset, sub, time.Time{}, out, &numObs)
+		close(out)
+
+		for obs := range out {
+			if obs.Fundamental != nil {
+				Expect(obs.Fundamental.Price).To(BeNumerically("==", 0))
+			}
+		}
 	})
 })

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -211,6 +211,16 @@ func fetchFundamentals(ctx context.Context, sub *library.Subscription, out chan<
 		log.Info().Int("filtered_ciks", len(filtered)).Msg("applied security filter to CIK map")
 	}
 
+	// Set up EOD price lookup for market-data enrichment.
+	eodView := FindEODViewName(ctx, sub.Library.Pool)
+	if eodView != "" {
+		SetPriceLookupFn(NewEODPriceLookup(ctx, sub.Library.Pool, eodView))
+		log.Info().Str("eod_view", eodView).Msg("market-data enrichment enabled")
+	} else {
+		SetPriceLookupFn(nil)
+		log.Warn().Msg("no published EOD view found; market-data fields will be zero")
+	}
+
 	skippedMissingFIGI := 0
 
 	// Determine the cutoff date for which periods to emit. If --lookback is
@@ -514,6 +524,8 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 	var annuals []quarterData
 
+	var buffered []*data.Observation
+
 	for _, p := range periods {
 		// AR: resolve using only facts available at the earliest filing date
 		arFields := ResolveFieldsForFiling(cf, p.PeriodEnd, p.FormType, p.ARFiledDate)
@@ -702,24 +714,24 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// ARY
 		fundamental := BuildFundamental(a.arEmit, asset.Ticker, asset.CompositeFigi, "ARY",
 			a.period.ARFiledDate, calendarDate, a.period.PeriodEnd, a.period.ARFiledDate)
-		out <- &data.Observation{
+		buffered = append(buffered, &data.Observation{
 			Fundamental:      fundamental,
 			ObservationDate:  calendarDate,
 			SubscriptionID:   sub.ID,
 			SubscriptionName: sub.Name,
-		}
+		})
 
 		*numObservations++
 
 		// MRY
 		fundamental = BuildFundamental(a.mrEmit, asset.Ticker, asset.CompositeFigi, "MRY",
 			a.period.PeriodEnd, calendarDate, a.period.PeriodEnd, a.period.MRFiledDate)
-		out <- &data.Observation{
+		buffered = append(buffered, &data.Observation{
 			Fundamental:      fundamental,
 			ObservationDate:  calendarDate,
 			SubscriptionID:   sub.ID,
 			SubscriptionName: sub.Name,
-		}
+		})
 
 		*numObservations++
 
@@ -738,24 +750,24 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// ARQ
 		fundamental := BuildFundamental(q.arEmit, asset.Ticker, asset.CompositeFigi, "ARQ",
 			q.period.ARFiledDate, calendarDate, q.period.PeriodEnd, q.period.ARFiledDate)
-		out <- &data.Observation{
+		buffered = append(buffered, &data.Observation{
 			Fundamental:      fundamental,
 			ObservationDate:  calendarDate,
 			SubscriptionID:   sub.ID,
 			SubscriptionName: sub.Name,
-		}
+		})
 
 		*numObservations++
 
 		// MRQ
 		fundamental = BuildFundamental(q.mrEmit, asset.Ticker, asset.CompositeFigi, "MRQ",
 			q.period.PeriodEnd, calendarDate, q.period.PeriodEnd, q.period.MRFiledDate)
-		out <- &data.Observation{
+		buffered = append(buffered, &data.Observation{
 			Fundamental:      fundamental,
 			ObservationDate:  calendarDate,
 			SubscriptionID:   sub.ID,
 			SubscriptionName: sub.Name,
-		}
+		})
 
 		*numObservations++
 
@@ -837,12 +849,12 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 			fundamental := BuildFundamental(ttm, asset.Ticker, asset.CompositeFigi, "ART",
 				q.period.ARFiledDate, calendarDate, q.period.PeriodEnd, latestARFiled)
-			out <- &data.Observation{
+			buffered = append(buffered, &data.Observation{
 				Fundamental:      fundamental,
 				ObservationDate:  calendarDate,
 				SubscriptionID:   sub.ID,
 				SubscriptionName: sub.Name,
-			}
+			})
 
 			*numObservations++
 		}
@@ -862,15 +874,34 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 			fundamental := BuildFundamental(ttm, asset.Ticker, asset.CompositeFigi, "MRT",
 				q.period.PeriodEnd, calendarDate, q.period.PeriodEnd, latestMRFiled)
-			out <- &data.Observation{
+			buffered = append(buffered, &data.Observation{
 				Fundamental:      fundamental,
 				ObservationDate:  calendarDate,
 				SubscriptionID:   sub.ID,
 				SubscriptionName: sub.Name,
-			}
+			})
 
 			*numObservations++
 		}
+	}
+
+	// Enrich buffered observations with market-data fields if a price
+	// lookup function is available.
+	if priceLookupFn != nil {
+		var fundamentals []*data.Fundamental
+
+		for _, obs := range buffered {
+			if obs.Fundamental != nil {
+				fundamentals = append(fundamentals, obs.Fundamental)
+			}
+		}
+
+		EnrichMarketData(fundamentals, priceLookupFn)
+	}
+
+	// Send all buffered observations to the output channel.
+	for _, obs := range buffered {
+		out <- obs
 	}
 
 	// Log per-company coverage. We use Debug for healthy companies (most of


### PR DESCRIPTION
## Summary

- Adds `EnrichMarketData` function that computes 14 market-data fields (price, market_cap, PE, PB, PS, PE1, PS1, EV, EV/EBIT, EV/EBITDA, dividend_yield, payout_ratio, share_factor, fx_usd) from EOD close prices and existing fundamentals
- Looks up unadjusted close from the published `eod` view, matching the most recent trading day on or before `event_date`
- Buffers observations in `emitFundamentals` and enriches before sending to the output channel
- Trailing/annual dimensions (ART, MRT, ARY, MRY) compute ratios from own fields; quarterly dimensions (ARQ, MRQ) copy ratios from corresponding trailing dimension
- PE1 uses basic EPS (not diluted) -- verified against Sharadar data

Fixes #38

## Known limitation

`shares_basic` resolves to a slightly different value than Sharadar (~0.02-0.12% for AAPL), which cascades to all ratio fields. Tracked in #51.

## Test plan

- [ ] `ginkgo run -race ./provider/sec/` -- 117 tests pass (9 new)
- [ ] Run `pvdata run --ticker AAPL "SEC Fundamentals"` -- all 14 fields populated
- [ ] `pvdata compare-fundamentals --ticker AAPL --fields price` -- 0 diffs (price matches exactly)