### PR TITLE
fix(sec): match Sharadar fundamentals for NVDA — 354→28 diffs (#65)

### DIFF
--- a/data/fundamental.go
+++ b/data/fundamental.go
@@ -763,6 +763,7 @@ func (fundamental *Fundamental) SaveDB(ctx context.Context, tbl string, dbConn *
 	) ON CONFLICT ON CONSTRAINT %[1]s_pkey DO UPDATE SET
 		ticker = EXCLUDED.ticker,
 		event_date = EXCLUDED.event_date,
+		date_key = EXCLUDED.date_key,
 		report_period = EXCLUDED.report_period,
 		last_updated = EXCLUDED.last_updated,
 		accumulated_other_comprehensive_income = EXCLUDED.accumulated_other_comprehensive_income,

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -196,15 +196,22 @@ func IdentifyPeriods(cf *CompanyFacts) []Period {
 //     (3/31, 6/30, 9/30, 12/31). For example, 2018-07-24 maps to 2018-06-30 (closer
 //     to the previous quarter end than the next), and 2018-09-29 maps to 2018-09-30
 //     (Apple's fiscal Q-end). Ties are broken by snapping forward.
-//   - Annual (10-K, ARY/MRY): always snaps to the calendar year end (12/31), so a
-//     fiscal year ending 2015-09-26 (Apple's FY2015) is reported as 2015-12-31.
+//   - Annual (10-K, ARY/MRY): snaps to 12/31 of the year determined by the nearest
+//     calendar quarter end. This handles companies whose fiscal year ends in January
+//     (e.g., NVDA FY2025 ending 2025-01-26 snaps to 2024-12-31 because Jan 26 is
+//     nearest to Q4 of the prior year).
 func NormalizeEventDate(periodEnd time.Time, formType string) time.Time {
 	if formType == "10-K" {
-		return time.Date(periodEnd.Year(), 12, 31, 0, 0, 0, 0, time.UTC)
+		qe := nearestQuarterEnd(periodEnd)
+		return time.Date(qe.Year(), 12, 31, 0, 0, 0, 0, time.UTC)
 	}
 
-	// Quarterly: snap to the nearest calendar quarter end. Build the candidate
-	// quarter ends bracketing the period end and pick whichever is closer.
+	return nearestQuarterEnd(periodEnd)
+}
+
+// nearestQuarterEnd snaps a date to the nearest calendar quarter end
+// (3/31, 6/30, 9/30, 12/31). Ties are broken by snapping forward.
+func nearestQuarterEnd(periodEnd time.Time) time.Time {
 	candidates := quarterEndCandidates(periodEnd)
 
 	// Truncate the period end to a date so the comparison is purely calendar-based.

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -521,7 +521,7 @@ func stripStaleAndRecompute(fields map[string]float64, stale map[string]bool) {
 // After de-cumulating direct fields, derived flow fields are recomputed from the
 // de-cumulated components. Metric-type derived fields (ratios) are then
 // recomputed from the updated flow/point-in-time values.
-func DecumulateYTD(cf *CompanyFacts, current, prior map[string]float64, periodEnd time.Time, formType string) map[string]float64 {
+func DecumulateYTD(cf *CompanyFacts, current, prior map[string]float64, priorPeriodEnd, periodEnd time.Time, formType string) map[string]float64 {
 	result := make(map[string]float64, len(current))
 	for k, v := range current {
 		result[k] = v
@@ -538,9 +538,27 @@ func DecumulateYTD(cf *CompanyFacts, current, prior map[string]float64, periodEn
 		}
 
 		currVal, hasCurr := current[m.FieldName]
+		if !hasCurr {
+			continue
+		}
+
+		// The prior map may hold a single-quarter value when
+		// ResolveDirect picked the shortest-duration fact. We need the
+		// prior's YTD cumulative for correct subtraction. Try
+		// ResolveLongestDuration first; fall back to the prior map.
 		priorVal, hasPrior := prior[m.FieldName]
 
-		if hasCurr && hasPrior {
+		if hasPrior && m.Type == MappingDirect {
+			if cumVal, ok := ResolveLongestDuration(cf, m, priorPeriodEnd, formType); ok {
+				if m.Negate {
+					cumVal = -cumVal
+				}
+
+				priorVal = cumVal
+			}
+		}
+
+		if hasPrior {
 			result[m.FieldName] = currVal - priorVal
 		}
 	}

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -312,6 +312,12 @@ var _ = Describe("Dimensions", func() {
 			Expect(d).To(Equal(time.Date(2018, 12, 31, 0, 0, 0, 0, time.UTC)))
 		})
 
+		It("normalizes January fiscal year end to prior calendar year", func() {
+			// NVDA's FY2025 ends Jan 26, 2025 — nearest quarter end is Dec 31, 2024
+			d := NormalizeEventDate(time.Date(2025, 1, 26, 0, 0, 0, 0, time.UTC), "10-K")
+			Expect(d).To(Equal(time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)))
+		})
+
 		// Sharadar comparability examples: a quarter ending mid-period should
 		// snap to whichever calendar quarter end is closest, not just the next
 		// one forward.

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -704,6 +704,9 @@ var _ = Describe("Dimensions", func() {
 				"_accruedIncomeTaxesNoncurrent":      true,
 				"_longTermDebtNoncurrent":            true,
 				"_operatingLeaseLiabilityNoncurrent": true,
+				"_paymentsInvestEquity":              true,
+				"_proceedsInvestEquity":              true,
+				"_deferredTaxAssets":                 true,
 			}
 
 			var missing []string

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -707,6 +707,7 @@ var _ = Describe("Dimensions", func() {
 				"_paymentsInvestEquity":              true,
 				"_proceedsInvestEquity":              true,
 				"_deferredTaxAssets":                 true,
+				"_taxWithholdingShareComp":           true,
 			}
 
 			var missing []string

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -475,3 +475,26 @@ func resolveSharesBasicAsOf(cf *CompanyFacts, asOfDate time.Time) (float64, bool
 
 	return best.Val, true
 }
+
+// overrideNCFDebtResidual recomputes NetCashFlowDebt as the residual of
+// the financing section: debt = financing - common - dividend. This captures
+// small items (finance lease payments, debt issuance costs) that are not
+// separately tagged in XBRL but are included in the financing total.
+//
+// Only applied when AccruedLiabilitiesCurrent is filed on 10-Q (NVDA),
+// indicating the company bundles financing items into broader categories.
+// For companies like AAPL that present debt cash flows as separate lines,
+// the direct XBRL-based computation is correct.
+func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64) {
+	if !conceptFiledQuarterly(cf, []string{"AccruedLiabilitiesCurrent"}) {
+		return
+	}
+
+	financing, hasF := fields["NetCashFlowFromFinancing"]
+	common, hasC := fields["NetCashFlowCommon"]
+	dividend, hasD := fields["NetCashFlowDividend"]
+
+	if hasF && hasC && hasD {
+		fields["NetCashFlowDebt"] = financing - common - dividend
+	}
+}

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -86,21 +86,31 @@ func ResolveDirect(cf *CompanyFacts, m FieldMapping, periodEnd time.Time, formTy
 				}
 			}
 
-			// Prefer the fact with the latest filing date (most recent data).
-			// When filing dates are equal, prefer the shorter duration. SEC
-			// 10-Q filings report both single-quarter (~90 days) and YTD
-			// cumulative (Q2: ~180, Q3: ~270 days) facts for income statement
-			// items. Cash flow items only have YTD facts. By preferring the
-			// shortest duration among same-filing-date facts, we pick the
-			// single-quarter value when available and fall through to the
-			// YTD value when it's the only option.
-			if best == nil || f.Filed.After(best.Filed) {
+			// Prefer single-quarter facts over YTD cumulative regardless of
+			// filing date. Comparative filings from later periods often
+			// include only the cumulative value (not single-quarter), so
+			// preferring the latest filing date would lose the original
+			// single-quarter fact. Within the same duration category,
+			// prefer the latest filing date (most recent data).
+			if best == nil {
 				best = f
-			} else if f.Filed.Equal(best.Filed) && !f.Start.IsZero() && !best.Start.IsZero() {
+			} else {
 				fDays := f.End.Sub(f.Start).Hours() / 24
 				bestDays := best.End.Sub(best.Start).Hours() / 24
+				fIsQuarterly := !f.Start.IsZero() && fDays <= ytdThresholdDays
+				bestIsQuarterly := !best.Start.IsZero() && bestDays <= ytdThresholdDays
 
-				if fDays < bestDays {
+				switch {
+				case fIsQuarterly && !bestIsQuarterly:
+					// Single-quarter always wins over cumulative.
+					best = f
+				case !fIsQuarterly && bestIsQuarterly:
+					// Keep the single-quarter fact.
+				case f.Filed.After(best.Filed):
+					// Same duration category: prefer latest filing.
+					best = f
+				case f.Filed.Equal(best.Filed) && !f.Start.IsZero() && !best.Start.IsZero() && fDays < bestDays:
+					// Same filing date: prefer shorter duration.
 					best = f
 				}
 			}

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -288,6 +288,13 @@ func ResolveAllFields(cf *CompanyFacts, periodEnd time.Time, formType string) ma
 			continue
 		}
 
+		// ExcludeIfQuarterly: skip this field if a sentinel concept is
+		// filed on 10-Q, indicating the field's tags are sub-components
+		// of a broader line item rather than separate balance sheet lines.
+		if len(m.ExcludeIfQuarterly) > 0 && conceptFiledQuarterly(cf, m.ExcludeIfQuarterly) {
+			continue
+		}
+
 		switch m.Type {
 		case MappingDirect:
 			if val, ok := ResolveDirect(cf, m, periodEnd, formType); ok {

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -295,6 +295,12 @@ func ResolveAllFields(cf *CompanyFacts, periodEnd time.Time, formType string) ma
 			continue
 		}
 
+		// RequireIfQuarterly: only resolve when a sentinel concept is
+		// filed on 10-Q. The inverse of ExcludeIfQuarterly.
+		if len(m.RequireIfQuarterly) > 0 && !conceptFiledQuarterly(cf, m.RequireIfQuarterly) {
+			continue
+		}
+
 		switch m.Type {
 		case MappingDirect:
 			if val, ok := ResolveDirect(cf, m, periodEnd, formType); ok {

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -708,17 +708,31 @@ var FieldMappings = []FieldMapping{
 			"ProceedsFromStockPlans", // NVDA uses this instead of the above
 		},
 	},
-	// NetCashFlowCommon = −repurchases + proceeds. Sharadar NCFCOMMON:
-	// "net cash inflow (outflow) from common equity changes."
-	// NOTE: Some companies (NVDA FY2026+) started bundling tax withholding
-	// for share-based compensation into the stock repurchase section. This
-	// creates quarterly diffs where Sharadar includes it but we don't.
-	// Adding it globally breaks AAPL/MSFT where it's a standalone line.
+	// Tax withholding for share-based compensation: some companies (NVDA)
+	// bundle this into the stock repurchase section of the cash flow
+	// statement when they start filing it on 10-Q. RequireQuarterly gates
+	// this to only resolve when the tag appears on 10-Q, which naturally
+	// handles the temporal transition (NVDA FY2025 had it only on 10-K).
+	// For companies that always file it on 10-Q (AAPL, MSFT), the tag IS
+	// already embedded in PaymentsForRepurchaseOfCommonStock, so adding it
+	// would double-count. RequireIfQuarterly on AccruedLiabilitiesCurrent
+	// excludes those companies.
+	{
+		FieldName: "_taxWithholdingShareComp", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		RequireQuarterly:   true,
+		RequireIfQuarterly: []string{"AccruedLiabilitiesCurrent"},
+		XBRLTags:           []string{"PaymentsRelatedToTaxWithholdingForShareBasedCompensation"},
+	},
+	// NetCashFlowCommon = −repurchases − taxWithholding + proceeds.
+	// The _taxWithholdingShareComp operand only resolves for companies that
+	// bundle it (RequireQuarterly + RequireIfQuarterly gate). For annual
+	// dimensions (ARY/MRY), the sub-field is stripped before emission to
+	// prevent the 10-K value from being included (see emitFundamentals).
 	{
 		FieldName: "NetCashFlowCommon", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
 		Op:               OpLinearCombination,
-		Operands:         []string{"_paymentsRepurchaseCommon", "_proceedsIssuanceCommon"},
-		Coefficients:     []float64{-1, 1},
+		Operands:         []string{"_paymentsRepurchaseCommon", "_proceedsIssuanceCommon", "_taxWithholdingShareComp"},
+		Coefficients:     []float64{-1, 1, -1},
 		OptionalOperands: true,
 	},
 	// --- Internal sub-fields for NetCashFlowDebt derivation ---

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -225,22 +225,26 @@ var FieldMappings = []FieldMapping{
 		Operands:         []string{"_goodwill", "_intangiblesExGoodwill"},
 		OptionalOperands: true,
 	},
+	// TaxAssets: try prepaid/receivable taxes first (FallbackTags on the
+	// derived wrapper). If none resolve, fall through to _deferredTaxAssets
+	// which is gated by RequireQuarterly — only companies that present
+	// deferred tax assets on 10-Q (NVDA) get the value; companies that
+	// only disclose in 10-K notes (AAPL) keep TaxAssets=0.
 	{
-		FieldName: "TaxAssets", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		XBRLTags: []string{
+		FieldName: "_deferredTaxAssets", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		RequireQuarterly: true,
+		XBRLTags:         []string{"DeferredIncomeTaxAssetsNet"},
+	},
+	{
+		FieldName: "TaxAssets", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+		FallbackTags: []string{
 			"IncomeTaxesReceivable",
 			"IncomeTaxReceivable",
 			"PrepaidTaxes",
 		},
-	},
-	// Some companies (NVDA) present deferred tax assets as a separate
-	// balance sheet line item on 10-Q; Sharadar picks this up as TaxAssets.
-	// Companies that only disclose it in 10-K notes (AAPL) have TaxAssets=0.
-	// RequireQuarterly ensures we only add it for companies that file on 10-Q.
-	{
-		FieldName: "TaxAssets", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		RequireQuarterly: true,
-		XBRLTags:         []string{"DeferredIncomeTaxAssetsNet"},
+		Op:               OpAdd,
+		Operands:         []string{"_deferredTaxAssets"},
+		OptionalOperands: true,
 	},
 	// --- Internal sub-fields for TaxLiabilities derivation ---
 	{

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -87,6 +87,16 @@ type FieldMapping struct {
 	// (supplemental note). Sharadar includes lease liabilities in debt for
 	// MSFT but not AAPL, matching this quarterly-availability signal.
 	RequireQuarterly bool
+
+	// ExcludeIfQuarterly is the inverse of RequireQuarterly: skip this
+	// field entirely if ANY of the listed sentinel concepts appear on a
+	// recent 10-Q filing. This detects when a concept is a sub-component
+	// of a broader balance sheet line item rather than a separate line.
+	// For example, NVDA files AccruedLiabilitiesCurrent (which bundles
+	// contract liabilities) so deferred_revenue should be 0; AAPL and
+	// MSFT present contract liabilities as a separate line and do not
+	// file AccruedLiabilitiesCurrent.
+	ExcludeIfQuarterly []string
 }
 
 // FieldMappings defines the complete mapping from XBRL to data.Fundamental fields.
@@ -270,9 +280,13 @@ var FieldMappings = []FieldMapping{
 	},
 	{
 		FieldName: "TaxLiabilities", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
-		Op:               OpAdd,
-		Operands:         []string{"_deferredTaxLiabilities", "_accruedIncomeTaxesCurrent", "_accruedIncomeTaxesNoncurrent"},
-		OptionalOperands: true,
+		// When AccruedLiabilitiesCurrent is filed on 10-Q, the company bundles
+		// tax liabilities into broader accrued/other line items (NVDA). Only
+		// resolve when tax items are separate balance sheet lines (MSFT).
+		ExcludeIfQuarterly: []string{"AccruedLiabilitiesCurrent"},
+		Op:                 OpAdd,
+		Operands:           []string{"_deferredTaxLiabilities", "_accruedIncomeTaxesCurrent", "_accruedIncomeTaxesNoncurrent"},
+		OptionalOperands:   true,
 	},
 	{
 		FieldName: "ShortTermDebt", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
@@ -328,8 +342,14 @@ var FieldMappings = []FieldMapping{
 		OptionalOperands: true,
 	},
 	// --- Internal sub-fields for DeferredRevenue derivation ---
+	// ExcludeIfQuarterly: when AccruedLiabilitiesCurrent is filed on 10-Q,
+	// contract liabilities are a sub-component of that broader line item
+	// (NVDA), not a separate balance sheet line. Sharadar reports 0 in
+	// that case. AAPL and MSFT present contract liabilities as their own
+	// line and do not file AccruedLiabilitiesCurrent.
 	{
 		FieldName: "_deferredRevenueCurrent", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AccruedLiabilitiesCurrent"},
 		XBRLTags: []string{
 			"DeferredRevenueCurrent",
 			"ContractWithCustomerLiabilityCurrent",
@@ -337,6 +357,7 @@ var FieldMappings = []FieldMapping{
 	},
 	{
 		FieldName: "_deferredRevenueNoncurrent", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AccruedLiabilitiesCurrent"},
 		XBRLTags: []string{
 			"DeferredRevenueNoncurrent",
 			"ContractWithCustomerLiabilityNoncurrent",
@@ -348,10 +369,11 @@ var FieldMappings = []FieldMapping{
 	// tag), OptionalOperands yields just the current value.
 	{
 		FieldName: "DeferredRevenue", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
-		FallbackTags:     []string{"DeferredRevenue"},
-		Op:               OpAdd,
-		Operands:         []string{"_deferredRevenueCurrent", "_deferredRevenueNoncurrent"},
-		OptionalOperands: true,
+		ExcludeIfQuarterly: []string{"AccruedLiabilitiesCurrent"},
+		FallbackTags:       []string{"DeferredRevenue"},
+		Op:                 OpAdd,
+		Operands:           []string{"_deferredRevenueCurrent", "_deferredRevenueNoncurrent"},
+		OptionalOperands:   true,
 	},
 	{
 		FieldName: "TotalLiabilities", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -97,6 +97,14 @@ type FieldMapping struct {
 	// MSFT present contract liabilities as a separate line and do not
 	// file AccruedLiabilitiesCurrent.
 	ExcludeIfQuarterly []string
+
+	// RequireIfQuarterly gates resolution on a sentinel concept: the
+	// field is only resolved when ANY of the listed concepts appear on
+	// a recent 10-Q filing. This is used for cash flow items that some
+	// companies bundle into a parent line (and thus should be added to
+	// a derived formula) while others present as a standalone line (and
+	// should not be added to avoid double-counting).
+	RequireIfQuarterly []string
 }
 
 // FieldMappings defines the complete mapping from XBRL to data.Fundamental fields.
@@ -701,9 +709,11 @@ var FieldMappings = []FieldMapping{
 		},
 	},
 	// NetCashFlowCommon = −repurchases + proceeds. Sharadar NCFCOMMON:
-	// "net cash inflow (outflow) from common equity changes." MSFT reports
-	// both repurchases and proceeds from employee stock plans; the net
-	// captures both sides.
+	// "net cash inflow (outflow) from common equity changes."
+	// NOTE: Some companies (NVDA FY2026+) started bundling tax withholding
+	// for share-based compensation into the stock repurchase section. This
+	// creates quarterly diffs where Sharadar includes it but we don't.
+	// Adding it globally breaks AAPL/MSFT where it's a standalone line.
 	{
 		FieldName: "NetCashFlowCommon", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
 		Op:               OpLinearCombination,

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -233,6 +233,15 @@ var FieldMappings = []FieldMapping{
 			"PrepaidTaxes",
 		},
 	},
+	// Some companies (NVDA) present deferred tax assets as a separate
+	// balance sheet line item on 10-Q; Sharadar picks this up as TaxAssets.
+	// Companies that only disclose it in 10-K notes (AAPL) have TaxAssets=0.
+	// RequireQuarterly ensures we only add it for companies that file on 10-Q.
+	{
+		FieldName: "TaxAssets", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		RequireQuarterly: true,
+		XBRLTags:         []string{"DeferredIncomeTaxAssetsNet"},
+	},
 	// --- Internal sub-fields for TaxLiabilities derivation ---
 	{
 		FieldName: "_deferredTaxLiabilities", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
@@ -310,8 +319,9 @@ var FieldMappings = []FieldMapping{
 	},
 	{
 		FieldName: "TotalDebt", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
-		Op:       OpAdd,
-		Operands: []string{"DebtCurrent", "DebtNonCurrent"},
+		Op:               OpAdd,
+		Operands:         []string{"DebtCurrent", "DebtNonCurrent"},
+		OptionalOperands: true,
 	},
 	// --- Internal sub-fields for DeferredRevenue derivation ---
 	{

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -671,6 +671,7 @@ var FieldMappings = []FieldMapping{
 		XBRLTags: []string{
 			"ProceedsFromIssuanceOfCommonStock",
 			"ProceedsFromStockOptionsExercised",
+			"ProceedsFromStockPlans", // NVDA uses this instead of the above
 		},
 	},
 	// NetCashFlowCommon = −repurchases + proceeds. Sharadar NCFCOMMON:
@@ -736,6 +737,16 @@ var FieldMappings = []FieldMapping{
 			"PaymentsToAcquireAvailableForSaleSecuritiesDebt",
 		},
 	},
+	// NVDA reports equity security purchases/sales separately from debt
+	// securities. Sharadar includes both in NetCashFlowInvest.
+	{
+		FieldName: "_paymentsInvestEquity", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{"PaymentsToAcquireEquitySecuritiesFvNi"},
+	},
+	{
+		FieldName: "_proceedsInvestEquity", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		XBRLTags: []string{"ProceedsFromSaleOfEquitySecuritiesFvNi"},
+	},
 	// Some companies report a combined maturities+sales tag; others report them
 	// separately. Split into two sub-fields and sum, with the combined tag as a
 	// fallback on _proceedsInvest so both cases are handled.
@@ -773,8 +784,8 @@ var FieldMappings = []FieldMapping{
 	{
 		FieldName: "NetCashFlowInvest", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
 		Op:               OpLinearCombination,
-		Operands:         []string{"_paymentsInvest", "_proceedsInvest"},
-		Coefficients:     []float64{-1, 1},
+		Operands:         []string{"_paymentsInvest", "_proceedsInvest", "_paymentsInvestEquity", "_proceedsInvestEquity"},
+		Coefficients:     []float64{-1, 1, -1, 1},
 		OptionalOperands: true,
 	},
 	{

--- a/provider/sec/market_data.go
+++ b/provider/sec/market_data.go
@@ -186,7 +186,9 @@ func EnrichMarketData(fundamentals []*data.Fundamental, lookupPrice PriceLookupF
 				f.PE1 = f.Price / f.EPS
 			}
 
-			if f.SalesPerShare != 0 {
+			if f.Revenues != 0 && f.WeightedAverageShares != 0 {
+				f.PS1 = f.Price / (float64(f.Revenues) / float64(f.WeightedAverageShares))
+			} else if f.SalesPerShare != 0 {
 				f.PS1 = f.Price / f.SalesPerShare
 			}
 

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -957,6 +957,14 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			continue
 		}
 
+		// Override NetCashFlowDebt for quarterly dimensions as the residual
+		// of financing cash flow: debt = financing - common - dividend.
+		// Sharadar's quarterly NCFDEBT captures small items (e.g. finance
+		// lease payments) that aren't separately tagged in XBRL. The
+		// residual naturally picks them up when the other components match.
+		overrideNCFDebtResidual(cf, q.arEmit)
+		overrideNCFDebtResidual(cf, q.mrEmit)
+
 		// ARQ
 		fundamental := BuildFundamental(q.arEmit, asset.Ticker, asset.CompositeFigi, "ARQ",
 			q.period.ARFiledDate, calendarDate, q.period.PeriodEnd, q.period.ARFiledDate)

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -773,6 +773,19 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		}
 	}
 
+	// Override SharesBasic in arEmit for AR dimensions. The standard
+	// ResolveDirect matches EntityCommonStockSharesOutstanding by normalized
+	// date, which fails for companies whose DEI end dates are in a different
+	// quarter than the fiscal period end (e.g., NVDA's January FY has DEI
+	// dates in February that normalize to the next quarter). Use the same
+	// filing-date resolution with the AR filing date to pick the DEI fact
+	// from the actual filing.
+	for i := range quarters {
+		if val, ok := resolveSharesBasicAsOf(cf, quarters[i].period.ARFiledDate); ok {
+			quarters[i].arEmit["SharesBasic"] = val
+		}
+	}
+
 	// Strip stale fields from MR quarterly emit maps and recompute derived
 	// fields. This must happen before TTM computation so that trailing sums
 	// use the corrected MR values.
@@ -881,7 +894,11 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			continue
 		}
 
-		// ARY
+		// ARY — override SharesBasic for AR semantics (see quarterly override above).
+		if val, ok := resolveSharesBasicAsOf(cf, a.period.ARFiledDate); ok {
+			a.arEmit["SharesBasic"] = val
+		}
+
 		fundamental := BuildFundamental(a.arEmit, asset.Ticker, asset.CompositeFigi, "ARY",
 			a.period.ARFiledDate, calendarDate, a.period.PeriodEnd, a.period.ARFiledDate)
 		buffered = append(buffered, &data.Observation{

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -899,6 +899,13 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			a.arEmit["SharesBasic"] = val
 		}
 
+		// Strip tax withholding from annual emit maps: Sharadar only
+		// includes it in quarterly NCFCOMMON when the company files it on
+		// 10-Q, not in the annual aggregation.
+		annualTWHStale := map[string]bool{"_taxWithholdingShareComp": true}
+		stripStaleAndRecompute(a.arEmit, annualTWHStale)
+		stripStaleAndRecompute(a.mrEmit, annualTWHStale)
+
 		fundamental := BuildFundamental(a.arEmit, asset.Ticker, asset.CompositeFigi, "ARY",
 			a.period.ARFiledDate, calendarDate, a.period.PeriodEnd, a.period.ARFiledDate)
 		buffered = append(buffered, &data.Observation{

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -679,8 +679,8 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			if gapDays <= maxQuarterGapDays {
 				// Consecutive quarter in same fiscal year: de-cumulate using
 				// the prior quarter's ORIGINAL (pre-de-cumulation) YTD values.
-				q.arEmit = DecumulateYTD(cf, q.arFields, prev.arFields, q.period.PeriodEnd, q.period.FormType)
-				q.mrEmit = DecumulateYTD(cf, q.mrFields, prev.mrFields, q.period.PeriodEnd, q.period.FormType)
+				q.arEmit = DecumulateYTD(cf, q.arFields, prev.arFields, prev.period.PeriodEnd, q.period.PeriodEnd, q.period.FormType)
+				q.mrEmit = DecumulateYTD(cf, q.mrFields, prev.mrFields, prev.period.PeriodEnd, q.period.PeriodEnd, q.period.FormType)
 
 				continue
 			}


### PR DESCRIPTION
## Summary

11 commits reducing NVDA diffs from 354 to 28. Key fixes:

- **NormalizeEventDate** for 10-K: snap fiscal year end to nearest quarter end — fixes January FY-end companies
- **AR SharesBasic override**: filing-date-based DEI resolution for AR dimensions
- **ExcludeIfQuarterly / RequireIfQuarterly gates**: sentinel-based field gating
- **TaxAssets**: DeferredIncomeTaxAssetsNet via derived field + RequireQuarterly
- **TotalDebt**: OptionalOperands=true for quarters missing DebtCurrent
- **DeferredRevenue + TaxLiabilities**: ExcludeIfQuarterly on AccruedLiabilitiesCurrent
- **NetCashFlowCommon**: ProceedsFromStockPlans + tax withholding for bundled companies
- **NetCashFlowInvest**: equity securities FvNi tags
- **NetCashFlowDebt**: compute as financing residual for bundled companies
- **De-cumulation bug**: ResolveLongestDuration for prior quarter cumulative value
- **ResolveDirect**: prefer single-quarter facts over cumulative from later filings
- **PS1 precision**: compute from full-precision revenue/shares
- **fundamental.go**: fix date_key not updated on upsert

## Results

| Ticker | Before | After |
|--------|--------|-------|
| NVDA | 354 | 28 |
| AAPL | 0 | 0 |
| MSFT | 0 | 0 |

## Remaining 28 diffs

All originate from Q4 FY2025 (date_key 2024-12-31) and cascade into trailing (ART/MRT):

| Diffs | Root Cause |
|-------|------------|
| 10 | NCFCOMMON: tax withholding included for FY2025 but Sharadar's snapshot excludes it |
| 7+7 | NCFBUS/NCFINVEST: equity securities tag not in original Q1 FY2025 filing (retrospective only), causing Q4 synthesis mismatch |
| 2 | NCFDEBT annual: $129M finance lease with no XBRL tag |
| 2 | gross_margin: $1M Q4 cost_of_revenue synthesis rounding |

## Test plan

- [x] `ginkgo run ./provider/sec/` — 153 passed, 0 failed
- [x] AAPL regression: 0 diffs
- [x] MSFT regression: 0 diffs
- [x] NVDA: 354 → 28 diffs (92% reduction)