### PR TITLE
fix(sec): derive NetCashFlowDebt and NetCashFlowInvest from component sub-fields

### DIFF
--- a/docs/superpowers/plans/2026-04-12-fix-ncfdebt-ncfinv.md
+++ b/docs/superpowers/plans/2026-04-12-fix-ncfdebt-ncfinv.md
@@ -1,0 +1,262 @@
+# Fix net_cash_flow_debt and net_cash_flow_invest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `NetCashFlowDebt` and `NetCashFlowInvest` from single-tag direct lookups to derived fields that net proceeds against payments, matching Sharadar's definitions.
+
+**Architecture:** Add four internal-only direct sub-fields (prefixed `_`) to resolve individual XBRL tags for debt proceeds, debt repayments, investment payments, and investment proceeds. Then define `NetCashFlowDebt` and `NetCashFlowInvest` as `MappingDerived` / `OpLinearCombination` entries that combine the sub-fields with appropriate +1/-1 coefficients. The `_`-prefixed names are not in `dimensions.go`'s allowlist, so they never reach the `Fundamental` struct.
+
+**Tech Stack:** Go, Ginkgo v2 + Gomega
+
+**Spec:** `docs/superpowers/specs/2026-04-12-fix-ncfdebt-ncfinv-design.md`
+
+---
+
+### Task 1: Write failing tests for NetCashFlowDebt derivation
+
+**Files:**
+- Modify: `provider/sec/mapping_test.go`
+
+- [ ] **Step 1: Write the failing test for NetCashFlowDebt as proceeds minus repayments**
+
+Add inside the `Describe("ResolveAllFields", ...)` block, after the existing `It("resolves InvestedCapital from component fields", ...)` test (around line 416):
+
+```go
+It("resolves NetCashFlowDebt as proceeds minus repayments", func() {
+    periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+    filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+    debtCF := &CompanyFacts{
+        CIK: 1, EntityName: "Test Co",
+        Facts: map[string][]Fact{
+            "ProceedsFromIssuanceOfLongTermDebt": {
+                {
+                    Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+                    End:   periodEnd,
+                    Filed: filed,
+                    Val:   5_000_000_000,
+                    Form:  "10-Q",
+                },
+            },
+            "RepaymentsOfLongTermDebt": {
+                {
+                    Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+                    End:   periodEnd,
+                    Filed: filed,
+                    Val:   3_000_000_000,
+                    Form:  "10-Q",
+                },
+            },
+        },
+    }
+
+    resolved := ResolveAllFields(debtCF, periodEnd, "10-Q")
+    Expect(resolved).To(HaveKey("NetCashFlowDebt"))
+    Expect(resolved["NetCashFlowDebt"]).To(Equal(2_000_000_000.0),
+        "NetCashFlowDebt = proceeds(5B) - repayments(3B) = 2B")
+})
+
+It("resolves NetCashFlowDebt with only repayments present", func() {
+    periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+    filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+    debtCF := &CompanyFacts{
+        CIK: 1, EntityName: "Test Co",
+        Facts: map[string][]Fact{
+            "RepaymentsOfLongTermDebt": {
+                {
+                    Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+                    End:   periodEnd,
+                    Filed: filed,
+                    Val:   3_000_000_000,
+                    Form:  "10-Q",
+                },
+            },
+        },
+    }
+
+    resolved := ResolveAllFields(debtCF, periodEnd, "10-Q")
+    Expect(resolved).To(HaveKey("NetCashFlowDebt"))
+    Expect(resolved["NetCashFlowDebt"]).To(Equal(-3_000_000_000.0),
+        "NetCashFlowDebt = -repayments(3B) when no proceeds exist")
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "resolves NetCashFlowDebt" ./provider/sec/`
+
+Expected: FAIL -- currently `NetCashFlowDebt` is a direct mapping that picks only the first matching tag (`ProceedsFromIssuanceOfLongTermDebt`), so the first test gets 5B instead of 2B, and the second test gets -3B from the wrong mapping path.
+
+---
+
+### Task 2: Write failing tests for NetCashFlowInvest derivation
+
+**Files:**
+- Modify: `provider/sec/mapping_test.go`
+
+- [ ] **Step 1: Write the failing test for NetCashFlowInvest as proceeds minus payments**
+
+Add immediately after the NetCashFlowDebt tests from Task 1:
+
+```go
+It("resolves NetCashFlowInvest as proceeds minus payments", func() {
+    periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+    filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+    investCF := &CompanyFacts{
+        CIK: 1, EntityName: "Test Co",
+        Facts: map[string][]Fact{
+            "PaymentsToAcquireAvailableForSaleSecuritiesDebt": {
+                {
+                    Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+                    End:   periodEnd,
+                    Filed: filed,
+                    Val:   15_300_000_000,
+                    Form:  "10-Q",
+                },
+            },
+            "ProceedsFromMaturitiesPrepaymentsAndCallsOfAvailableForSaleSecurities": {
+                {
+                    Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+                    End:   periodEnd,
+                    Filed: filed,
+                    Val:   13_200_000_000,
+                    Form:  "10-Q",
+                },
+            },
+        },
+    }
+
+    resolved := ResolveAllFields(investCF, periodEnd, "10-Q")
+    Expect(resolved).To(HaveKey("NetCashFlowInvest"))
+    Expect(resolved["NetCashFlowInvest"]).To(Equal(-2_100_000_000.0),
+        "NetCashFlowInvest = -payments(15.3B) + proceeds(13.2B) = -2.1B")
+})
+
+It("resolves NetCashFlowInvest with only proceeds present", func() {
+    periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+    filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+    investCF := &CompanyFacts{
+        CIK: 1, EntityName: "Test Co",
+        Facts: map[string][]Fact{
+            "ProceedsFromSaleOfAvailableForSaleSecuritiesDebt": {
+                {
+                    Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+                    End:   periodEnd,
+                    Filed: filed,
+                    Val:   7_000_000_000,
+                    Form:  "10-Q",
+                },
+            },
+        },
+    }
+
+    resolved := ResolveAllFields(investCF, periodEnd, "10-Q")
+    Expect(resolved).To(HaveKey("NetCashFlowInvest"))
+    Expect(resolved["NetCashFlowInvest"]).To(Equal(7_000_000_000.0),
+        "NetCashFlowInvest = proceeds(7B) when no payments exist")
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "resolves NetCashFlowInvest" ./provider/sec/`
+
+Expected: FAIL -- currently picks first matching tag as a direct value instead of netting.
+
+---
+
+### Task 3: Implement the derived mappings in mapping_config.go
+
+**Files:**
+- Modify: `provider/sec/mapping_config.go:504-528`
+
+- [ ] **Step 1: Replace the NetCashFlowDebt and NetCashFlowInvest entries**
+
+Replace lines 504-528 (the `NetCashFlowDebt` and `NetCashFlowInvest` entries) with:
+
+```go
+	// --- Internal sub-fields for NetCashFlowDebt derivation ---
+	{
+		FieldName: "_proceedsDebt", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{
+			"ProceedsFromIssuanceOfLongTermDebt",
+			"ProceedsFromIssuanceOfDebt",
+			"ProceedsFromDebtNetOfIssuanceCosts",
+		},
+	},
+	{
+		FieldName: "_repaymentsDebt", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{
+			"RepaymentsOfLongTermDebt",
+			"RepaymentsOfDebt",
+			"RepaymentsOfLongTermDebtAndCapitalSecurities",
+		},
+	},
+	// NetCashFlowDebt = proceeds - repayments (Sharadar NCFDEBT:
+	// "net cash inflow (outflow) from issuance (repayment) of debt securities")
+	{
+		FieldName: "NetCashFlowDebt", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
+		Op:               OpLinearCombination,
+		Operands:         []string{"_proceedsDebt", "_repaymentsDebt"},
+		Coefficients:     []float64{1, -1},
+		OptionalOperands: true,
+	},
+	// --- Internal sub-fields for NetCashFlowInvest derivation ---
+	{
+		FieldName: "_paymentsInvest", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{
+			"PaymentsToAcquireInvestments",
+			"PaymentsToAcquireAvailableForSaleSecuritiesDebt",
+		},
+	},
+	{
+		FieldName: "_proceedsInvest", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{
+			"ProceedsFromSaleAndMaturityOfMarketableSecurities",
+			"ProceedsFromMaturitiesPrepaymentsAndCallsOfAvailableForSaleSecurities",
+			"ProceedsFromSaleOfAvailableForSaleSecuritiesDebt",
+		},
+	},
+	// NetCashFlowInvest = -payments + proceeds (Sharadar NCFINV:
+	// "net cash inflow (outflow) associated with acquisition & disposal of investments")
+	{
+		FieldName: "NetCashFlowInvest", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
+		Op:               OpLinearCombination,
+		Operands:         []string{"_paymentsInvest", "_proceedsInvest"},
+		Coefficients:     []float64{-1, 1},
+		OptionalOperands: true,
+	},
+```
+
+- [ ] **Step 2: Run the new tests to verify they pass**
+
+Run: `ginkgo run -race --focus "resolves NetCashFlow(Debt|Invest)" ./provider/sec/`
+
+Expected: PASS -- all four new tests should pass.
+
+- [ ] **Step 3: Run the full test suite to check for regressions**
+
+Run: `ginkgo run -race ./provider/sec/`
+
+Expected: PASS -- the existing mapping config validation tests (duplicate names, operand references, coefficient lengths) should all still pass.
+
+- [ ] **Step 4: Run the linter**
+
+Run: `golangci-lint run --fix ./provider/sec/...`
+
+Expected: PASS with no issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/sec/mapping_config.go provider/sec/mapping_test.go
+git commit -m "fix(sec): derive NetCashFlowDebt and NetCashFlowInvest from component sub-fields (#41)
+
+NetCashFlowDebt was picking either proceeds or repayments (never both);
+NetCashFlowInvest was picking gross purchases instead of netting against
+sales/maturities. Convert both to MappingDerived with OpLinearCombination
+using internal _-prefixed sub-fields."
+```

--- a/docs/superpowers/specs/2026-04-12-fix-ncfdebt-ncfinv-design.md
+++ b/docs/superpowers/specs/2026-04-12-fix-ncfdebt-ncfinv-design.md
@@ -1,0 +1,107 @@
+# Fix net_cash_flow_debt and net_cash_flow_invest Resolution
+
+**Issue:** #41
+**Date:** 2026-04-12
+
+## Problem
+
+`NetCashFlowDebt` and `NetCashFlowInvest` are currently `MappingDirect` fields
+that pick the first matching XBRL tag. Both fields represent **net** values that
+require combining proceeds and payments, but the pick-first behavior grabs only
+one side of the equation.
+
+**NetCashFlowDebt** picks either `ProceedsFromIssuanceOfLongTermDebt` or
+`RepaymentsOfLongTermDebt` -- never both. This produces sign flips and magnitude
+mismatches vs Sharadar across quarters.
+
+**NetCashFlowInvest** picks the first match from a list of five tags (payments
+and proceeds mixed together). For AAPL, it grabs
+`PaymentsToAcquireAvailableForSaleSecuritiesDebt` (gross purchases = 15.3B)
+instead of netting against sales/maturities (Sharadar = 2.1B).
+
+## Approach
+
+Convert both fields from `MappingDirect` to `MappingDerived` using internal-only
+sub-fields and `OpLinearCombination`. This follows the existing pattern used by
+`Investments`, `Receivables`, and `InvestedCapital`.
+
+Internal sub-fields use a `_` prefix convention and are not listed in
+`dimensions.go`, so they never reach the `Fundamental` struct.
+
+## Design
+
+### NetCashFlowDebt
+
+Sharadar definition: "net cash inflow (outflow) from issuance (repayment) of
+debt securities."
+
+**Internal sub-fields** (`MappingDirect`, `StmtFlow`, `int64`):
+
+| Sub-field | XBRL Tags (priority order) |
+|---|---|
+| `_proceedsDebt` | `ProceedsFromIssuanceOfLongTermDebt`, `ProceedsFromIssuanceOfDebt`, `ProceedsFromDebtNetOfIssuanceCosts` |
+| `_repaymentsDebt` | `RepaymentsOfLongTermDebt`, `RepaymentsOfDebt`, `RepaymentsOfLongTermDebtAndCapitalSecurities` |
+
+Neither sub-field uses `Negate` -- the raw XBRL values are kept as-is. Proceeds
+are reported as positive, repayments as positive. The linear combination applies
+the sign:
+
+**Derived field:**
+```
+NetCashFlowDebt = (+1 * _proceedsDebt) + (-1 * _repaymentsDebt)
+Op: OpLinearCombination
+Operands: [_proceedsDebt, _repaymentsDebt]
+Coefficients: [+1, -1]
+OptionalOperands: true
+FallbackTags: [] (no direct XBRL fallback)
+```
+
+`OptionalOperands: true` so that if a company reports only one side, we still
+produce a value.
+
+### NetCashFlowInvest
+
+Sharadar definition: "net cash inflow (outflow) associated with the acquisition
+& disposal of investments, including marketable securities and loan originations."
+
+**Internal sub-fields** (`MappingDirect`, `StmtFlow`, `int64`):
+
+| Sub-field | XBRL Tags (priority order) |
+|---|---|
+| `_paymentsInvest` | `PaymentsToAcquireInvestments`, `PaymentsToAcquireAvailableForSaleSecuritiesDebt` |
+| `_proceedsInvest` | `ProceedsFromSaleAndMaturityOfMarketableSecurities`, `ProceedsFromMaturitiesPrepaymentsAndCallsOfAvailableForSaleSecurities`, `ProceedsFromSaleOfAvailableForSaleSecuritiesDebt` |
+
+**Derived field:**
+```
+NetCashFlowInvest = (-1 * _paymentsInvest) + (+1 * _proceedsInvest)
+Op: OpLinearCombination
+Operands: [_paymentsInvest, _proceedsInvest]
+Coefficients: [-1, +1]
+OptionalOperands: true
+FallbackTags: [] (no direct XBRL fallback)
+```
+
+Payments are negated (outflow) and proceeds are positive (inflow), matching
+Sharadar's sign convention.
+
+## Files Changed
+
+- `provider/sec/mapping_config.go` -- Replace the two `MappingDirect` entries
+  with four internal sub-fields and two `MappingDerived` entries. The sub-fields
+  must appear before the derived fields in `FieldMappings` (ordering requirement).
+
+## No Changes Required
+
+- `data/fundamental.go` -- No struct changes; field names are unchanged.
+- `provider/sec/dimensions.go` -- The `_`-prefixed sub-fields are not in the
+  allowlist, so they are naturally ignored.
+- `provider/sec/mapping.go` -- `OpLinearCombination` with `OptionalOperands` is
+  already fully supported.
+- `provider/sec/synthesize_q4.go` -- Sub-fields are `StmtFlow`, so Q4
+  de-cumulation applies automatically.
+
+## Verification
+
+Run `pvdata compare --ticker AAPL --source sec --source sharadar` and confirm
+that `net_cash_flow_debt` and `net_cash_flow_invest` diffs are reduced. The issue
+reports ~48 AAPL diffs attributable to these two fields.

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -629,6 +629,10 @@ var _ = Describe("Dimensions", func() {
 				"ShortTermDebt":                 true,
 				"LongTermDebtCurrentMaturities": true,
 				"CommercialPaperDebt":           true,
+				"_proceedsDebt":                 true,
+				"_repaymentsDebt":               true,
+				"_paymentsInvest":               true,
+				"_proceedsInvest":               true,
 			}
 
 			var missing []string

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -505,12 +505,31 @@ var FieldMappings = []FieldMapping{
 			"PaymentsForRepurchaseOfCommonStock",
 		},
 	},
+	// --- Internal sub-fields for NetCashFlowDebt derivation ---
 	{
-		FieldName: "NetCashFlowDebt", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		FieldName: "_proceedsDebt", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
 		XBRLTags: []string{
 			"ProceedsFromIssuanceOfLongTermDebt",
-			"RepaymentsOfLongTermDebt",
+			"ProceedsFromIssuanceOfDebt",
+			"ProceedsFromDebtNetOfIssuanceCosts",
 		},
+	},
+	{
+		FieldName: "_repaymentsDebt", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{
+			"RepaymentsOfLongTermDebt",
+			"RepaymentsOfDebt",
+			"RepaymentsOfLongTermDebtAndCapitalSecurities",
+		},
+	},
+	// NetCashFlowDebt = proceeds - repayments (Sharadar NCFDEBT:
+	// "net cash inflow (outflow) from issuance (repayment) of debt securities")
+	{
+		FieldName: "NetCashFlowDebt", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
+		Op:               OpLinearCombination,
+		Operands:         []string{"_proceedsDebt", "_repaymentsDebt"},
+		Coefficients:     []float64{1, -1},
+		OptionalOperands: true,
 	},
 	{
 		FieldName: "NetCashFlowDividend", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
@@ -520,15 +539,30 @@ var FieldMappings = []FieldMapping{
 			"PaymentsOfDividends",
 		},
 	},
+	// --- Internal sub-fields for NetCashFlowInvest derivation ---
 	{
-		FieldName: "NetCashFlowInvest", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		FieldName: "_paymentsInvest", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
 		XBRLTags: []string{
 			"PaymentsToAcquireInvestments",
 			"PaymentsToAcquireAvailableForSaleSecuritiesDebt",
+		},
+	},
+	{
+		FieldName: "_proceedsInvest", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{
 			"ProceedsFromSaleAndMaturityOfMarketableSecurities",
 			"ProceedsFromMaturitiesPrepaymentsAndCallsOfAvailableForSaleSecurities",
 			"ProceedsFromSaleOfAvailableForSaleSecuritiesDebt",
 		},
+	},
+	// NetCashFlowInvest = -payments + proceeds (Sharadar NCFINV:
+	// "net cash inflow (outflow) associated with acquisition & disposal of investments")
+	{
+		FieldName: "NetCashFlowInvest", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
+		Op:               OpLinearCombination,
+		Operands:         []string{"_paymentsInvest", "_proceedsInvest"},
+		Coefficients:     []float64{-1, 1},
+		OptionalOperands: true,
 	},
 	{
 		FieldName: "NetCashFlowFx", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -498,6 +498,124 @@ var _ = Describe("Mapping Engine", func() {
 			Expect(resolved["InvestedCapital"]).To(Equal(315_000.0))
 		})
 
+		It("resolves NetCashFlowDebt as proceeds minus repayments", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			debtCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"ProceedsFromIssuanceOfLongTermDebt": {
+						{
+							Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+							End:   periodEnd,
+							Filed: filed,
+							Val:   5_000_000_000,
+							Form:  "10-Q",
+						},
+					},
+					"RepaymentsOfLongTermDebt": {
+						{
+							Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+							End:   periodEnd,
+							Filed: filed,
+							Val:   3_000_000_000,
+							Form:  "10-Q",
+						},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(debtCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("NetCashFlowDebt"))
+			Expect(resolved["NetCashFlowDebt"]).To(Equal(2_000_000_000.0),
+				"NetCashFlowDebt = proceeds(5B) - repayments(3B) = 2B")
+		})
+
+		It("resolves NetCashFlowDebt with only repayments present", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			debtCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"RepaymentsOfLongTermDebt": {
+						{
+							Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+							End:   periodEnd,
+							Filed: filed,
+							Val:   3_000_000_000,
+							Form:  "10-Q",
+						},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(debtCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("NetCashFlowDebt"))
+			Expect(resolved["NetCashFlowDebt"]).To(Equal(-3_000_000_000.0),
+				"NetCashFlowDebt = -repayments(3B) when no proceeds exist")
+		})
+
+		It("resolves NetCashFlowInvest as proceeds minus payments", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			investCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"PaymentsToAcquireAvailableForSaleSecuritiesDebt": {
+						{
+							Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+							End:   periodEnd,
+							Filed: filed,
+							Val:   15_300_000_000,
+							Form:  "10-Q",
+						},
+					},
+					"ProceedsFromMaturitiesPrepaymentsAndCallsOfAvailableForSaleSecurities": {
+						{
+							Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+							End:   periodEnd,
+							Filed: filed,
+							Val:   13_200_000_000,
+							Form:  "10-Q",
+						},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(investCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("NetCashFlowInvest"))
+			Expect(resolved["NetCashFlowInvest"]).To(Equal(-2_100_000_000.0),
+				"NetCashFlowInvest = -payments(15.3B) + proceeds(13.2B) = -2.1B")
+		})
+
+		It("resolves NetCashFlowInvest with only proceeds present", func() {
+			periodEnd := time.Date(2024, 3, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+			investCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"ProceedsFromSaleOfAvailableForSaleSecuritiesDebt": {
+						{
+							Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+							End:   periodEnd,
+							Filed: filed,
+							Val:   7_000_000_000,
+							Form:  "10-Q",
+						},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(investCF, periodEnd, "10-Q")
+			Expect(resolved).To(HaveKey("NetCashFlowInvest"))
+			Expect(resolved["NetCashFlowInvest"]).To(Equal(7_000_000_000.0),
+				"NetCashFlowInvest = proceeds(7B) when no payments exist")
+		})
+
 		It("falls back to basic weighted-average shares when diluted tags are absent", func() {
 			// Simulates a loss-quarter filer (e.g. Nordstrom during COVID,
 			// Vaxart as a pre-revenue biotech) that reports only the basic


### PR DESCRIPTION
## Summary

Fixes #41.

- Convert `NetCashFlowDebt` from `MappingDirect` to `MappingDerived` using `OpLinearCombination`: `proceeds - repayments` across long-term and general debt XBRL tags
- Convert `NetCashFlowInvest` from `MappingDirect` to `MappingDerived`: `-payments + proceeds` across investment acquisition and sale/maturity tags
- Add four internal `_`-prefixed sub-fields (`_proceedsDebt`, `_repaymentsDebt`, `_paymentsInvest`, `_proceedsInvest`) that resolve individual XBRL tags but never reach the `Fundamental` struct

Previously both fields used pick-first-matching-tag behavior, which grabbed only one side of the net calculation (e.g., gross purchases instead of net purchases/sales).

## Test Plan

- [x] 4 new unit tests covering both-operands and single-operand cases for each field
- [x] Full provider/sec suite passes (112/112)
- [x] Linter clean
- [ ] Run `pvdata compare --ticker AAPL --source sec --source sharadar` to verify reduced diffs