### PR TITLE
fix(sec): emit Q4 ARQ/MRQ rows at fiscal year-end (#58)

### DIFF
--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -208,6 +208,54 @@ var _ = Describe("Dimensions", func() {
 				}
 			})
 
+			It("excludes spurious 10-K periods created by short-duration quarterly facts", func() {
+				// SEC 10-K filings often include quarterly-duration facts
+				// (e.g. current-quarter revenue or comparative quarterly data)
+				// alongside full-year data. These short-duration facts share
+				// Form="10-K" but their End dates correspond to quarter boundaries.
+				// Without filtering, they create spurious 10-K periods that merge
+				// with the real annual period during NormalizeEventDate dedup
+				// (both snap to Dec 31), shifting PeriodEnd to December.
+				shortDurationCF := &CompanyFacts{
+					CIK:        320193,
+					EntityName: "Apple Inc",
+					Facts: map[string][]Fact{
+						"Revenues": {
+							// Full-year fact (genuine 10-K period)
+							{
+								Val:   400000,
+								Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+								Form:  "10-K",
+								FY:    2024,
+								FP:    "FY",
+								Filed: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC),
+							},
+							// Q1 quarterly-duration fact within the 10-K filing
+							{
+								Val:   110000,
+								Start: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(2023, 12, 30, 0, 0, 0, 0, time.UTC),
+								Form:  "10-K",
+								FY:    2024,
+								FP:    "Q1",
+								Filed: time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC),
+							},
+						},
+					},
+				}
+
+				periods := IdentifyPeriods(shortDurationCF)
+
+				// Should have exactly 1 10-K period at the actual fiscal year-end.
+				Expect(periods).To(HaveLen(1))
+				Expect(periods[0].FormType).To(Equal("10-K"))
+				// PeriodEnd must be the annual End date (Sep 28), NOT the
+				// quarterly End date (Dec 30) that would result from merging.
+				Expect(periods[0].PeriodEnd).To(Equal(
+					time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC)))
+			})
+
 			It("keeps distinct calendar quarters as separate periods", func() {
 				// Q2 2018 (2018-06-30) and Q3 2018 (2018-09-30) normalize to
 				// different calendar quarter ends and must remain separate.

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -424,14 +424,20 @@ var FieldMappings = []FieldMapping{
 		},
 	},
 	{
-		FieldName: "WeightedAverageShares", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		// Weighted average shares are period-average values, not cumulative
+		// flows. StmtPointInTime ensures Q4 synthesis copies the annual value
+		// directly (rather than computing annual - sum(Q1..Q3), which produces
+		// nonsensical negative numbers) and TTM uses the latest quarter's value
+		// (rather than summing 4 quarters, which would quadruple the count).
+		FieldName: "WeightedAverageShares", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
 		XBRLTags: []string{
 			"WeightedAverageNumberOfShareOutstandingBasicAndDiluted",
 			"WeightedAverageNumberOfSharesOutstandingBasic",
 		},
 	},
 	{
-		FieldName: "WeightedAverageSharesDiluted", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		// See WeightedAverageShares comment above for StatementType rationale.
+		FieldName: "WeightedAverageSharesDiluted", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
 		// WeightedAverageNumberOfSharesOutstandingBasic is the final fallback
 		// because in loss periods the diluted count is antidilutive and many
 		// filers omit the diluted tag entirely; in those cases basic ≡ diluted.

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -610,24 +610,8 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 		arQ4, mrQ4 := SynthesizeQ4(a.arFields, a.mrFields, a.period, inputs)
 		if arQ4 == nil {
-			log.Debug().
-				Str("ticker", asset.Ticker).
-				Time("annual_period_end", a.period.PeriodEnd).
-				Int("quarters_available", len(inputs)).
-				Msg("Q4 synthesis returned nil (insufficient preceding quarters)")
-
 			continue
 		}
-
-		log.Debug().
-			Str("ticker", asset.Ticker).
-			Time("annual_period_end", a.period.PeriodEnd).
-			Int("ar_fields", len(arQ4)).
-			Int("mr_fields", len(mrQ4)).
-			Float64("ar_revenues", arQ4["Revenues"]).
-			Float64("ar_total_assets", arQ4["TotalAssets"]).
-			Float64("annual_total_assets", a.arFields["TotalAssets"]).
-			Msg("Q4 synthesis result")
 
 		// Skip if a quarter already exists at this period end (e.g. if a
 		// company unusually filed a 10-Q for Q4 alongside its 10-K).


### PR DESCRIPTION
## Summary

- Reclassify `WeightedAverageShares` and `WeightedAverageSharesDiluted` from `StmtFlow` to `StmtPointInTime` so Q4 synthesis copies the annual value directly instead of computing `annual - sum(Q1..Q3)` (which produces negative numbers for period-average fields, triggering the `positive_shares` inline check blocker)
- Remove leftover debug logging from the Q4 synthesis path
- Add regression test for the short-duration 10-K fact filter in `IdentifyPeriods`

## Root cause

Two issues prevented synthesized Q4 ARQ/MRQ observations from reaching the database:

1. **Spurious 10-K period merging** (fixed in #56): quarterly-duration facts within 10-K filings created spurious periods that merged with real annual periods during `NormalizeEventDate` dedup, shifting `PeriodEnd` to December instead of the actual fiscal year-end.

2. **Incorrect share count classification** (this PR): `WeightedAverageShares` and `WeightedAverageSharesDiluted` were `StmtFlow`, so Q4 synthesis computed `Q4_shares = annual_shares - (Q1 + Q2 + Q3)`. Since weighted average shares are period-average values (not cumulative flows), this produced negative numbers, which failed the `positive_shares` critical inline check and blocked the observation.

## Verification

Ran `pvdata run` for AAPL followed by `compare-fundamentals --dimension ARQ,MRQ --since 2019-01-01`:
- Before: 13 `missing_in_sec` entries at fiscal year-end Sep 30 dates
- After: 0 `missing_in_sec` entries

## Test plan

- [x] Existing `SynthesizeQ4` unit tests pass (129 specs)
- [x] New regression test for short-duration 10-K fact filtering
- [x] Full test suite passes (`ginkgo run -race ./...`)
- [x] Lint clean (`make lint`)
- [x] AAPL comparison shows zero missing Q4 ARQ/MRQ rows

Closes #58