### PR TITLE
fix(docker): correct image tag from pvapi to pvdata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,4 +34,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pennyvault/pvapi:latest
+          tags: pennyvault/pvdata:latest


### PR DESCRIPTION
## Summary

- Fixes the Docker workflow to push to `pennyvault/pvdata:latest` instead of the incorrect `pennyvault/pvapi:latest`

## Test plan

- [ ] Merge and confirm the Docker workflow pushes to the correct image on DockerHub