### PR TITLE
fix(sec): add bank-specific XBRL mappings for JPM validation (#66)

### DIFF
--- a/provider/sec/cik.go
+++ b/provider/sec/cik.go
@@ -92,26 +92,28 @@ func FetchCompanyTickers(ctx context.Context, client *resty.Client) (map[int]CIK
 	return entries, nil
 }
 
-// LoadCIKMapFromDB loads a CIK -> AssetInfo map from the assets in the database.
-// This provides the primary lookup path for resolving CIKs to tickers and FIGIs.
-// The pool parameter is *pgxpool.Pool (Library.Pool is a public field, not a method).
-func LoadCIKMapFromDB(ctx context.Context, pool *pgxpool.Pool) (map[int]AssetInfo, error) {
+// LoadCIKMapFromDB loads asset information from the database, returning two
+// maps: a CIK-keyed map (one representative entry per CIK) and a ticker-keyed
+// map (every asset with a CIK). Multiple tickers can share a single CIK (e.g.
+// JPM, AMJ, AMJB, VYLD all belong to CIK 19617). The CIK map picks one entry
+// arbitrarily; callers that need to look up a specific ticker should consult
+// the ticker map.
+func LoadCIKMapFromDB(ctx context.Context, pool *pgxpool.Pool) (map[int]AssetInfo, map[string]AssetInfo, error) {
 	conn, err := pool.Acquire(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("acquiring connection: %w", err)
+		return nil, nil, fmt.Errorf("acquiring connection: %w", err)
 	}
 	defer conn.Release()
 
-	// Note: The actual table and column names must match your schema.
-	// Check the assets table DDL in data/datatype.go for exact column names.
 	rows, err := conn.Query(ctx,
 		`SELECT ticker, composite_figi, cik FROM assets WHERE cik IS NOT NULL AND cik != ''`)
 	if err != nil {
-		return nil, fmt.Errorf("querying assets: %w", err)
+		return nil, nil, fmt.Errorf("querying assets: %w", err)
 	}
 	defer rows.Close()
 
-	result := make(map[int]AssetInfo)
+	byCIK := make(map[int]AssetInfo)
+	byTicker := make(map[string]AssetInfo)
 
 	for rows.Next() {
 		var ticker, figi, cikStr string
@@ -125,12 +127,15 @@ func LoadCIKMapFromDB(ctx context.Context, pool *pgxpool.Pool) (map[int]AssetInf
 			continue
 		}
 
-		result[cik] = AssetInfo{
+		info := AssetInfo{
 			Ticker:        ticker,
 			CompositeFigi: figi,
 			CIK:           cik,
 		}
+
+		byCIK[cik] = info
+		byTicker[ticker] = info
 	}
 
-	return result, rows.Err()
+	return byCIK, byTicker, rows.Err()
 }

--- a/provider/sec/companyfacts.go
+++ b/provider/sec/companyfacts.go
@@ -376,6 +376,7 @@ func EnrichWithExtensionFacts(ctx context.Context, client *resty.Client, cik int
 			}
 		}
 	}
+
 done:
 
 	log.Debug().Int("cik", cik).Int("filings", len(filings)).Msg("enriching with extension facts from XBRL instance documents")

--- a/provider/sec/companyfacts.go
+++ b/provider/sec/companyfacts.go
@@ -277,13 +277,6 @@ func EnrichWithExtensionFacts(ctx context.Context, client *resty.Client, cik int
 	}
 
 	root := gjson.ParseBytes(resp.Body())
-	recent := root.Get("filings.recent")
-
-	forms := recent.Get("form").Array()
-	accessions := recent.Get("accessionNumber").Array()
-	docs := recent.Get("primaryDocument").Array()
-	filingDates := recent.Get("filingDate").Array()
-	reportDates := recent.Get("reportDate").Array()
 
 	// Collect recent 10-K and 10-Q filings for extension enrichment. We need
 	// enough history so that Q4 synthesis for the prior fiscal year uses
@@ -305,39 +298,85 @@ func EnrichWithExtensionFacts(ctx context.Context, client *resty.Client, cik int
 	// If a filing cutoff is set, skip filings filed after it.
 	cutoff, hasCutoff := provider.FilingCutoffFromContext(ctx)
 
-	for i := range forms {
-		form := forms[i].String()
-		if form != "10-K" && form != "10-Q" {
-			continue
-		}
+	// scanFilingList scans a gjson filing list (recent or overflow) for
+	// 10-K and 10-Q filings. Returns true when we've found enough.
+	scanFilingList := func(list gjson.Result) bool {
+		forms := list.Get("form").Array()
+		accessions := list.Get("accessionNumber").Array()
+		docs := list.Get("primaryDocument").Array()
+		filingDates := list.Get("filingDate").Array()
+		reportDates := list.Get("reportDate").Array()
 
-		fi := filingInfo{
-			accession: accessions[i].String(),
-			doc:       docs[i].String(),
-			filedDate: filingDates[i].String(),
-			form:      form,
-		}
-
-		if i < len(reportDates) {
-			fi.reportDate = reportDates[i].String()
-		}
-
-		// Skip filings filed after the cutoff date.
-		if hasCutoff {
-			if filedTime, err := time.Parse(dateFormat, fi.filedDate); err == nil && filedTime.After(cutoff) {
+		for i := range forms {
+			form := forms[i].String()
+			if form != "10-K" && form != "10-Q" {
 				continue
+			}
+
+			fi := filingInfo{
+				accession: accessions[i].String(),
+				doc:       docs[i].String(),
+				filedDate: filingDates[i].String(),
+				form:      form,
+			}
+
+			if i < len(reportDates) {
+				fi.reportDate = reportDates[i].String()
+			}
+
+			if hasCutoff {
+				if filedTime, err := time.Parse(dateFormat, fi.filedDate); err == nil && filedTime.After(cutoff) {
+					continue
+				}
+			}
+
+			filings = append(filings, fi)
+
+			if form == "10-K" {
+				kCount++
+				if kCount >= 3 {
+					return true
+				}
 			}
 		}
 
-		filings = append(filings, fi)
+		return false
+	}
 
-		if form == "10-K" {
-			kCount++
-			if kCount >= 3 {
-				break // stop after the third 10-K
+	// Scan the recent filings first.
+	if scanFilingList(root.Get("filings.recent")) {
+		goto done
+	}
+
+	// If we haven't found enough 10-K filings, load overflow submission
+	// files. Large filers (e.g. JPM with 23K+ filings/year) push older
+	// 10-K/10-Q filings into overflow files.
+	{
+		overflowFiles := root.Get("filings.files").Array()
+		for _, f := range overflowFiles {
+			if ctx.Err() != nil {
+				break
+			}
+
+			fileName := f.Get("name").String()
+			if fileName == "" {
+				continue
+			}
+
+			overflowURL := submissionsURL + fileName
+
+			overflowResp, err := client.R().SetContext(ctx).Get(overflowURL)
+			if err != nil || overflowResp.StatusCode() != http.StatusOK {
+				log.Debug().Str("file", fileName).Msg("failed to fetch overflow submissions file")
+				continue
+			}
+
+			if scanFilingList(gjson.ParseBytes(overflowResp.Body())) {
+				break
 			}
 		}
 	}
+done:
 
 	log.Debug().Int("cik", cik).Int("filings", len(filings)).Msg("enriching with extension facts from XBRL instance documents")
 

--- a/provider/sec/companyfacts.go
+++ b/provider/sec/companyfacts.go
@@ -389,7 +389,12 @@ done:
 	}
 
 	// Log extension facts found for key concepts.
-	for _, key := range []string{"DepreciationAmortizationAndOther"} {
+	for _, key := range []string{
+		"DepreciationAmortizationAndOther",
+		"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets",
+		"AccruedInterestAndAccountsReceivable",
+		"PropertyPlantAndEquipmentAndOperatingLeaseRightOfUseAssetAfterAccumulatedDepreciationAndAmortization",
+	} {
 		if facts, ok := cf.Facts[key]; ok {
 			for _, f := range facts {
 				log.Debug().Str("concept", key).Time("end", f.End).Time("start", f.Start).Time("filed", f.Filed).Str("form", f.Form).Float64("val", f.Val).Msg("extension fact")

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -364,13 +364,13 @@ func ResolveCumulativePerShareForFiling(cf *CompanyFacts, periodEnd time.Time, f
 	result := make(map[string]float64)
 
 	for _, m := range FieldMappings {
-		// Per-share flow fields: YTD cumulative avoids rounding error when
-		// summing individually rounded quarterly per-share values.
-		// Period-average fields (e.g. WeightedAverageShares): the company-
-		// reported YTD average captures day-weighted precision that is lost
-		// when summing individually rounded quarterly averages.
+		// Flow fields: YTD cumulative avoids rounding error from summing
+		// individually rounded quarterly values, and captures any cross-
+		// quarter restatements (e.g. JPM Q3 cumulative 43,199M vs single-
+		// quarter sum 43,197M). Period-average fields: the company-reported
+		// YTD average captures day-weighted precision.
 		switch {
-		case m.StatementType == StmtFlow && m.ValueType == "float64":
+		case m.StatementType == StmtFlow:
 		case m.StatementType == StmtPeriodAverage:
 		default:
 			continue

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -178,23 +178,30 @@ func IdentifyPeriods(cf *CompanyFacts) []Period {
 		}
 	}
 
-	// Filter out spurious periods whose raw PeriodEnd is too far from the
-	// nearest calendar quarter end. Banks (JPM) have facts with non-standard
-	// dates (e.g., EntityCommonStockSharesOutstanding at 2025-01-31 on 10-K
-	// cover page, PaymentsToAcquireBusinessesGross at acquisition closing
-	// dates). These create ghost periods that disrupt TTM computation.
-	const maxGhostPeriodDays = 10
-
+	// Filter out spurious 10-Q periods at fiscal year-end dates. Banks (JPM)
+	// have 10-Q facts at the annual period end (comparative data + one-off
+	// transaction dates like PaymentsToAcquireBusinessesGross at 2025-01-31
+	// which normalizes to 2024-12-31). When a 10-K period exists at the same
+	// normalized date AND the 10-Q's raw PeriodEnd is far from the normalized
+	// date (> 10 days), the 10-Q is spurious — not a real quarterly filing.
+	// Real quarterly filings have PeriodEnd within a few days of their
+	// normalized quarter end (e.g., AAPL Q1 at 2024-12-28 → 2024-12-31).
 	periods := make([]Period, 0, len(dedupedPeriods))
 	for _, p := range dedupedPeriods {
-		qe := nearestQuarterEnd(p.PeriodEnd)
-		dist := p.PeriodEnd.Sub(qe)
-		if dist < 0 {
-			dist = -dist
-		}
+		if p.FormType == "10-Q" {
+			normalEnd := NormalizeEventDate(p.PeriodEnd, p.FormType)
+			annualKey := periodKey{end: normalEnd, form: "10-K"}
 
-		if dist.Hours()/24 > maxGhostPeriodDays {
-			continue
+			if _, hasAnnual := dedupedPeriods[annualKey]; hasAnnual {
+				dist := p.PeriodEnd.Sub(normalEnd)
+				if dist < 0 {
+					dist = -dist
+				}
+
+				if dist.Hours()/24 > 10 {
+					continue
+				}
+			}
 		}
 
 		periods = append(periods, *p)

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -369,9 +369,8 @@ func ResolveCumulativePerShareForFiling(cf *CompanyFacts, periodEnd time.Time, f
 		// quarter restatements (e.g. JPM Q3 cumulative 43,199M vs single-
 		// quarter sum 43,197M). Period-average fields: the company-reported
 		// YTD average captures day-weighted precision.
-		switch {
-		case m.StatementType == StmtFlow:
-		case m.StatementType == StmtPeriodAverage:
+		switch m.StatementType {
+		case StmtFlow, StmtPeriodAverage:
 		default:
 			continue
 		}

--- a/provider/sec/dimensions.go
+++ b/provider/sec/dimensions.go
@@ -178,8 +178,25 @@ func IdentifyPeriods(cf *CompanyFacts) []Period {
 		}
 	}
 
+	// Filter out spurious periods whose raw PeriodEnd is too far from the
+	// nearest calendar quarter end. Banks (JPM) have facts with non-standard
+	// dates (e.g., EntityCommonStockSharesOutstanding at 2025-01-31 on 10-K
+	// cover page, PaymentsToAcquireBusinessesGross at acquisition closing
+	// dates). These create ghost periods that disrupt TTM computation.
+	const maxGhostPeriodDays = 10
+
 	periods := make([]Period, 0, len(dedupedPeriods))
 	for _, p := range dedupedPeriods {
+		qe := nearestQuarterEnd(p.PeriodEnd)
+		dist := p.PeriodEnd.Sub(qe)
+		if dist < 0 {
+			dist = -dist
+		}
+
+		if dist.Hours()/24 > maxGhostPeriodDays {
+			continue
+		}
+
 		periods = append(periods, *p)
 	}
 

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -717,6 +717,7 @@ var _ = Describe("Dimensions", func() {
 				"_bankLTDebtRepayments":              true,
 				"_bankSTDebtProceeds":                true,
 				"_bankOtherInvesting":                true,
+				"_bankOtherNoninterestExpense":       true,
 			}
 
 			var missing []string

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -712,6 +712,10 @@ var _ = Describe("Dimensions", func() {
 				"_bankShortTermDebt":                 true,
 				"_bankLongTermDebt":                  true,
 				"_bankFederalFundsPurchased":         true,
+				"_bankFedFundsChange":                true,
+				"_bankLTDebtProceeds":                true,
+				"_bankLTDebtRepayments":              true,
+				"_bankSTDebtProceeds":                true,
 			}
 
 			var missing []string

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -716,6 +716,7 @@ var _ = Describe("Dimensions", func() {
 				"_bankLTDebtProceeds":                true,
 				"_bankLTDebtRepayments":              true,
 				"_bankSTDebtProceeds":                true,
+				"_bankOtherInvesting":                true,
 			}
 
 			var missing []string

--- a/provider/sec/dimensions_test.go
+++ b/provider/sec/dimensions_test.go
@@ -709,6 +709,9 @@ var _ = Describe("Dimensions", func() {
 				"_deferredTaxAssets":                 true,
 				"_taxWithholdingShareComp":           true,
 				"_repaymentsFinancedAssets":          true,
+				"_bankShortTermDebt":                 true,
+				"_bankLongTermDebt":                  true,
+				"_bankFederalFundsPurchased":         true,
 			}
 
 			var missing []string

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -516,6 +516,20 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		fields["NetCashFlowDebt"] = financing - common - dividend
 	}
 
+	// For banks, derive OperatingIncome = GrossProfit - OperatingExpenses
+	// when OperatingIncomeLoss isn't available. OperatingExpenses resolves
+	// from NoninterestExpense FallbackTag, and GrossProfit = Revenues.
+	if isBank {
+		if _, hasOI := fields["OperatingIncome"]; !hasOI {
+			gp, hasGP := fields["GrossProfit"]
+			opex, hasOE := fields["OperatingExpenses"]
+
+			if hasGP && hasOE {
+				fields["OperatingIncome"] = gp - opex
+			}
+		}
+	}
+
 	// For banks, also recompute NetCashFlowInvest as the residual of the
 	// investing section: invest = total_investing - capex. Bank investing
 	// activities include loan originations, fed funds, and repo transactions

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -17,6 +17,7 @@ package sec
 
 import (
 	"math"
+	"strings"
 	"time"
 )
 
@@ -513,7 +514,29 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 	dividend, hasD := fields["NetCashFlowDividend"]
 
 	if hasF && hasC && hasD {
-		fields["NetCashFlowDebt"] = financing - common - dividend
+		ncfDebt := financing - common - dividend
+
+		// For banks, subtract preferred stock activities (issuance/repurchase)
+		// from the residual. These are in the financing total but are not debt.
+		if isBank {
+			prefTags := []string{
+				"ProceedsFromIssuanceOfPreferredStockAndPreferenceStock",
+				"PaymentsForRepurchaseOfRedeemablePreferredStock",
+				"PaymentsForRepurchaseOfPreferredStockAndPreferenceStock",
+			}
+
+			for _, tag := range prefTags {
+				if v, ok := ResolveDirect(cf, FieldMapping{XBRLTags: []string{tag}}, periodEnd, formType); ok {
+					if strings.HasPrefix(tag, "Proceeds") {
+						ncfDebt -= v // proceeds increase financing, subtract from debt
+					} else {
+						ncfDebt += v // payments decrease financing, add back to debt
+					}
+				}
+			}
+		}
+
+		fields["NetCashFlowDebt"] = ncfDebt
 	}
 
 	// For banks, derive OperatingIncome = GrossProfit - OperatingExpenses

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -548,6 +548,16 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		}
 	}
 
+	// For banks, ensure NetCashFlowBusiness is present in the fields map
+	// (even as 0) so the strictFlow TTM check passes. Without this, quarters
+	// where no acquisitions occurred have the field absent, causing the
+	// MRT TTM to skip it entirely (found < 4 with strictFlow=true).
+	if isBank {
+		if _, ok := fields["NetCashFlowBusiness"]; !ok {
+			fields["NetCashFlowBusiness"] = 0
+		}
+	}
+
 	// For banks, derive OperatingIncome = GrossProfit - OperatingExpenses
 	// when OperatingIncomeLoss isn't available. OperatingExpenses resolves
 	// from NoninterestExpense FallbackTag, and GrossProfit = Revenues.

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -626,8 +626,8 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		}{
 			// JPM 10-K and 10-Q use different casing for extension concepts.
 			{"Intangibles", []string{
-				"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets",   // 10-Q
-				"GoodwillServicingAssetsatFairValueandOtherIntangibleAssets",   // 10-K
+				"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets", // 10-Q
+				"GoodwillServicingAssetsatFairValueandOtherIntangibleAssets", // 10-K
 			}},
 			{"PropertyPlantAndEquipmentNet", []string{
 				"PropertyPlantAndEquipmentAndOperatingLeaseRightOfUseAssetAfterAccumulatedDepreciationAndAmortization",

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -571,8 +571,11 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 	if isBank {
 		investing, hasI := fields["NetCashFlowFromInvesting"]
 		if hasI {
-			capex, _ := fields["CapitalExpenditure"] // 0 when absent (banks)
-			fields["NetCashFlowInvest"] = investing - capex
+			capex, _ := fields["CapitalExpenditure"]     // 0 when absent (banks)
+			otherInv, _ := fields["_bankOtherInvesting"] // 0 when absent
+			// Add back "other" investing (it's a net payment included in the
+			// investing total but NOT in Sharadar's NCFINV).
+			fields["NetCashFlowInvest"] = investing - capex + otherInv
 		}
 	}
 

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -516,6 +516,29 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		fields["NetCashFlowDebt"] = financing - common - dividend
 	}
 
+	// For banks, recompute derived income fields from their Q4 components.
+	// The Q4 synthesis computes each field independently (Annual - Q1-Q2-Q3),
+	// but when NetIncome uses the cumulative path (43,199) while the Q1-Q3
+	// EBT sum uses single-quarter NI (43,197), derived fields like EBT/EBIT
+	// get a 2M inconsistency. Recomputing from formulas ensures consistency.
+	if isBank {
+		if ni, hasNI := fields["NetIncome"]; hasNI {
+			tax, _ := fields["IncomeTaxExpense"]
+			intExp, _ := fields["InterestExpense"]
+			da, _ := fields["DepreciationAmortizationAndAccretion"]
+
+			fields["EBT"] = ni + tax
+			fields["EBIT"] = ni + tax + intExp
+			fields["EBITDA"] = ni + tax + intExp + da
+
+			// Recompute NCI from corrected values
+			if consolidated, hasCons := fields["ConsolidatedIncome"]; hasCons {
+				pref, _ := fields["PreferredDividendsIncomeStatementImpact"]
+				fields["NetIncomeToNonControllingInterests"] = consolidated - ni - pref
+			}
+		}
+	}
+
 	// For banks, override NCFDEBT with a direct computation from de-cumulated
 	// bank-specific fields. The residual approach doesn't work for banks
 	// because the financing total includes deposits, preferred stock, and

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -17,7 +17,6 @@ package sec
 
 import (
 	"math"
-	"strings"
 	"time"
 )
 
@@ -514,29 +513,39 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 	dividend, hasD := fields["NetCashFlowDividend"]
 
 	if hasF && hasC && hasD {
-		ncfDebt := financing - common - dividend
+		fields["NetCashFlowDebt"] = financing - common - dividend
+	}
 
-		// For banks, subtract preferred stock activities (issuance/repurchase)
-		// from the residual. These are in the financing total but are not debt.
-		if isBank {
-			prefTags := []string{
-				"ProceedsFromIssuanceOfPreferredStockAndPreferenceStock",
-				"PaymentsForRepurchaseOfRedeemablePreferredStock",
-				"PaymentsForRepurchaseOfPreferredStockAndPreferenceStock",
-			}
+	// For banks, override NCFDEBT with a direct computation from de-cumulated
+	// bank-specific fields. The residual approach doesn't work for banks
+	// because the financing total includes deposits, preferred stock, and
+	// other non-debt items. The sub-fields (_bankFedFundsChange, etc.) are
+	// mapped as StmtFlow in FieldMappings so YTD cumulative values are
+	// properly de-cumulated before reaching this point.
+	if isBank {
+		bankDebtFields := []struct {
+			name string
+			sign float64
+		}{
+			{"_bankFedFundsChange", 1},
+			{"_bankLTDebtProceeds", 1},
+			{"_bankLTDebtRepayments", -1},
+			{"_bankSTDebtProceeds", 1},
+		}
 
-			for _, tag := range prefTags {
-				if v, ok := ResolveDirect(cf, FieldMapping{XBRLTags: []string{tag}}, periodEnd, formType); ok {
-					if strings.HasPrefix(tag, "Proceeds") {
-						ncfDebt -= v // proceeds increase financing, subtract from debt
-					} else {
-						ncfDebt += v // payments decrease financing, add back to debt
-					}
-				}
+		ncfDebt := 0.0
+		found := false
+
+		for _, f := range bankDebtFields {
+			if v, ok := fields[f.name]; ok {
+				ncfDebt += f.sign * v
+				found = true
 			}
 		}
 
-		fields["NetCashFlowDebt"] = ncfDebt
+		if found {
+			fields["NetCashFlowDebt"] = ncfDebt
+		}
 	}
 
 	// For banks, derive OperatingIncome = GrossProfit - OperatingExpenses

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -573,9 +573,11 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		if hasI {
 			capex, _ := fields["CapitalExpenditure"]     // 0 when absent (banks)
 			otherInv, _ := fields["_bankOtherInvesting"] // 0 when absent
-			// Add back "other" investing (it's a net payment included in the
-			// investing total but NOT in Sharadar's NCFINV).
-			fields["NetCashFlowInvest"] = investing - capex + otherInv
+			biz, _ := fields["NetCashFlowBusiness"]      // 0 when absent; already negated
+			// Add back "other" investing and subtract business acquisitions
+			// (both are in the investing total but Sharadar classifies them
+			// separately as NCFBIZ and other, not NCFINV).
+			fields["NetCashFlowInvest"] = investing - capex + otherInv - biz
 		}
 	}
 
@@ -610,14 +612,12 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 	// For banks, compute SGA = NoninterestExpense - OtherNoninterestExpense.
 	// Sharadar excludes "OtherNoninterestExpense" (a catch-all for misc items
 	// like FDIC assessments, regulatory fees, litigation) from SGA.
+	// Uses the mapped _bankOtherNoninterestExpense field which is properly
+	// de-cumulated (critical for Q4 synthesis where the raw tag isn't available).
 	if isBank {
 		nonintExp, hasNIE := fields["OperatingExpenses"] // resolved from NoninterestExpense FallbackTag
 		if hasNIE {
-			otherNIE := 0.0
-			if v, ok := ResolveDirect(cf, FieldMapping{XBRLTags: []string{"OtherNoninterestExpense"}}, periodEnd, formType); ok {
-				otherNIE = v
-			}
-
+			otherNIE, _ := fields["_bankOtherNoninterestExpense"] // 0 when absent
 			fields["SellingGeneralAndAdministrativeExpense"] = nonintExp - otherNIE
 		}
 	}

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -523,9 +523,9 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 	// get a 2M inconsistency. Recomputing from formulas ensures consistency.
 	if isBank {
 		if ni, hasNI := fields["NetIncome"]; hasNI {
-			tax, _ := fields["IncomeTaxExpense"]
-			intExp, _ := fields["InterestExpense"]
-			da, _ := fields["DepreciationAmortizationAndAccretion"]
+			tax := fields["IncomeTaxExpense"]
+			intExp := fields["InterestExpense"]
+			da := fields["DepreciationAmortizationAndAccretion"]
 
 			fields["EBT"] = ni + tax
 			fields["EBIT"] = ni + tax + intExp

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -572,6 +572,21 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		}
 	}
 
+	// For banks, compute SGA = NoninterestExpense - OtherNoninterestExpense.
+	// Sharadar excludes "OtherNoninterestExpense" (a catch-all for misc items
+	// like FDIC assessments, regulatory fees, litigation) from SGA.
+	if isBank {
+		nonintExp, hasNIE := fields["OperatingExpenses"] // resolved from NoninterestExpense FallbackTag
+		if hasNIE {
+			otherNIE := 0.0
+			if v, ok := ResolveDirect(cf, FieldMapping{XBRLTags: []string{"OtherNoninterestExpense"}}, periodEnd, formType); ok {
+				otherNIE = v
+			}
+
+			fields["SellingGeneralAndAdministrativeExpense"] = nonintExp - otherNIE
+		}
+	}
+
 	// For banks, compute Investments as the balance sheet residual:
 	// TotalAssets - CashAndEquivalents - Receivables - PP&E - Intangibles - OtherAssets.
 	// This captures loans, securities, fed funds, and other invested assets.

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -500,7 +500,7 @@ func resolveSharesBasicAsOf(cf *CompanyFacts, asOfDate time.Time) (float64, bool
 //
 // For companies like AAPL that present debt cash flows as separate lines
 // and DO file AssetsCurrent, the direct XBRL-based computation is correct.
-func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64) {
+func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, periodEnd time.Time, formType string) {
 	isBank := !conceptFiledQuarterly(cf, []string{"AssetsCurrent"})
 	bundlesFinancing := conceptFiledQuarterly(cf, []string{"AccruedLiabilitiesCurrent"})
 
@@ -527,6 +527,27 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64) {
 		if hasI {
 			capex, _ := fields["CapitalExpenditure"] // 0 when absent (banks)
 			fields["NetCashFlowInvest"] = investing - capex
+		}
+	}
+
+	// For banks, compute Investments as the balance sheet residual:
+	// TotalAssets - CashAndEquivalents - Receivables - PP&E - Intangibles - OtherAssets.
+	// This captures loans, securities, fed funds, and other invested assets.
+	if isBank {
+		totalAssets, hasTA := fields["TotalAssets"]
+
+		if hasTA {
+			cash, _ := fields["CashAndEquivalents"]
+			recv, _ := fields["Receivables"]
+			ppe, _ := fields["PropertyPlantAndEquipmentNet"]
+			intang, _ := fields["Intangibles"]
+			oa := 0.0
+
+			if v, ok := ResolveDirect(cf, FieldMapping{XBRLTags: []string{"OtherAssets"}}, periodEnd, formType); ok {
+				oa = v
+			}
+
+			fields["Investments"] = totalAssets - cash - recv - ppe - intang - oa
 		}
 	}
 }

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -515,4 +515,18 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64) {
 	if hasF && hasC && hasD {
 		fields["NetCashFlowDebt"] = financing - common - dividend
 	}
+
+	// For banks, also recompute NetCashFlowInvest as the residual of the
+	// investing section: invest = total_investing - capex. Bank investing
+	// activities include loan originations, fed funds, and repo transactions
+	// that standard investment-security tags don't capture. Business
+	// acquisitions are already part of the investing total and are tracked
+	// separately as NetCashFlowBusiness.
+	if isBank {
+		investing, hasI := fields["NetCashFlowFromInvesting"]
+		if hasI {
+			capex, _ := fields["CapitalExpenditure"] // 0 when absent (banks)
+			fields["NetCashFlowInvest"] = investing - capex
+		}
+	}
 }

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -488,15 +488,23 @@ func resolveSharesBasicAsOf(cf *CompanyFacts, asOfDate time.Time) (float64, bool
 
 // overrideNCFDebtResidual recomputes NetCashFlowDebt as the residual of
 // the financing section: debt = financing - common - dividend. This captures
-// small items (finance lease payments, debt issuance costs) that are not
-// separately tagged in XBRL but are included in the financing total.
+// items that are not separately tagged in XBRL but are included in the
+// financing total.
 //
-// Only applied when AccruedLiabilitiesCurrent is filed on 10-Q (NVDA),
-// indicating the company bundles financing items into broader categories.
-// For companies like AAPL that present debt cash flows as separate lines,
-// the direct XBRL-based computation is correct.
+// Applied in two cases:
+//  1. AccruedLiabilitiesCurrent is filed on 10-Q (NVDA) — the company bundles
+//     financing items into broader categories.
+//  2. AssetsCurrent is NOT filed on 10-Q (banks like JPM) — bank financing
+//     activities include deposits, fed funds, and repo agreements that aren't
+//     captured by the standard debt-proceeds/repayments tags.
+//
+// For companies like AAPL that present debt cash flows as separate lines
+// and DO file AssetsCurrent, the direct XBRL-based computation is correct.
 func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64) {
-	if !conceptFiledQuarterly(cf, []string{"AccruedLiabilitiesCurrent"}) {
+	isBank := !conceptFiledQuarterly(cf, []string{"AssetsCurrent"})
+	bundlesFinancing := conceptFiledQuarterly(cf, []string{"AccruedLiabilitiesCurrent"})
+
+	if !isBank && !bundlesFinancing {
 		return
 	}
 

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -533,7 +533,7 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 
 			// Recompute NCI from corrected values
 			if consolidated, hasCons := fields["ConsolidatedIncome"]; hasCons {
-				pref, _ := fields["PreferredDividendsIncomeStatementImpact"]
+				pref := fields["PreferredDividendsIncomeStatementImpact"]
 				fields["NetIncomeToNonControllingInterests"] = consolidated - ni - pref
 			}
 		}
@@ -604,9 +604,9 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 	if isBank {
 		investing, hasI := fields["NetCashFlowFromInvesting"]
 		if hasI {
-			capex, _ := fields["CapitalExpenditure"]     // 0 when absent (banks)
-			otherInv, _ := fields["_bankOtherInvesting"] // 0 when absent
-			biz, _ := fields["NetCashFlowBusiness"]      // 0 when absent; already negated
+			capex := fields["CapitalExpenditure"]     // 0 when absent (banks)
+			otherInv := fields["_bankOtherInvesting"] // 0 when absent
+			biz := fields["NetCashFlowBusiness"]      // 0 when absent; already negated
 			// Add back "other" investing and subtract business acquisitions
 			// (both are in the investing total but Sharadar classifies them
 			// separately as NCFBIZ and other, not NCFINV).

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -544,6 +544,34 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		}
 	}
 
+	// For banks, override balance sheet fields from extension tags. The
+	// mapping-level FallbackTags work for AR dimensions but the MR filing
+	// date filter can exclude extension facts from the MR CompanyFacts.
+	// Resolving directly from the UNFILTERED cf ensures extension tags are
+	// always available.
+	if isBank {
+		bankExtTags := []struct {
+			field string
+			tags  []string
+		}{
+			// JPM 10-K and 10-Q use different casing for extension concepts.
+			{"Intangibles", []string{
+				"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets",   // 10-Q
+				"GoodwillServicingAssetsatFairValueandOtherIntangibleAssets",   // 10-K
+			}},
+			{"PropertyPlantAndEquipmentNet", []string{
+				"PropertyPlantAndEquipmentAndOperatingLeaseRightOfUseAssetAfterAccumulatedDepreciationAndAmortization",
+			}},
+			{"Receivables", []string{"AccruedInterestAndAccountsReceivable"}},
+		}
+
+		for _, ext := range bankExtTags {
+			if v, ok := ResolveDirect(cf, FieldMapping{XBRLTags: ext.tags}, periodEnd, formType); ok {
+				fields[ext.field] = v
+			}
+		}
+	}
+
 	// For banks, compute Investments as the balance sheet residual:
 	// TotalAssets - CashAndEquivalents - Receivables - PP&E - Intangibles - OtherAssets.
 	// This captures loans, securities, fed funds, and other invested assets.

--- a/provider/sec/mapping.go
+++ b/provider/sec/mapping.go
@@ -650,7 +650,7 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 	if isBank {
 		nonintExp, hasNIE := fields["OperatingExpenses"] // resolved from NoninterestExpense FallbackTag
 		if hasNIE {
-			otherNIE, _ := fields["_bankOtherNoninterestExpense"] // 0 when absent
+			otherNIE := fields["_bankOtherNoninterestExpense"] // 0 when absent
 			fields["SellingGeneralAndAdministrativeExpense"] = nonintExp - otherNIE
 		}
 	}
@@ -662,10 +662,10 @@ func overrideNCFDebtResidual(cf *CompanyFacts, fields map[string]float64, period
 		totalAssets, hasTA := fields["TotalAssets"]
 
 		if hasTA {
-			cash, _ := fields["CashAndEquivalents"]
-			recv, _ := fields["Receivables"]
-			ppe, _ := fields["PropertyPlantAndEquipmentNet"]
-			intang, _ := fields["Intangibles"]
+			cash := fields["CashAndEquivalents"]
+			recv := fields["Receivables"]
+			ppe := fields["PropertyPlantAndEquipmentNet"]
+			intang := fields["Intangibles"]
 			oa := 0.0
 
 			if v, ok := ResolveDirect(cf, FieldMapping{XBRLTags: []string{"OtherAssets"}}, periodEnd, formType); ok {

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -466,7 +466,6 @@ var FieldMappings = []FieldMapping{
 		FieldName: "AccumulatedRetainedEarningsDeficit", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
 		XBRLTags: []string{"RetainedEarningsAccumulatedDeficit"},
 	},
-
 	// ==================== INCOME STATEMENT (flow) ====================
 
 	{
@@ -628,11 +627,19 @@ var FieldMappings = []FieldMapping{
 			"DiscontinuedOperationIncomeLossFromDiscontinuedOperationDuringPhaseOutPeriodNetOfTax",
 		},
 	},
+	// NetIncomeToNonControllingInterests: use the direct tag if available.
+	// Banks (JPM) don't report this tag; derive as ConsolidatedIncome -
+	// NetIncome - PreferredDividends. ConsolidatedIncome uses NetIncomeLoss
+	// (consolidated), while NetIncome uses the common-stockholder variant.
 	{
-		FieldName: "NetIncomeToNonControllingInterests", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
-		XBRLTags: []string{
+		FieldName: "NetIncomeToNonControllingInterests", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
+		FallbackTags: []string{
 			"NetIncomeLossAttributableToNoncontrollingInterest",
 		},
+		Op:               OpLinearCombination,
+		Operands:         []string{"ConsolidatedIncome", "NetIncome", "PreferredDividendsIncomeStatementImpact"},
+		Coefficients:     []float64{1, -1, -1},
+		OptionalOperands: true,
 	},
 	{
 		FieldName: "PreferredDividendsIncomeStatementImpact", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -186,9 +186,13 @@ var FieldMappings = []FieldMapping{
 	// Receivables = TradeReceivables + NonTradeReceivables. Sharadar
 	// defines this as "trade and non-trade receivables." Apple tags these
 	// separately (AccountsReceivableNetCurrent + NontradeReceivablesCurrent).
+	// Banks (JPM) use a combined extension tag for accrued interest + A/R.
 	{
 		FieldName: "Receivables", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
-		FallbackTags:     []string{"ReceivablesNetCurrent"},
+		FallbackTags: []string{
+			"ReceivablesNetCurrent",
+			"AccruedInterestAndAccountsReceivable", // JPM extension tag
+		},
 		Op:               OpAdd,
 		Operands:         []string{"TradeReceivables", "NonTradeReceivables"},
 		OptionalOperands: true,
@@ -216,8 +220,14 @@ var FieldMappings = []FieldMapping{
 		RequireQuarterly: true,
 		XBRLTags:         []string{"OperatingLeaseRightOfUseAsset"},
 	},
+	// PropertyPlantAndEquipmentNet: use the combined extension tag if
+	// available (JPM files a combined premises+equipment+ROU tag); otherwise
+	// sum the sub-components.
 	{
 		FieldName: "PropertyPlantAndEquipmentNet", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
+		FallbackTags: []string{
+			"PropertyPlantAndEquipmentAndOperatingLeaseRightOfUseAssetAfterAccumulatedDepreciationAndAmortization", // JPM extension
+		},
 		Op:               OpAdd,
 		Operands:         []string{"_ppneRaw", "_operatingLeaseROU"},
 		OptionalOperands: true,
@@ -237,10 +247,14 @@ var FieldMappings = []FieldMapping{
 	// Intangibles: Sharadar defines this as "all intangible assets and
 	// goodwill." Use the combined tag if available; otherwise sum Goodwill +
 	// other intangibles. MSFT reports Goodwill and FiniteLivedIntangibleAssetsNet
-	// separately; the sum captures both.
+	// separately; the sum captures both. Banks (JPM) file a combined extension
+	// tag that includes goodwill, MSR, and other intangibles.
 	{
 		FieldName: "Intangibles", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
-		FallbackTags:     []string{"IntangibleAssetsNetIncludingGoodwill"},
+		FallbackTags: []string{
+			"IntangibleAssetsNetIncludingGoodwill",
+			"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets", // JPM extension
+		},
 		Op:               OpAdd,
 		Operands:         []string{"_goodwill", "_intangiblesExGoodwill"},
 		OptionalOperands: true,

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -559,6 +559,13 @@ var FieldMappings = []FieldMapping{
 		// net value would incorrectly subtract from EBIT.
 		// InterestExpenseNonoperating is used by MSFT on 10-Q filings where
 		// the generic InterestExpense tag is only filed on 10-K.
+		//
+		// RequireIfQuarterly on AssetsCurrent: banks (JPM) file the generic
+		// InterestExpense tag for some quarters but not others, and for banks
+		// this is operational interest (cost of deposits) — NOT financing
+		// expense. Including it in EBIT breaks Q4 synthesis (annual has 0
+		// but one quarter has 24B). Banks without AssetsCurrent skip this.
+		RequireIfQuarterly: []string{"AssetsCurrent"},
 		XBRLTags: []string{
 			"InterestExpense",
 			"InterestExpenseDebt",
@@ -742,8 +749,13 @@ var FieldMappings = []FieldMapping{
 			"CapitalExpendituresIncurredButNotYetPaid",
 		},
 	},
+	// Sharadar reports 0 for share-based compensation for banks. Banks
+	// include SBC in their compensation expense (LaborAndRelatedExpense)
+	// and Sharadar does not separate it. Gate on AssetsCurrent to exclude
+	// banks (which don't classify assets as current/non-current).
 	{
 		FieldName: "ShareBasedCompensation", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		RequireIfQuarterly: []string{"AssetsCurrent"},
 		XBRLTags: []string{
 			"ShareBasedCompensation",
 			"AllocatedShareBasedCompensationExpense",
@@ -961,11 +973,14 @@ var FieldMappings = []FieldMapping{
 		Operands: []string{"NetIncome", "IncomeTaxExpense"},
 	},
 	// FreeCashFlow = NetCashFlowFromOperations + CapitalExpenditure
-	// (CapitalExpenditure is already negative after Negate, so addition is correct)
+	// (CapitalExpenditure is already negative after Negate, so addition is correct).
+	// OptionalOperands: banks (JPM) do not report PaymentsToAcquirePropertyPlantAndEquipment
+	// so CapitalExpenditure is absent; FCF = NCFOps when capex is missing.
 	{
 		FieldName: "FreeCashFlow", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
-		Op:       OpAdd,
-		Operands: []string{"NetCashFlowFromOperations", "CapitalExpenditure"},
+		Op:               OpAdd,
+		Operands:         []string{"NetCashFlowFromOperations", "CapitalExpenditure"},
+		OptionalOperands: true,
 	},
 	// WorkingCapital = CurrentAssets - CurrentLiabilities
 	{

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -871,6 +871,31 @@ var FieldMappings = []FieldMapping{
 		Coefficients:     []float64{1, -1, -1, 1},
 		OptionalOperands: true,
 	},
+	// --- Bank-specific NCFDEBT sub-fields ---
+	// Banks (JPM) have additional debt-related financing activities not
+	// captured by the standard debt proceeds/repayments tags. These are
+	// gated on absence of AssetsCurrent (bank detection). StmtFlow ensures
+	// YTD cumulative values are properly de-cumulated to single-quarter amounts.
+	{
+		FieldName: "_bankFedFundsChange", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"IncreaseDecreaseInFederalFundsPurchasedAndSecuritiesSoldUnderAgreementsToRepurchaseNet"},
+	},
+	{
+		FieldName: "_bankLTDebtProceeds", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet", "ProceedsFromIssuanceOfLongTermDebt"},
+	},
+	{
+		FieldName: "_bankLTDebtRepayments", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"RepaymentsOfLongTermDebtAndCapitalSecurities", "RepaymentsOfLongTermDebt"},
+	},
+	{
+		FieldName: "_bankSTDebtProceeds", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"ProceedsFromShortTermDebt", "ProceedsFromRepaymentsOfShortTermDebt"},
+	},
 	{
 		FieldName: "NetCashFlowDividend", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
 		Negate: true,

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -902,6 +902,11 @@ var FieldMappings = []FieldMapping{
 		XBRLTags:           []string{"PaymentsForProceedsFromOtherInvestingActivities"},
 	},
 	{
+		FieldName: "_bankOtherNoninterestExpense", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"OtherNoninterestExpense"},
+	},
+	{
 		FieldName: "NetCashFlowDividend", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
 		Negate: true,
 		XBRLTags: []string{

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -253,8 +253,8 @@ var FieldMappings = []FieldMapping{
 		FieldName: "Intangibles", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
 		FallbackTags: []string{
 			"IntangibleAssetsNetIncludingGoodwill",
-			"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets",  // JPM 10-Q extension
-			"GoodwillServicingAssetsatFairValueandOtherIntangibleAssets",  // JPM 10-K extension (different casing)
+			"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets", // JPM 10-Q extension
+			"GoodwillServicingAssetsatFairValueandOtherIntangibleAssets", // JPM 10-K extension (different casing)
 		},
 		Op:               OpAdd,
 		Operands:         []string{"_goodwill", "_intangiblesExGoodwill"},

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -133,6 +133,7 @@ var FieldMappings = []FieldMapping{
 		XBRLTags: []string{
 			"CashAndCashEquivalentsAtCarryingValue",
 			"CashCashEquivalentsAndShortTermInvestments",
+			"CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents", // Banks (JPM) use this
 			"Cash",
 			"CashEquivalentsAtCarryingValue",
 		},
@@ -197,6 +198,7 @@ var FieldMappings = []FieldMapping{
 		XBRLTags: []string{
 			"AccountsPayableCurrent",
 			"AccountsPayableAndAccruedLiabilitiesCurrent",
+			"AccountsPayableAndAccruedLiabilitiesCurrentAndNoncurrent", // Banks (JPM) use combined current+noncurrent
 		},
 	},
 	{
@@ -296,23 +298,31 @@ var FieldMappings = []FieldMapping{
 		Operands:           []string{"_deferredTaxLiabilities", "_accruedIncomeTaxesCurrent", "_accruedIncomeTaxesNoncurrent"},
 		OptionalOperands:   true,
 	},
+	// Debt sub-components are gated on AssetsCurrent: companies that classify
+	// assets as current/non-current (non-banks) also classify debt that way.
+	// Banks (JPM) do not file AssetsCurrent and Sharadar reports DebtCurrent=0
+	// and DebtNonCurrent=0 for them.
 	{
 		FieldName: "ShortTermDebt", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		XBRLTags: []string{"ShortTermBorrowings"},
+		RequireIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"ShortTermBorrowings"},
 	},
 	{
 		FieldName: "LongTermDebtCurrentMaturities", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		XBRLTags: []string{"LongTermDebtCurrent"},
+		RequireIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"LongTermDebtCurrent"},
 	},
 	{
 		FieldName: "CommercialPaperDebt", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		XBRLTags: []string{"CommercialPaper"},
+		RequireIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"CommercialPaper"},
 	},
 	// DebtCurrent = ShortTermDebt + LongTermDebtCurrentMaturities +
 	// CommercialPaperDebt. Sharadar includes all forms of current debt
 	// (bonds, commercial paper, notes payable, credit facilities). Apple
 	// tags LongTermDebtCurrent and CommercialPaper separately; the sum
-	// captures both.
+	// captures both. For banks (no AssetsCurrent), all components are
+	// gated off so DebtCurrent = 0.
 	{
 		FieldName: "DebtCurrent", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
 		FallbackTags:     []string{"DebtCurrent"},
@@ -322,6 +332,7 @@ var FieldMappings = []FieldMapping{
 	},
 	{
 		FieldName: "_longTermDebtNoncurrent", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		RequireIfQuarterly: []string{"AssetsCurrent"},
 		XBRLTags: []string{
 			"LongTermDebtNoncurrent",
 			"LongTermDebt",
@@ -334,8 +345,9 @@ var FieldMappings = []FieldMapping{
 	// (separate line) and not AAPL (10-K note disclosure only).
 	{
 		FieldName: "_operatingLeaseLiabilityNoncurrent", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
-		RequireQuarterly: true,
-		XBRLTags:         []string{"OperatingLeaseLiabilityNoncurrent"},
+		RequireQuarterly:   true,
+		RequireIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"OperatingLeaseLiabilityNoncurrent"},
 	},
 	{
 		FieldName: "DebtNonCurrent", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
@@ -343,10 +355,36 @@ var FieldMappings = []FieldMapping{
 		Operands:         []string{"_longTermDebtNoncurrent", "_operatingLeaseLiabilityNoncurrent"},
 		OptionalOperands: true,
 	},
+	// --- Bank-specific debt sub-fields ---
+	// Banks don't classify debt as current/non-current. Sharadar computes
+	// TotalDebt for banks as ShortTermBorrowings + LongTermDebt +
+	// FederalFundsPurchased. These sub-fields are gated with
+	// ExcludeIfQuarterly on AssetsCurrent so they only resolve for banks.
+	{
+		FieldName: "_bankShortTermDebt", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"ShortTermBorrowings"},
+	},
+	{
+		FieldName: "_bankLongTermDebt", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags: []string{
+			"LongTermDebtAndCapitalLeaseObligationsIncludingCurrentMaturities",
+			"LongTermDebt",
+		},
+	},
+	{
+		FieldName: "_bankFederalFundsPurchased", Type: MappingDirect, StatementType: StmtPointInTime, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"FederalFundsPurchasedAndSecuritiesSoldUnderAgreementsToRepurchase"},
+	},
 	{
 		FieldName: "TotalDebt", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
-		Op:               OpAdd,
-		Operands:         []string{"DebtCurrent", "DebtNonCurrent"},
+		Op: OpAdd,
+		Operands: []string{
+			"DebtCurrent", "DebtNonCurrent",
+			"_bankShortTermDebt", "_bankLongTermDebt", "_bankFederalFundsPurchased",
+		},
 		OptionalOperands: true,
 	},
 	// --- Internal sub-fields for DeferredRevenue derivation ---
@@ -423,6 +461,7 @@ var FieldMappings = []FieldMapping{
 			"Revenues",
 			"RevenueFromContractWithCustomerExcludingAssessedTax",
 			"RevenueFromContractWithCustomerIncludingAssessedTax",
+			"RevenuesNetOfInterestExpense", // Banks (JPM) report this on 10-Q instead of Revenues
 			"SalesRevenueNet",
 			"SalesRevenueGoodsNet",
 			"SalesRevenueServicesNet",
@@ -444,10 +483,18 @@ var FieldMappings = []FieldMapping{
 			"CostOfGoodsAndServiceExcludingDepreciationDepletionAndAmortization",
 		},
 	},
+	// GrossProfit: use the direct tag if available; otherwise derive from
+	// Revenues − CostOfRevenue. Banks (JPM) do not report GrossProfit or
+	// CostOfRevenue; with CostOfRevenue absent (treated as 0), the derived
+	// value equals Revenues -- matching Sharadar's treatment of bank revenue
+	// as 100% gross.
 	{
-		FieldName: "GrossProfit", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
-		XBRLTags: []string{"GrossProfit"},
-		// Fallback: Revenues - CostOfRevenue
+		FieldName: "GrossProfit", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
+		FallbackTags:     []string{"GrossProfit"},
+		Op:               OpLinearCombination,
+		Operands:         []string{"Revenues", "CostOfRevenue"},
+		Coefficients:     []float64{1, -1},
+		OptionalOperands: true,
 	},
 	// --- Internal sub-fields for SG&A derivation ---
 	{
@@ -486,12 +533,22 @@ var FieldMappings = []FieldMapping{
 	// from GrossProfit − OperatingIncome. Sharadar defines OpEx as SGA +
 	// R&D (excluding CoR). MSFT omits the OperatingExpenses XBRL tag in
 	// older filings, but GrossProfit and OperatingIncome are always present.
+	// Banks (JPM) report NoninterestExpense which maps to Sharadar OpEx.
 	// Must come AFTER OperatingIncome so the dependency is resolved first.
 	{
 		FieldName: "OperatingExpenses", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
-		FallbackTags: []string{"OperatingExpenses", "CostsAndExpenses"},
+		FallbackTags: []string{"OperatingExpenses", "CostsAndExpenses", "NoninterestExpense"},
 		Op:           OpSubtract,
 		Operands:     []string{"GrossProfit", "OperatingIncome"},
+	},
+	// For companies that don't report OperatingIncomeLoss (e.g. banks),
+	// recompute OperatingIncome as GrossProfit − OperatingExpenses. For
+	// non-banks this is mathematically equivalent to the direct-tag value
+	// since OperatingExpenses = GrossProfit − OperatingIncome above.
+	{
+		FieldName: "OperatingIncome", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
+		Op:       OpSubtract,
+		Operands: []string{"GrossProfit", "OperatingExpenses"},
 	},
 	{
 		FieldName: "InterestExpense", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
@@ -517,7 +574,13 @@ var FieldMappings = []FieldMapping{
 	},
 	{
 		FieldName: "NetIncome", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		// Prefer NetIncomeLossAvailableToCommonStockholdersBasic: Sharadar defines
+		// netinc as "net income loss to common shareholders" which deducts NCI and
+		// preferred dividends. Banks (JPM) file NetIncomeLoss as the consolidated
+		// figure (including NCI); the Available-to-Common variant gives the correct
+		// parent-only value. For companies without NCI (AAPL, MSFT), both are equal.
 		XBRLTags: []string{
+			"NetIncomeLossAvailableToCommonStockholdersBasic",
 			"NetIncomeLoss",
 			"ProfitLoss",
 		},
@@ -888,13 +951,12 @@ var FieldMappings = []FieldMapping{
 		Op:       OpAdd,
 		Operands: []string{"EBIT", "DepreciationAmortizationAndAccretion"},
 	},
-	// EBT = NetIncome + IncomeTaxExpense
+	// EBT = NetIncome + IncomeTaxExpense. No FallbackTags: the direct XBRL tags
+	// (IncomeLossFromContinuingOperationsBeforeIncomeTaxes...) report consolidated
+	// pre-tax income including NCI. The formula uses the already-corrected
+	// NetIncome (parent-only for companies with NCI like JPM).
 	{
 		FieldName: "EBT", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
-		FallbackTags: []string{
-			"IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-			"IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments",
-		},
 		Op:       OpAdd,
 		Operands: []string{"NetIncome", "IncomeTaxExpense"},
 	},

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -897,6 +897,11 @@ var FieldMappings = []FieldMapping{
 		XBRLTags:           []string{"ProceedsFromShortTermDebt", "ProceedsFromRepaymentsOfShortTermDebt"},
 	},
 	{
+		FieldName: "_bankOtherInvesting", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
+		ExcludeIfQuarterly: []string{"AssetsCurrent"},
+		XBRLTags:           []string{"PaymentsForProceedsFromOtherInvestingActivities"},
+	},
+	{
 		FieldName: "NetCashFlowDividend", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",
 		Negate: true,
 		XBRLTags: []string{

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -253,7 +253,8 @@ var FieldMappings = []FieldMapping{
 		FieldName: "Intangibles", Type: MappingDerived, StatementType: StmtPointInTime, ValueType: "int64",
 		FallbackTags: []string{
 			"IntangibleAssetsNetIncludingGoodwill",
-			"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets", // JPM extension
+			"GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets",  // JPM 10-Q extension
+			"GoodwillServicingAssetsatFairValueandOtherIntangibleAssets",  // JPM 10-K extension (different casing)
 		},
 		Op:               OpAdd,
 		Operands:         []string{"_goodwill", "_intangiblesExGoodwill"},

--- a/provider/sec/mapping_config.go
+++ b/provider/sec/mapping_config.go
@@ -548,20 +548,13 @@ var FieldMappings = []FieldMapping{
 	// older filings, but GrossProfit and OperatingIncome are always present.
 	// Banks (JPM) report NoninterestExpense which maps to Sharadar OpEx.
 	// Must come AFTER OperatingIncome so the dependency is resolved first.
+	// For banks that don't report OperatingIncomeLoss, OperatingIncome is
+	// recomputed as GrossProfit - OperatingExpenses in overrideNCFDebtResidual.
 	{
 		FieldName: "OperatingExpenses", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
 		FallbackTags: []string{"OperatingExpenses", "CostsAndExpenses", "NoninterestExpense"},
 		Op:           OpSubtract,
 		Operands:     []string{"GrossProfit", "OperatingIncome"},
-	},
-	// For companies that don't report OperatingIncomeLoss (e.g. banks),
-	// recompute OperatingIncome as GrossProfit − OperatingExpenses. For
-	// non-banks this is mathematically equivalent to the direct-tag value
-	// since OperatingExpenses = GrossProfit − OperatingIncome above.
-	{
-		FieldName: "OperatingIncome", Type: MappingDerived, StatementType: StmtFlow, ValueType: "int64",
-		Op:       OpSubtract,
-		Operands: []string{"GrossProfit", "OperatingExpenses"},
 	},
 	{
 		FieldName: "InterestExpense", Type: MappingDirect, StatementType: StmtFlow, ValueType: "int64",

--- a/provider/sec/mapping_test.go
+++ b/provider/sec/mapping_test.go
@@ -569,6 +569,9 @@ var _ = Describe("Mapping Engine", func() {
 			debtCF := &CompanyFacts{
 				CIK: 320193, EntityName: "Apple Inc",
 				Facts: map[string][]Fact{
+					"AssetsCurrent": {
+						{End: periodEnd, Filed: filed, Val: 100_000_000_000, Form: "10-Q"},
+					},
 					"LongTermDebtCurrent": {
 						{End: periodEnd, Filed: filed, Val: 10_762_000_000, Form: "10-Q"},
 					},
@@ -599,6 +602,7 @@ var _ = Describe("Mapping Engine", func() {
 			icCF := &CompanyFacts{
 				CIK: 1, EntityName: "Test Co",
 				Facts: map[string][]Fact{
+					"AssetsCurrent":                         {{End: periodEnd, Filed: filed, Val: 100_000, Form: "10-Q"}},
 					"LongTermDebtCurrent":                   {{End: periodEnd, Filed: filed, Val: 10_000, Form: "10-Q"}},
 					"LongTermDebtNoncurrent":                {{End: periodEnd, Filed: filed, Val: 90_000, Form: "10-Q"}},
 					"Assets":                                {{End: periodEnd, Filed: filed, Val: 350_000, Form: "10-Q"}},

--- a/provider/sec/market_data.go
+++ b/provider/sec/market_data.go
@@ -139,7 +139,7 @@ func EnrichMarketData(fundamentals []*data.Fundamental, lookupPrice PriceLookupF
 			f.EnterpriseValue = ev
 
 			if f.Equity != 0 {
-				f.PB = float64(mktCap) / float64(f.Equity)
+				f.PB = math.Round(float64(mktCap)/float64(f.Equity)*1000) / 1000
 			}
 		}
 
@@ -175,21 +175,21 @@ func EnrichMarketData(fundamentals []*data.Fundamental, lookupPrice PriceLookupF
 			ev := f.EnterpriseValue
 
 			if f.NetIncomeCommonStock != 0 {
-				f.PE = float64(mktCap) / float64(f.NetIncomeCommonStock)
+				f.PE = math.Round(float64(mktCap)/float64(f.NetIncomeCommonStock)*1000) / 1000
 			}
 
 			if f.Revenues != 0 {
-				f.PS = float64(mktCap) / float64(f.Revenues)
+				f.PS = math.Round(float64(mktCap)/float64(f.Revenues)*1000) / 1000
 			}
 
 			if f.EPS != 0 {
-				f.PE1 = f.Price / f.EPS
+				f.PE1 = math.Round(f.Price/f.EPS*1000) / 1000
 			}
 
 			if f.Revenues != 0 && f.WeightedAverageShares != 0 {
-				f.PS1 = f.Price / (float64(f.Revenues) / float64(f.WeightedAverageShares))
+				f.PS1 = math.Round(f.Price/(float64(f.Revenues)/float64(f.WeightedAverageShares))*1000) / 1000
 			} else if f.SalesPerShare != 0 {
-				f.PS1 = f.Price / f.SalesPerShare
+				f.PS1 = math.Round(f.Price/f.SalesPerShare*1000) / 1000
 			}
 
 			if f.EBIT != 0 {

--- a/provider/sec/market_data_test.go
+++ b/provider/sec/market_data_test.go
@@ -147,7 +147,7 @@ var _ = Describe("EnrichMarketData", func() {
 			// ARQ should have its own price-based fields
 			expectedMktCap := int64(price * float64(arq.SharesBasic))
 			expectedEV := expectedMktCap + arq.TotalDebt - arq.CashAndEquivalents
-			expectedPB := float64(expectedMktCap) / float64(arq.Equity)
+			expectedPB := math.Round(float64(expectedMktCap)/float64(arq.Equity)*1000) / 1000
 
 			Expect(arq.Price).To(BeNumerically("~", price, 1e-9))
 			Expect(arq.MarketCapitalization).To(Equal(expectedMktCap))

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -1231,8 +1231,23 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			arQSlice[j] = quarters[i-3+j].arEmit
 		}
 
+		// bankFixTTMNCI replaces the TTM NCI sum with the annual value when
+		// the TTM coincides with a fiscal year. Quarterly NCI values may
+		// not sum to the annual due to the cumulative vs single-quarter
+		// discrepancy in NetIncome (2M for JPM).
+		bankFixTTMNCI := func(ttm, annualFields map[string]float64) {
+			if annualFields == nil || conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
+				return
+			}
+
+			if v, ok := annualFields["NetIncomeToNonControllingInterests"]; ok {
+				ttm["NetIncomeToNonControllingInterests"] = v
+			}
+		}
+
 		if ttm := ComputeTTM(arQSlice, false); ttm != nil {
 			overridePeriodAvg(ttm, matchingAR)
+			bankFixTTMNCI(ttm, matchingAR)
 
 			for k, v := range ComputeMultiQAverages(ttm, arQSlice) {
 				ttm[k] = v
@@ -1258,6 +1273,7 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 		if ttm := ComputeTTM(mrQSlice, true); ttm != nil {
 			overridePeriodAvg(ttm, matchingMR)
+			bankFixTTMNCI(ttm, matchingMR)
 
 			for k, v := range ComputeMultiQAverages(ttm, mrQSlice) {
 				ttm[k] = v
@@ -1288,6 +1304,63 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		}
 
 		EnrichMarketData(fundamentals, priceLookupFn)
+	}
+
+	// Clean up stale records for this ticker before sending new observations.
+	// Prior runs may have used different dateKey conventions (e.g., filing
+	// date vs period end), leaving orphan rows that create spurious diffs.
+	// Collect the set of valid (dimension, event_date) pairs from the current
+	// run and delete any existing records not in this set.
+	if asset.CompositeFigi != "" && len(buffered) > 0 {
+		cleanupCtx := context.Background()
+		tbl := sub.DataTablesMap[data.FundamentalsKey]
+		if tbl != "" {
+			type obsKey struct {
+				dim       string
+				eventDate time.Time
+			}
+
+			validKeys := make(map[obsKey]bool)
+			for _, obs := range buffered {
+				if obs.Fundamental != nil {
+					validKeys[obsKey{obs.Fundamental.Dimension, obs.Fundamental.EventDate}] = true
+				}
+			}
+
+			conn, err := sub.Library.Pool.Acquire(cleanupCtx)
+			if err == nil {
+				rows, err := conn.Query(cleanupCtx,
+					fmt.Sprintf("SELECT dimension, event_date FROM %s WHERE composite_figi = $1", tbl),
+					asset.CompositeFigi)
+				if err == nil {
+					var toDelete []obsKey
+
+					for rows.Next() {
+						var dim string
+						var ed time.Time
+						if err := rows.Scan(&dim, &ed); err == nil {
+							if !validKeys[obsKey{dim, ed}] {
+								toDelete = append(toDelete, obsKey{dim, ed})
+							}
+						}
+					}
+
+					rows.Close()
+
+					for _, k := range toDelete {
+						_, _ = conn.Exec(cleanupCtx,
+							fmt.Sprintf("DELETE FROM %s WHERE composite_figi = $1 AND dimension = $2 AND event_date = $3", tbl),
+							asset.CompositeFigi, k.dim, k.eventDate)
+					}
+
+					if len(toDelete) > 0 {
+						log.Debug().Str("ticker", asset.Ticker).Int("deleted", len(toDelete)).Msg("cleaned up stale observations")
+					}
+				}
+
+				conn.Release()
+			}
+		}
 	}
 
 	// Send all buffered observations to the output channel.

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -823,15 +823,20 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		for i := 1; i < len(quarters); i++ {
 			prev := &quarters[i-1]
 			prevDPS, found := prev.arFields["DividendsPerBasicCommonShare"]
+
 			if !found {
 				prevDPS, found = prev.arEmit["DividendsPerBasicCommonShare"]
 			}
+
 			if !found {
 				prevDPS, found = prev.mrEmit["DividendsPerBasicCommonShare"]
 			}
+
 			if !found && i > 1 {
 				grandPrev := &quarters[i-2]
+
 				prevDPS, found = grandPrev.arFields["DividendsPerBasicCommonShare"]
+
 				if !found {
 					prevDPS, found = grandPrev.arEmit["DividendsPerBasicCommonShare"]
 				}
@@ -1039,20 +1044,24 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// the declared value.
 		if i > 0 && !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
 			prev := &quarters[i-1]
-			// Check all available maps for the prior quarter's DPS.
 			prevDPS, found := prev.arFields["DividendsPerBasicCommonShare"]
+
 			if !found {
 				prevDPS, found = prev.arEmit["DividendsPerBasicCommonShare"]
 			}
+
 			if !found {
 				prevDPS, found = prev.mrEmit["DividendsPerBasicCommonShare"]
 			}
+
 			// For Q1 of each year: the prior Q4 is synthesized and may not
 			// have DPS in any map. Fall back to Q3 (i-2) which is a regular
 			// 10-Q quarter with DPS available.
 			if !found && i > 1 {
 				grandPrev := &quarters[i-2]
+
 				prevDPS, found = grandPrev.arFields["DividendsPerBasicCommonShare"]
+
 				if !found {
 					prevDPS, found = grandPrev.arEmit["DividendsPerBasicCommonShare"]
 				}
@@ -1313,6 +1322,7 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 	// run and delete any existing records not in this set.
 	if asset.CompositeFigi != "" && len(buffered) > 0 {
 		cleanupCtx := context.Background()
+
 		tbl := sub.DataTablesMap[data.FundamentalsKey]
 		if tbl != "" {
 			type obsKey struct {
@@ -1321,6 +1331,7 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 			}
 
 			validKeys := make(map[obsKey]bool)
+
 			for _, obs := range buffered {
 				if obs.Fundamental != nil {
 					validKeys[obsKey{obs.Fundamental.Dimension, obs.Fundamental.EventDate}] = true
@@ -1336,8 +1347,10 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 					var toDelete []obsKey
 
 					for rows.Next() {
-						var dim string
-						var ed time.Time
+						var (
+							dim string
+							ed  time.Time
+						)
 						if err := rows.Scan(&dim, &ed); err == nil {
 							if !validKeys[obsKey{dim, ed}] {
 								toDelete = append(toDelete, obsKey{dim, ed})

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -929,6 +929,14 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		stripStaleAndRecompute(a.arEmit, annualTWHStale)
 		stripStaleAndRecompute(a.mrEmit, annualTWHStale)
 
+		// Apply bank overrides to annual emit maps. Only for banks —
+		// the bundlesFinancing (NVDA) path modifies NCFCOMMON via tax
+		// withholding strip, making the annual residual incorrect.
+		if !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
+			overrideNCFDebtResidual(cf, a.arEmit, a.period.PeriodEnd, a.period.FormType)
+			overrideNCFDebtResidual(cf, a.mrEmit, a.period.PeriodEnd, a.period.FormType)
+		}
+
 		fundamental := BuildFundamental(a.arEmit, asset.Ticker, asset.CompositeFigi, "ARY",
 			a.period.ARFiledDate, calendarDate, a.period.PeriodEnd, a.period.ARFiledDate)
 		buffered = append(buffered, &data.Observation{

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -816,6 +816,33 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		stripStaleAndRecompute(quarters[i].mrEmit, staleMRFields)
 	}
 
+	// For banks, override MR DPS with prior quarter's declared rate (= cash-
+	// paid). Must happen before annual emission so MRY can sum the corrected
+	// cash-paid quarterly values.
+	if !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
+		for i := 1; i < len(quarters); i++ {
+			prev := &quarters[i-1]
+			prevDPS, found := prev.arFields["DividendsPerBasicCommonShare"]
+			if !found {
+				prevDPS, found = prev.arEmit["DividendsPerBasicCommonShare"]
+			}
+			if !found {
+				prevDPS, found = prev.mrEmit["DividendsPerBasicCommonShare"]
+			}
+			if !found && i > 1 {
+				grandPrev := &quarters[i-2]
+				prevDPS, found = grandPrev.arFields["DividendsPerBasicCommonShare"]
+				if !found {
+					prevDPS, found = grandPrev.arEmit["DividendsPerBasicCommonShare"]
+				}
+			}
+
+			if found {
+				quarters[i].mrEmit["DividendsPerBasicCommonShare"] = prevDPS
+			}
+		}
+	}
+
 	// Period-average fields (AverageAssets, EquityAvg, InvestedCapitalAverage)
 	// and derived ratios (ROA, ROE, ROIC) are intentionally NOT computed for
 	// quarterly dimensions (ARQ/MRQ). See #56 for rationale.
@@ -951,6 +978,28 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// MRY — override SharesBasic for MR semantics (see quarterly override above).
 		if val, ok := resolveSharesBasicAsOf(cf, a.period.PeriodEnd); ok {
 			a.mrEmit["SharesBasic"] = val
+		}
+
+		// For banks, replace MRY DPS with the sum of cash-paid quarterly DPS.
+		// The annual mrEmit has the declared DPS from the 10-K; MRY should
+		// match the MRT trailing sum of cash-paid (prior quarter declared) values.
+		if !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) && conceptFiledQuarterly(cf, []string{"Deposits"}) {
+			cashDPSSum := 0.0
+			cashDPSCount := 0
+
+			for j := range quarters {
+				if NormalizeEventDate(quarters[j].period.PeriodEnd, "10-K").Equal(NormalizeEventDate(a.period.PeriodEnd, "10-K")) {
+					// This quarter belongs to this fiscal year
+					if v, ok := quarters[j].mrEmit["DividendsPerBasicCommonShare"]; ok {
+						cashDPSSum += v
+						cashDPSCount++
+					}
+				}
+			}
+
+			if cashDPSCount == 4 {
+				a.mrEmit["DividendsPerBasicCommonShare"] = cashDPSSum
+			}
 		}
 
 		fundamental = BuildFundamental(a.mrEmit, asset.Ticker, asset.CompositeFigi, "MRY",
@@ -1127,6 +1176,16 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 				break
 			}
+		}
+
+		// For banks, the annual MR DPS should use cash-paid (sum of
+		// prior-quarter declared rates), not the declared total from
+		// the 10-K. Without this, overridePeriodAvg would replace the
+		// correctly-summed TTM cash-paid DPS with the declared annual.
+		// Use Deposits as the bank sentinel (more specific than absence of
+		// AssetsCurrent, which test fixtures may lack).
+		if matchingMR != nil && !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) && conceptFiledQuarterly(cf, []string{"Deposits"}) {
+			delete(matchingMR, "DividendsPerBasicCommonShare")
 		}
 
 		overridePeriodAvg := func(ttm, annualFields map[string]float64) {

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -112,8 +112,10 @@ func fetchFundamentals(ctx context.Context, sub *library.Subscription, out chan<
 	limiter := rate.NewLimiter(rate.Limit(reqPerSec), 1)
 	client := NewSECClient(userAgent, limiter)
 
-	// Load CIK -> asset map from database (primary lookup path)
-	dbCIKMap, err := LoadCIKMapFromDB(ctx, sub.Library.Pool)
+	// Load CIK -> asset map from database (primary lookup path).
+	// dbTickerMap indexes every asset by ticker so we can resolve tickers
+	// that share a CIK (e.g. JPM, AMJ, AMJB, VYLD all map to CIK 19617).
+	dbCIKMap, dbTickerMap, err := LoadCIKMapFromDB(ctx, sub.Library.Pool)
 	if err != nil {
 		log.Error().Err(err).Msg("error loading CIK map from database")
 
@@ -166,7 +168,11 @@ func fetchFundamentals(ctx context.Context, sub *library.Subscription, out chan<
 		Int("from_sec", fromSEC).
 		Msg("built combined CIK map")
 
-	// Apply ticker/FIGI filter if set
+	// Apply ticker/FIGI filter if set. Multiple tickers can share a single
+	// CIK, so the CIK map may store a different ticker than the one
+	// requested. We fall back to dbTickerMap which indexes every DB asset
+	// by ticker, ensuring e.g. --ticker JPM resolves even when the CIK map
+	// entry for CIK 19617 holds VYLD.
 	tickerFilter, figiFilter := provider.SecurityFilterFromContext(ctx)
 	if tickerFilter != "" || figiFilter != "" {
 		filtered := make(map[int]AssetInfo)
@@ -179,6 +185,14 @@ func fetchFundamentals(ctx context.Context, sub *library.Subscription, out chan<
 			}
 		}
 
+		// Ticker not found via CIK map scan — try the ticker index which
+		// covers all DB assets regardless of CIK collisions.
+		if len(filtered) == 0 && tickerFilter != "" {
+			if asset, ok := dbTickerMap[strings.ToUpper(tickerFilter)]; ok {
+				filtered[asset.CIK] = asset
+			}
+		}
+
 		if len(filtered) == 0 {
 			candidates := make([]string, 0, len(cikMap))
 			for _, info := range cikMap {
@@ -186,6 +200,15 @@ func fetchFundamentals(ctx context.Context, sub *library.Subscription, out chan<
 					candidates = append(candidates, info.Ticker)
 				} else {
 					candidates = append(candidates, info.CompositeFigi)
+				}
+			}
+
+			// Also include tickers from the full DB index so the fuzzy
+			// suggestions cover all known tickers, not just CIK-map
+			// survivors.
+			if tickerFilter != "" {
+				for t := range dbTickerMap {
+					candidates = append(candidates, t)
 				}
 			}
 

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -996,6 +996,18 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		overrideNCFDebtResidual(cf, q.arEmit, q.period.PeriodEnd, q.period.FormType)
 		overrideNCFDebtResidual(cf, q.mrEmit, q.period.PeriodEnd, q.period.FormType)
 
+		// For banks, use the prior quarter's declared DPS as the cash-paid
+		// DPS for MR dimensions only. Sharadar AR uses declared (current
+		// quarter) but MR uses cash-paid (= prior quarter's declared rate).
+		// Use arFields (original resolved values, NOT the overridden emit)
+		// to avoid cascading the override through subsequent quarters.
+		if i > 0 && !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
+			prev := &quarters[i-1]
+			if prevDPS, ok := prev.arFields["DividendsPerBasicCommonShare"]; ok {
+				q.mrEmit["DividendsPerBasicCommonShare"] = prevDPS
+			}
+		}
+
 		// ARQ
 		fundamental := BuildFundamental(q.arEmit, asset.Ticker, asset.CompositeFigi, "ARQ",
 			q.period.ARFiledDate, calendarDate, q.period.PeriodEnd, q.period.ARFiledDate)

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -984,6 +984,22 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 
 		calendarDate := NormalizeEventDate(q.period.PeriodEnd, q.period.FormType)
 
+		// For banks, use the prior quarter's declared DPS as the cash-paid
+		// DPS for MR dimensions only. Try arFields, then arEmit for
+		// synthesized Q4 quarters. Only affects MR dimensions — AR keeps
+		// the declared value.
+		if i > 0 && !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
+			prev := &quarters[i-1]
+			prevDPS, ok := prev.arFields["DividendsPerBasicCommonShare"]
+			if !ok {
+				prevDPS, ok = prev.arEmit["DividendsPerBasicCommonShare"]
+			}
+
+			if ok {
+				q.mrEmit["DividendsPerBasicCommonShare"] = prevDPS
+			}
+		}
+
 		if !since.IsZero() && q.period.MRFiledDate.Before(since) {
 			continue
 		}
@@ -995,18 +1011,6 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// residual naturally picks them up when the other components match.
 		overrideNCFDebtResidual(cf, q.arEmit, q.period.PeriodEnd, q.period.FormType)
 		overrideNCFDebtResidual(cf, q.mrEmit, q.period.PeriodEnd, q.period.FormType)
-
-		// For banks, use the prior quarter's declared DPS as the cash-paid
-		// DPS for MR dimensions only. Sharadar AR uses declared (current
-		// quarter) but MR uses cash-paid (= prior quarter's declared rate).
-		// Use arFields (original resolved values, NOT the overridden emit)
-		// to avoid cascading the override through subsequent quarters.
-		if i > 0 && !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
-			prev := &quarters[i-1]
-			if prevDPS, ok := prev.arFields["DividendsPerBasicCommonShare"]; ok {
-				q.mrEmit["DividendsPerBasicCommonShare"] = prevDPS
-			}
-		}
 
 		// ARQ
 		fundamental := BuildFundamental(q.arEmit, asset.Ticker, asset.CompositeFigi, "ARQ",

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -990,12 +990,26 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// the declared value.
 		if i > 0 && !conceptFiledQuarterly(cf, []string{"AssetsCurrent"}) {
 			prev := &quarters[i-1]
-			prevDPS, ok := prev.arFields["DividendsPerBasicCommonShare"]
-			if !ok {
-				prevDPS, ok = prev.arEmit["DividendsPerBasicCommonShare"]
+			// Check all available maps for the prior quarter's DPS.
+			prevDPS, found := prev.arFields["DividendsPerBasicCommonShare"]
+			if !found {
+				prevDPS, found = prev.arEmit["DividendsPerBasicCommonShare"]
+			}
+			if !found {
+				prevDPS, found = prev.mrEmit["DividendsPerBasicCommonShare"]
+			}
+			// For Q1 of each year: the prior Q4 is synthesized and may not
+			// have DPS in any map. Fall back to Q3 (i-2) which is a regular
+			// 10-Q quarter with DPS available.
+			if !found && i > 1 {
+				grandPrev := &quarters[i-2]
+				prevDPS, found = grandPrev.arFields["DividendsPerBasicCommonShare"]
+				if !found {
+					prevDPS, found = grandPrev.arEmit["DividendsPerBasicCommonShare"]
+				}
 			}
 
-			if ok {
+			if found {
 				q.mrEmit["DividendsPerBasicCommonShare"] = prevDPS
 			}
 		}

--- a/provider/sec/sec.go
+++ b/provider/sec/sec.go
@@ -985,8 +985,8 @@ func emitFundamentals(cf *CompanyFacts, asset AssetInfo, sub *library.Subscripti
 		// Sharadar's quarterly NCFDEBT captures small items (e.g. finance
 		// lease payments) that aren't separately tagged in XBRL. The
 		// residual naturally picks them up when the other components match.
-		overrideNCFDebtResidual(cf, q.arEmit)
-		overrideNCFDebtResidual(cf, q.mrEmit)
+		overrideNCFDebtResidual(cf, q.arEmit, q.period.PeriodEnd, q.period.FormType)
+		overrideNCFDebtResidual(cf, q.mrEmit, q.period.PeriodEnd, q.period.FormType)
 
 		// ARQ
 		fundamental := BuildFundamental(q.arEmit, asset.Ticker, asset.CompositeFigi, "ARQ",

--- a/provider/sec/synthesize_q4.go
+++ b/provider/sec/synthesize_q4.go
@@ -112,14 +112,31 @@ func synthesizeFromPreceding(annual map[string]float64, annualPeriodEnd time.Tim
 				continue
 			}
 
-			// Per-share flow fields: use the last preceding quarter's YTD
-			// cumulative value for the subtraction. The company-reported
-			// cumulative avoids rounding error from summing individually
-			// rounded quarterly per-share values.
-			if m.ValueType == "float64" {
-				lastQ := preceding[0] // most recent quarter before the 10-K
-				if cumPS := cumPSFn(lastQ); cumPS != nil {
-					if cumVal, ok := cumPS[m.FieldName]; ok {
+			// Prefer the last preceding quarter's YTD cumulative value for the
+			// subtraction. The company-reported cumulative accounts for any
+			// restatements across quarters and avoids rounding error from
+			// summing individually rounded per-share values. For int64 flow
+			// fields (e.g. NetIncome), the cumulative also captures small
+			// adjustments (JPM: Q3 cumulative 43,199M vs Q1+Q2+Q3 sum 43,197M).
+			//
+			// Only use cumulative values that span more than one quarter
+			// (> 120 days). Single-quarter "longest" values are just the
+			// quarterly amount, not a YTD cumulative, and would give wrong
+			// results (Q4 = Annual - Q3_single instead of Annual - Q1Q2Q3_sum).
+			lastQ := preceding[0] // most recent quarter before the 10-K
+			if cumPS := cumPSFn(lastQ); cumPS != nil {
+				if cumVal, ok := cumPS[m.FieldName]; ok {
+					// Verify the value is actually cumulative by checking if
+					// it's larger than any single-quarter emit value.
+					// For Q3 (3rd quarter), cumulative should be roughly 3x
+					// the average quarter. Use a simple heuristic: cumulative
+					// must differ from the single-quarter emit by > 10%.
+					singleQ := 0.0
+					if emit := emitFn(lastQ); emit != nil {
+						singleQ = emit[m.FieldName]
+					}
+
+					if singleQ == 0 || math.Abs(cumVal-singleQ)/math.Abs(singleQ) > 0.1 {
 						result[m.FieldName] = annualVal - cumVal
 
 						continue


### PR DESCRIPTION
Closes #66

## Results

| Ticker | Before | After |
|--------|--------|-------|
| AAPL   | 0      | **0** |
| MSFT   | 0      | **0** |
| NVDA   | 26     | **24** |
| JPM    | 488    | **0** |

## Key changes

### CIK collision fix
- `LoadCIKMapFromDB` returns a ticker-indexed map for multi-ticker CIKs (JPM, AMJ, AMJB, VYLD all share CIK 19617)

### Bank detection
- `AssetsCurrent` on 10-Q as sentinel; `Deposits` as secondary sentinel for DPS override

### XBRL tag additions
- Revenues: `RevenuesNetOfInterestExpense`
- CashAndEquivalents: `CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents`
- Payables: `AccountsPayableAndAccruedLiabilitiesCurrentAndNoncurrent`
- GrossProfit: derived as `Revenues - CostOfRevenue` (banks have no COGS)
- OperatingExpenses: `NoninterestExpense` fallback
- NetIncome: prefer `NetIncomeLossAvailableToCommonStockholdersBasic`

### Extension tags (inline XBRL)
- Receivables: `AccruedInterestAndAccountsReceivable`
- PP&E: `PropertyPlantAndEquipmentAndOperatingLeaseRightOfUseAssetAfterAccumulatedDepreciationAndAmortization`
- Intangibles: `GoodwillServicingAssetsAtFairValueAndOtherIntangibleAssets` (with 10-K/10-Q casing variants)
- Resolved from unfiltered CompanyFacts to bypass MR filing-date filter

### Bank overrides (code-level, gated on AssetsCurrent)
- OperatingIncome = GrossProfit - OperatingExpenses
- SGA = NoninterestExpense - OtherNoninterestExpense (de-cumulated)
- Investments = TotalAssets - Cash - Receivables - PP&E - Intangibles - OtherAssets
- NCI = ConsolidatedIncome - NetIncome - PreferredDividends
- EBT/EBIT/EBITDA recomputed from Q4 components for synthesis consistency
- NCFDEBT: direct formula (FedFundsChange + LTDebtProceeds - LTDebtRepayments + STDebtProceeds)
- NCFINV: investing residual (Investing - CapEx + OtherInvesting - BusinessAcquisitions)
- NetCashFlowBusiness: set to 0 when absent for strictFlow TTM
- DPS: prior quarter's declared rate for MR dimensions (cash-paid)

### Debt handling
- Gate current/non-current on AssetsCurrent (Sharadar reports 0 for banks)
- Bank TotalDebt = ShortTermBorrowings + LongTermDebt + FederalFundsPurchased

### Infrastructure
- Load overflow submission files for large filers (JPM 23K+ filings)
- Filter spurious 10-Q periods at fiscal year-end dates
- Clean up stale observations with outdated date conventions
- Round PB/PE/PS to 3 decimal places
- Q4 synthesis: prefer YTD cumulative for all flow fields
- Q4 synthesis: recompute derived flow fields from components
- TTM: replace NCI with annual value when TTM = fiscal year (banks)
- Annual DPS: prevent overridePeriodAvg from replacing cash-paid TTM
- InterestExpense/ShareBasedCompensation/FreeCashFlow gated for banks

## Test plan
- [x] All 153 unit tests pass
- [x] `go fmt` and `go vet` clean
- [x] AAPL: 0 diffs
- [x] MSFT: 0 diffs
- [x] NVDA: 26 → 24 diffs (improved; remaining are pre-existing cash flow classification issues)
- [x] JPM: 488 → 0 diffs