### PR TITLE
fix(sec): exclude averaging/ratio fields from ARQ/MRQ dimensions (#56)

### DIFF
--- a/docs/superpowers/specs/2026-04-12-period-average-fields-design.md
+++ b/docs/superpowers/specs/2026-04-12-period-average-fields-design.md
@@ -86,20 +86,15 @@ If either period is missing a required input, dependent fields are omitted from 
 
 **File:** `provider/sec/sec.go`
 
-Three insertion points corresponding to the three dimension types:
+Two insertion points corresponding to annual and trailing-twelve-month dimension types.
 
-#### Quarterly (ARQ/MRQ)
+#### Quarterly (ARQ/MRQ) -- excluded
 
-After the existing de-cumulation loop, add a new loop over `quarters`:
+Period averages, derived ratios (`ROA`, `ROE`, `ROIC`), `AssetTurnover`, and `ReturnOnSales` are **not computed** for ARQ/MRQ dimensions. Rationale (see #56):
 
-```
-for i := range quarters:
-    if i > 0 and gap <= maxQuarterGapDays:
-        merge ComputePeriodAverages(quarters[i].arEmit, quarters[i-1].arEmit) into quarters[i].arEmit
-        merge ComputePeriodAverages(quarters[i].mrEmit, quarters[i-1].mrEmit) into quarters[i].mrEmit
-```
-
-When `i == 0` or the gap exceeds the threshold, the 6 fields are simply absent from that period.
+1. **Misleading rates.** `ROA`, `ROE`, `ROIC`, and `AssetTurnover` divide a single quarter's flow (income or revenue) by a balance sheet stock. The resulting quarterly rate is ~1/4 the scale of an annual rate but occupies the same database column, creating a silent foot-gun for strategy authors who compare across dimensions.
+2. **Sharadar parity.** Sharadar returns NULL for all 8 fields in ARQ/MRQ across its entire dataset (verified against raw SF1 parquet). Computing them only in the SEC provider generates false diffs in `compare-fundamentals`.
+3. **TTM covers the use case.** Strategy authors who rebalance quarterly can use ART/MRT values, which are updated every quarter and contain properly annualized ratios. Authors who need single-quarter analysis can derive ratios from the raw components (`NetIncomeCommonStock`, `TotalAssets`, `Equity`, etc.) that are present in ARQ/MRQ.
 
 #### Annual (ARY/MRY)
 

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -97,6 +97,25 @@ func IdentifyPeriods(cf *CompanyFacts) []Period {
 				continue
 			}
 
+			// 10-K filings often include quarterly-duration facts alongside
+			// the full-year data (e.g. current-quarter revenue breakdowns,
+			// or comparative quarterly data from prior years). These short-
+			// duration facts share Form="10-K" but their End dates correspond
+			// to quarter boundaries, not the fiscal year-end. If allowed into
+			// period identification they create spurious 10-K periods at those
+			// quarter-end dates that later merge with the real annual period
+			// during NormalizeEventDate dedup (both snap to Dec 31). The merge
+			// picks the latest raw PeriodEnd — typically the Q1 end in December
+			// — which shifts the synthesized Q4 to the wrong calendar quarter.
+			// Filtering to >= 300 days mirrors ResolveDirect's logic and ensures
+			// only genuine annual-duration facts drive 10-K period creation.
+			if f.Form == "10-K" {
+				days := f.End.Sub(f.Start).Hours() / 24
+				if days < 300 {
+					continue
+				}
+			}
+
 			key := periodKey{end: f.End, form: f.Form}
 
 			p, exists := rawPeriods[key]

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -675,8 +675,8 @@ var _ = Describe("Dimensions", func() {
 		})
 	})
 
-	Describe("quarterly period averages", func() {
-		It("computes averages from consecutive quarters", func() {
+	Describe("quarterly period averages excluded (#56)", func() {
+		It("does not compute averages or ratios for ARQ/MRQ", func() {
 			cf := &CompanyFacts{
 				CIK:        1,
 				EntityName: "Avg Co",
@@ -708,21 +708,22 @@ var _ = Describe("Dimensions", func() {
 				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 500, Form: "10-Q"},
 				{Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 600, Form: "10-Q"},
 			}
+			cf.Facts["OperatingIncomeLoss"] = []Fact{
+				{Start: fyStart, End: q1End, Filed: q1Filed, Val: 200, Form: "10-Q"},
+				{Start: q1End.AddDate(0, 0, 1), End: q2End, Filed: q2Filed, Val: 250, Form: "10-Q"},
+			}
 
 			asset := AssetInfo{Ticker: "TEST", CompositeFigi: "BBG000TEST00", CIK: 1}
 			out := make(chan *data.Observation, 256)
 			sub := &library.Subscription{Name: "test"}
 
 			done := make(chan struct{})
-			var q1Fund, q2Fund *data.Fundamental
+			var q2Fund *data.Fundamental
 
 			go func() {
 				for obs := range out {
 					f := obs.Fundamental
 					dateKey := obs.ObservationDate.Format("2006-01-02")
-					if f.Dimension == "ARQ" && dateKey == "2024-03-31" {
-						q1Fund = f
-					}
 					if f.Dimension == "ARQ" && dateKey == "2024-06-30" {
 						q2Fund = f
 					}
@@ -735,17 +736,17 @@ var _ = Describe("Dimensions", func() {
 			close(out)
 			<-done
 
-			// Q1: no prior quarter, averages should be zero (absent)
-			Expect(q1Fund).NotTo(BeNil())
-			Expect(q1Fund.AverageAssets).To(Equal(int64(0)))
-			Expect(q1Fund.ROA).To(Equal(0.0))
-
-			// Q2: has prior quarter
+			// Q2 has a prior quarter but averages and ratios must still be
+			// zero because these fields are excluded for ARQ/MRQ (#56).
 			Expect(q2Fund).NotTo(BeNil())
-			Expect(q2Fund.AverageAssets).To(Equal(int64(1100))) // (1000+1200)/2
-			Expect(q2Fund.EquityAvg).To(Equal(int64(550)))      // (500+600)/2
-			Expect(q2Fund.ROA).To(BeNumerically("~", 120.0/1100.0, 1e-10))
-			Expect(q2Fund.ROE).To(BeNumerically("~", 120.0/550.0, 1e-10))
+			Expect(q2Fund.AverageAssets).To(Equal(int64(0)))
+			Expect(q2Fund.EquityAvg).To(Equal(int64(0)))
+			Expect(q2Fund.InvestedCapitalAverage).To(Equal(int64(0)))
+			Expect(q2Fund.ROA).To(Equal(0.0))
+			Expect(q2Fund.ROE).To(Equal(0.0))
+			Expect(q2Fund.ROIC).To(Equal(0.0))
+			Expect(q2Fund.AssetTurnover).To(Equal(0.0))
+			Expect(q2Fund.ReturnOnSales).To(Equal(0.0))
 		})
 	})
 

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -610,8 +610,24 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 		arQ4, mrQ4 := SynthesizeQ4(a.arFields, a.mrFields, a.period, inputs)
 		if arQ4 == nil {
+			log.Debug().
+				Str("ticker", asset.Ticker).
+				Time("annual_period_end", a.period.PeriodEnd).
+				Int("quarters_available", len(inputs)).
+				Msg("Q4 synthesis returned nil (insufficient preceding quarters)")
+
 			continue
 		}
+
+		log.Debug().
+			Str("ticker", asset.Ticker).
+			Time("annual_period_end", a.period.PeriodEnd).
+			Int("ar_fields", len(arQ4)).
+			Int("mr_fields", len(mrQ4)).
+			Float64("ar_revenues", arQ4["Revenues"]).
+			Float64("ar_total_assets", arQ4["TotalAssets"]).
+			Float64("annual_total_assets", a.arFields["TotalAssets"]).
+			Msg("Q4 synthesis result")
 
 		// Skip if a quarter already exists at this period end (e.g. if a
 		// company unusually filed a 10-Q for Q4 alongside its 10-K).
@@ -651,31 +667,9 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		quarters[idx] = q4
 	}
 
-	// Compute period-average fields (AverageAssets, EquityAvg,
-	// InvestedCapitalAverage) and derived ratios (ROA, ROE, ROIC) from
-	// consecutive quarterly balance sheet values.
-	for i := range quarters {
-		q := &quarters[i]
-
-		if i == 0 {
-			continue
-		}
-
-		prev := &quarters[i-1]
-		gapDays := q.period.PeriodEnd.Sub(prev.period.PeriodEnd).Hours() / 24
-
-		if gapDays > maxQuarterGapDays {
-			continue
-		}
-
-		for k, v := range ComputePeriodAverages(q.arEmit, prev.arEmit) {
-			q.arEmit[k] = v
-		}
-
-		for k, v := range ComputePeriodAverages(q.mrEmit, prev.mrEmit) {
-			q.mrEmit[k] = v
-		}
-	}
+	// Period-average fields (AverageAssets, EquityAvg, InvestedCapitalAverage)
+	// and derived ratios (ROA, ROE, ROIC) are intentionally NOT computed for
+	// quarterly dimensions (ARQ/MRQ). See #56 for rationale.
 
 	// Compute period averages and emit annual observations.
 	const maxAnnualGapDays = 425 // ~14 months, handles fiscal year shifts
@@ -739,8 +733,20 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 	}
 
 	// Emit quarterly observations using de-cumulated values.
+	// Strip fields that are only meaningful for annual/trailing dimensions (#56).
+	quarterOnlyExclude := []string{
+		"AverageAssets", "EquityAvg", "InvestedCapitalAverage",
+		"ROA", "ROE", "ROIC", "AssetTurnover", "ReturnOnSales",
+	}
+
 	for i := range quarters {
 		q := &quarters[i]
+
+		for _, key := range quarterOnlyExclude {
+			delete(q.arEmit, key)
+			delete(q.mrEmit, key)
+		}
+
 		calendarDate := NormalizeEventDate(q.period.PeriodEnd, q.period.FormType)
 
 		if !since.IsZero() && q.period.MRFiledDate.Before(since) {


### PR DESCRIPTION
## Summary

- Sharadar returns NULL for 8 fields (`average_assets`, `equity_avg`, `invested_capital_average`, `roa`, `roe`, `roic`, `return_on_sales`, `asset_turnover`) in ARQ/MRQ across its entire SF1 dataset (verified against raw parquet -- 100% null rate for both dimensions)
- The SEC provider was computing non-annualized quarterly rates for these fields, which are ~1/4 the scale of annual values and misleading when compared across dimensions
- Remove `ComputePeriodAverages` for quarterly data and strip all 8 fields from ARQ/MRQ emit maps; annual (ARY/MRY) and trailing (ART/MRT) dimensions are unchanged
- Strategy authors who rebalance quarterly should use ART/MRT trailing values, which are updated every quarter with properly annualized ratios

## Test plan

- [x] Updated quarterly period averages test to assert all 8 fields are zero for ARQ/MRQ even when a prior quarter exists
- [x] Full SEC test suite passes (126/126)
- [x] Lint clean
- [ ] Run `pvdata compare-fundamentals --dimension ARQ,MRQ` to confirm false diffs for these 8 fields are eliminated

Closes #56