### PR TITLE
fix(sec): map TaxAssets to tax receivables instead of deferred tax assets

### DIFF
--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -184,9 +184,9 @@ var FieldMappings = []FieldMapping{
 	{
 		FieldName: "TaxAssets", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
 		XBRLTags: []string{
-			"DeferredTaxAssetsNet",
-			"DeferredTaxAssetsNetCurrent",
-			"DeferredIncomeTaxAssetsNet",
+			"IncomeTaxesReceivable",
+			"IncomeTaxReceivable",
+			"PrepaidTaxes",
 		},
 	},
 	{

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -759,6 +759,55 @@ var _ = Describe("Mapping Engine", func() {
 			Expect(ok).To(BeTrue())
 			Expect(val).To(Equal(float64(157_000_000)))
 		})
+
+		It("resolves TaxAssets from IncomeTaxesReceivable, not deferred tax tags", func() {
+			// Sharadar defines taxassets as "tax assets and receivables" --
+			// current tax receivables, not deferred tax assets. A company
+			// that reports both should resolve TaxAssets from
+			// IncomeTaxesReceivable and ignore DeferredTaxAssetsNet.
+			periodEnd := time.Date(2024, 9, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)
+
+			taxCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"IncomeTaxesReceivable": {
+						{End: periodEnd, Filed: filed, Val: 450_000_000, Form: "10-K"},
+					},
+					"DeferredTaxAssetsNet": {
+						{End: periodEnd, Filed: filed, Val: 27_451_000_000, Form: "10-K"},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(taxCF, periodEnd, "10-K")
+			Expect(resolved).To(HaveKey("TaxAssets"))
+			Expect(resolved["TaxAssets"]).To(Equal(450_000_000.0),
+				"TaxAssets should resolve from IncomeTaxesReceivable (450M), not DeferredTaxAssetsNet (27.5B)")
+		})
+
+		It("does not resolve TaxAssets from deferred tax tags alone", func() {
+			// When only deferred tax tags are present (like AAPL), TaxAssets
+			// should not resolve -- matching Sharadar's 0 for such companies.
+			periodEnd := time.Date(2024, 9, 30, 0, 0, 0, 0, time.UTC)
+			filed := time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC)
+
+			deferredOnlyCF := &CompanyFacts{
+				CIK: 1, EntityName: "Test Co",
+				Facts: map[string][]Fact{
+					"DeferredTaxAssetsNet": {
+						{End: periodEnd, Filed: filed, Val: 27_451_000_000, Form: "10-K"},
+					},
+					"DeferredIncomeTaxAssetsNet": {
+						{End: periodEnd, Filed: filed, Val: 20_777_000_000, Form: "10-K"},
+					},
+				},
+			}
+
+			resolved := ResolveAllFields(deferredOnlyCF, periodEnd, "10-K")
+			Expect(resolved).NotTo(HaveKey("TaxAssets"),
+				"TaxAssets should not resolve when only deferred tax tags are present")
+		})
 	})
 
 	Describe("Sign negation for cash outflow fields", func() {


### PR DESCRIPTION
## Summary

- Replaces deferred tax XBRL tags (`DeferredTaxAssetsNet`, `DeferredTaxAssetsNetCurrent`, `DeferredIncomeTaxAssetsNet`) with non-deferred tax receivable tags (`IncomeTaxesReceivable`, `IncomeTaxReceivable`, `PrepaidTaxes`) for the `TaxAssets` field mapping
- Sharadar defines `taxassets` as "tax assets and receivables" (current tax receivables), not deferred tax assets -- the old mapping caused a ~$27.5B discrepancy for AAPL
- Companies that only report deferred tax assets (like AAPL) now correctly resolve to 0, matching Sharadar

Closes #57

## Test plan

- [x] Added test: `TaxAssets` resolves from `IncomeTaxesReceivable` when both deferred and non-deferred tags present
- [x] Added test: `TaxAssets` does not resolve when only deferred tax tags present
- [x] Full SEC test suite passes (128 specs, 0 failures)
- [x] Lint clean